### PR TITLE
Fixes Drupal core can't be find by DrupalTestBot

### DIFF
--- a/src/DependencyInjection/DrupalExtension.php
+++ b/src/DependencyInjection/DrupalExtension.php
@@ -66,7 +66,7 @@ class DrupalExtension extends CompilerExtension
         if ($config['drupal_root'] !== '' && realpath($config['drupal_root']) !== false && is_dir($config['drupal_root'])) {
             $start_path = $config['drupal_root'];
         } else {
-            $start_path = dirname($GLOBALS['autoloaderInWorkingDirectory'], 2);
+            $start_path = dirname($GLOBALS['autoloaderInWorkingDirectory']);
         }
 
         $finder->locateRoot($start_path);


### PR DESCRIPTION
I'm not sure why the dirname was cut by 2 levels, but this make trouble with DrupalTestBot.

See https://www.drupal.org/project/upgrade_status/issues/3050653

It seems what DrupalTestBot does is something along the line
```
git clone drupal
composer install
install upgrade_status
```

In this case the autoload.php is in the root dir:
```
core
vendor
autoload.php
```
all in the same directory.

while when I use composer create project the drupal root is in a sub directory and the vendor one level above and then the current code works.