### PR TITLE
Suggest installing deprecation rules as dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ parameters:
 Add the deprecation rules to your Drupal project's dependencies
 
 ```
-composer require phpstan/phpstan-deprecation-rules
+composer require --dev phpstan/phpstan-deprecation-rules
 ```
 
 Edit your `phpstan.neon` to look like the following:


### PR DESCRIPTION
Hola!

Testing this package, and just noticed what I find is a somewhat bad advice :)

One probably wants to install the deprecation rules package as a dev dependency (as one does with all other phpstan libraries)