### PR TITLE
Fix root drush directory path detection

### DIFF
--- a/src/Drupal/Bootstrap.php
+++ b/src/Drupal/Bootstrap.php
@@ -128,7 +128,7 @@ class Bootstrap
         if (class_exists(\Drush\Drush::class)) {
             $reflect = new \ReflectionClass(\Drush\Drush::class);
             if ($reflect->getFileName() !== false) {
-                $drushDir = dirname($reflect->getFileName(), 2);
+                $drushDir = dirname($reflect->getFileName(), 3);
                 /** @var \SplFileInfo $file */
                 foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
                     require_once $file->getPathname();


### PR DESCRIPTION
Drush class is at `drush/drush/lib/Drush/Drush.php`, so `dirname()` with level `2` would give `drush/drush/lib` and then it tried to append `/includes` to it, but include directory is at `drush/drush/includes`. So, setting it to level `3` fixes this issue.