### PR TITLE
\Drupal static class included in classmap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,43 @@ jobs:
           command: |
             cd /tmp/drupal
             ./vendor/bin/phpstan analyze web/core/modules/dynamic_page_cache --debug
+  test_upgrade_status:
+    <<: *defaults
+    steps:
+      - start-project
+      - run:
+          name: Disable Xdebug PHP extension
+          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+      - create-drupal-project:
+          project: 'drupal/drupal:^8@alpha'
+      - local-require
+# @todo use this when `require` constraints relaxed.
+#      - run:
+#          name: Add upgrade_status
+#          command: |
+#            cd /tmp/drupal
+#            composer require drupal/upgrade_status:1.x-dev
+# @todo use composer, not this hack.
+      - run:
+          name: Add upgrade_status
+          command: |
+            cd /tmp/drupal
+            composer require phpstan/phpstan-deprecation-rules drupal/git_deploy
+            curl -L https://ftp.drupal.org/files/projects/upgrade_status-8.x-1.x-dev.tar.gz | tar -zx -C /tmp/drupal/modules
+      - run:
+          name: Start builtin
+          command: php -S 127.0.0.1:8080 -t /tmp/drupal
+          background: true
+      - run:
+          name: Wait for web server
+          command: dockerize -wait http://127.0.0.1:8080 -timeout 120s
+      - run:
+          name: Upgrade Status PHPUnit
+          command: |
+            cp ~/repo/tests/fixtures/config/circleci-phpunit.xml /tmp/drupal/core/phpunit.xml
+            cd /tmp/drupal
+            composer run-script drupal-phpunit-upgrade
+            ./vendor/bin/phpunit -c core modules/upgrade_status --debug --stop-on-failure
 workflows:
   version: 2
   tests:
@@ -100,3 +137,4 @@ workflows:
       - build
       - test_drupal
       - test_drupal_project
+      - test_upgrade_status

--- a/src/Drupal/Bootstrap.php
+++ b/src/Drupal/Bootstrap.php
@@ -151,7 +151,6 @@ class Bootstrap
 
     protected function addCoreNamespaces(): void
     {
-        require $this->drupalRoot . '/core/lib/Drupal.php';
         foreach (['Core', 'Component'] as $parent_directory) {
             $path = $this->drupalRoot . '/core/lib/Drupal/' . $parent_directory;
             $parent_namespace = 'Drupal\\' . $parent_directory;

--- a/tests/fixtures/config/circleci-phpunit.xml
+++ b/tests/fixtures/config/circleci-phpunit.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- TODO set checkForUnintentionallyCoveredCode="true" once https://www.drupal.org/node/2626832 is resolved. -->
+<!-- PHPUnit expects functional tests to be run with either a privileged user
+ or your current system user. See core/tests/README.md and
+ https://www.drupal.org/node/2116263 for details.
+-->
+<phpunit bootstrap="tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true">
+<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
+ https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
+ result printer that links to the html output results for functional tests.
+ Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
+ using the command line you can add
+ - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
+ should be no spaces between the hyphens).
+-->
+  <php>
+    <!-- Set error reporting to E_ALL. -->
+    <ini name="error_reporting" value="32767"/>
+    <!-- Do not limit the amount of memory tests take to run. -->
+    <ini name="memory_limit" value="-1"/>
+    <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
+    <env name="SIMPLETEST_BASE_URL" value="http://127.0.0.1:8080"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
+    <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <!-- To disable deprecation testing completely uncomment the next line. -->
+    <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
+    <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+  </php>
+  <testsuites>
+    <testsuite name="unit">
+      <file>./tests/TestSuites/UnitTestSuite.php</file>
+    </testsuite>
+    <testsuite name="kernel">
+      <file>./tests/TestSuites/KernelTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional">
+      <file>./tests/TestSuites/FunctionalTestSuite.php</file>
+    </testsuite>
+    <testsuite name="functional-javascript">
+      <file>./tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="\Drupal\Tests\Listeners\DrupalListener">
+    </listener>
+    <!-- The Symfony deprecation listener has to come after the Drupal listener -->
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+    </listener>
+  </listeners>
+  <!-- Filter for coverage reports. -->
+  <filter>
+    <whitelist>
+      <directory>./includes</directory>
+      <directory>./lib</directory>
+      <directory>./modules</directory>
+      <directory>../modules</directory>
+      <directory>../sites</directory>
+      <!-- Exclude all test modules, tests etc -->
+      <exclude-pattern>*/tests/*</exclude-pattern>
+     </whitelist>
+  </filter>
+</phpunit>


### PR DESCRIPTION
This tests part of the failures/errors discussed in https://github.com/mglaman/phpstan-drupal/pull/77

```
'Drupal' => $baseDir . '/tests/fixtures/drupal/core/lib/Drupal.php',
```