### PR TITLE
Analyzing *.install still shows: \Drupal:: is not initialized yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
 
   # Check "Cannot redeclare token_theme() due to blazy_test.module"
   - composer require drupal/token drupal/blazy
+  - ./vendor/bin/phpstan analyze web/modules/contrib/token --no-progress || if (($? == 255)); then false; else true; fi
   - ./vendor/bin/phpstan analyze web/modules/contrib/blazy --no-progress || if (($? == 255)); then false; else true; fi
 
 cache:


### PR DESCRIPTION
Signed-off-by: Jibran Ijaz <jibran.ijaz@gmail.com>

This is a follow up of #51 and #52 which got reverted in #53. 

If `\Drupal` is used anywhere in `*.install` file it shows: 
```
\Drupal::$container is not initialized yet. \Drupal::setContainer() must be called with a real container.
```