### PR TITLE
Exclude build directory from discovery

### DIFF
--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -334,7 +334,7 @@ class ExtensionDiscovery
         // this to not check for files in common special-purpose directories. For
         // example, node_modules and bower_components. Ignoring irrelevant
         // directories is a performance boost.
-        $ignore_directories = ['node_modules', 'bower_components'];
+        $ignore_directories = ['node_modules', 'bower_components', 'build'];
 
         // Filter the recursive scan to discover extensions only.
         // Important: Without a RecursiveFilterIterator, RecursiveDirectoryIterator


### PR DESCRIPTION
Well, this a PR that kinda solves our specific problem and it is related to:
https://github.com/mglaman/drupal-check/pull/98 and https://www.drupal.org/project/drupal/issues/2943172

I understand this PR is probably not going to be merged as-is but I hope it starts a conversation about how this problem can be solved in a maintainable way (and can use this PR as a patch with Composer as a temporary fix our builds ;P)

I see that this library basically has a copy-paste of Drupal core's extension discovery with a major difference. It does not retrieve the ignored files list from Settings or from a configuration parameter: https://github.com/drupal/core/blob/8.7.6/lib/Drupal/Core/Extension/ExtensionDiscovery.php#L427