### PR TITLE
Improve type coverage

### DIFF
--- a/src/Drupal/Bootstrap.php
+++ b/src/Drupal/Bootstrap.php
@@ -16,7 +16,7 @@ class Bootstrap
     ];
 
     /**
-     * @var string
+     * @var ?string
      */
     private $autoloaderPath;
 
@@ -55,7 +55,7 @@ class Bootstrap
     private $themes = [];
 
     /**
-     * @var \PHPStan\Drupal\ExtensionDiscovery
+     * @var ?\PHPStan\Drupal\ExtensionDiscovery
      */
     private $extensionDiscovery;
 
@@ -81,19 +81,21 @@ class Bootstrap
         if (is_dir($project_root . '/core')) {
             $this->drupalRoot = $project_root;
         }
+        $drupalRoot = null;
         foreach (['web', 'docroot'] as $possible_docroot) {
             if (is_dir("$project_root/$possible_docroot/core")) {
-                $this->drupalRoot = "$project_root/$possible_docroot";
+                $drupalRoot = "$project_root/$possible_docroot";
             }
         }
-        if ($this->drupalRoot === null) {
+        if ($drupalRoot === null) {
             throw new \InvalidArgumentException('Unable to determine the Drupal root');
         }
+        $this->drupalRoot = $drupalRoot;
 
         $this->extensionDiscovery = new ExtensionDiscovery($this->drupalRoot);
         $this->extensionDiscovery->setProfileDirectories([]);
         $profiles = $this->extensionDiscovery->scan('profile');
-        $profile_directories = array_map(function ($profile) {
+        $profile_directories = array_map(function (\PHPStan\Drupal\Extension $profile) : string {
             return $profile->getPath();
         }, $profiles);
         $this->extensionDiscovery->setProfileDirectories($profile_directories);

--- a/src/Drupal/Extension.php
+++ b/src/Drupal/Extension.php
@@ -37,7 +37,7 @@ class Extension
      *
      * Note that SplFileInfo is a PHP resource and resources cannot be serialized.
      *
-     * @var \SplFileInfo
+     * @var ?\SplFileInfo
      */
     protected $splFileInfo;
 
@@ -51,12 +51,12 @@ class Extension
     /**
      * @var string
      */
-    public $subpath;
+    public $subpath = '';
 
     /**
      * @var string
      */
-    public $origin;
+    public $origin = '';
 
     /**
      * Constructs a new Extension object.

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -197,7 +197,7 @@ class ExtensionDiscovery
             return $all_files;
         }
 
-        $all_files = array_filter($all_files, function ($file) {
+        $all_files = array_filter($all_files, function (\PHPStan\Drupal\Extension $file) : bool {
             if (strpos($file->subpath, 'profiles') !== 0) {
                 // This extension doesn't belong to a profile, ignore it.
                 return true;

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -13,6 +13,8 @@ class ServiceMap
      */
     public function __construct(array $drupalServices)
     {
+        $this->services = [];
+
         foreach ($drupalServices as $serviceId => $serviceDefinition) {
             // @todo support factories
             if (!isset($serviceDefinition['class'])) {

--- a/src/Rules/Classes/EnhancedRequireParentConstructCallRule.php
+++ b/src/Rules/Classes/EnhancedRequireParentConstructCallRule.php
@@ -31,11 +31,13 @@ class EnhancedRequireParentConstructCallRule extends RequireParentConstructCallR
             return [];
         }
 
+        $scopeClassReflection = $scope->getClassReflection();
+
         // Provides specific handling for Drupal instances where not calling the parent __construct is "okay."
-        if ($scope->getClassReflection() === null) {
+        if ($scopeClassReflection === null) {
             throw new ShouldNotHappenException();
         }
-        $classReflection = $scope->getClassReflection()->getNativeReflection();
+        $classReflection = $scopeClassReflection->getNativeReflection();
         if (!$classReflection->isInterface()
             && !$classReflection->isAnonymous()
             && $classReflection->implementsInterface('Drupal\Component\Plugin\PluginManagerInterface')

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -26,7 +26,8 @@ class GlobalDrupalDependencyInjectionRule implements Rule
         if (!$scope->isInClass() && !$scope->isInTrait()) {
             return [];
         }
-        if ($scope->getClassReflection() === null) {
+        $scopeClassReflection = $scope->getClassReflection();
+        if ($scopeClassReflection === null) {
             throw new ShouldNotHappenException();
         }
 
@@ -38,18 +39,23 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             'Drupal\Core\Render\Element\FormElementInterface',
             'Drupal\config_translation\FormElement\ElementInterface',
         ];
-        $classReflection = $scope->getClassReflection()->getNativeReflection();
+        $classReflection = $scopeClassReflection->getNativeReflection();
         foreach ($whitelist as $item) {
             if ($classReflection->implementsInterface($item)) {
                 return [];
             }
         }
 
-        if ($scope->getFunctionName() === null || !($scope->getFunction() instanceof MethodReflection)) {
+        if ($scope->getFunctionName() === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        $scopeFunction = $scope->getFunction();
+        if(!($scopeFunction instanceof MethodReflection)) {
             throw new ShouldNotHappenException();
         }
         // Static methods have to invoke \Drupal.
-        if ($scope->getFunction()->isStatic()) {
+        if ($scopeFunction->isStatic()) {
             return [];
         }
 

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -51,7 +51,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
         }
 
         $scopeFunction = $scope->getFunction();
-        if(!($scopeFunction instanceof MethodReflection)) {
+        if (!($scopeFunction instanceof MethodReflection)) {
             throw new ShouldNotHappenException();
         }
         // Static methods have to invoke \Drupal.

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -36,11 +36,13 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
             return [];
         }
 
-        if ($scope->getClassReflection() === null) {
+        $scopeClassReflection = $scope->getClassReflection();
+
+        if ($scopeClassReflection === null) {
             throw new ShouldNotHappenException();
         }
 
-        $classReflection = $scope->getClassReflection()->getNativeReflection();
+        $classReflection = $scopeClassReflection->getNativeReflection();
 
         if (!$this->isPluginManager($classReflection)) {
             return [];
@@ -71,6 +73,7 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                     $cacheTags = $setCacheBackendArgs[2]->value;
                     if (count($cacheTags->items) > 0) {
                         $hasCacheTags = true;
+                        /** @var \PhpParser\Node\Expr\ArrayItem $item */
                         foreach ($cacheTags->items as $item) {
                             if (($item->value instanceof Node\Scalar\String_) &&
                                 strpos($item->value->value, $cacheKey->value) === false) {


### PR DESCRIPTION
This tightens up some of the types used in the project, ensuring things are never set to values they cannot be, and adding closure params/return types. It also avoids calling methods that give the same result more than once.