### PR TITLE
Make sure the service providers can be found with cold caches

### DIFF
--- a/src/DependencyInjection/DrupalExtension.php
+++ b/src/DependencyInjection/DrupalExtension.php
@@ -125,9 +125,11 @@ class DrupalExtension extends CompilerExtension
             $name = "{$camelized}ServiceProvider";
             $class = "Drupal\\{$moduleName}\\{$name}";
 
-            if (class_exists($class)) {
-                $serviceClassProviders[$moduleName] = $class;
-            }
+            $serviceClassProviders[$moduleName] = $class;
+            $serviceId = "service_provider.$moduleName.service_provider";
+            $builder->parameters['drupalServiceMap'][$serviceId] = [
+                'class' => $class,
+            ];
         }
 
         foreach ($serviceYamls as $extension => $serviceYaml) {


### PR DESCRIPTION
This fixes #31 

So, I do not know how the piece of code is supposed to actually work, since it used to just set service providers in an array and never use them for anything. 

The point is, it would even work had the autoloader already mapped the service providers, because then they would be registered by class_exists. But since this runs before the registering of classes in Bootstrap::addModuleNamespaces service providers are never found.

I have now solved this by assigning all potential module service provider to the drupalServiceMap parameter. I am pretty sure this could be factored out to its own factory, and actually check when things are needed, but this solves the problem and should not give any side effects.

The most annoying part of the bug is that class definitions are cached, so after you run the command once, classes are found. Which is not something we want to do in a CI environment, where we use phpstan.

Anyway, here are steps to reproduce:

- Create a module with a service provider. In my case this is called `JsonapiSafeDefaultsServiceProvider.php`
- Make sure the phpstan cache is cleared. In my case right now this means deleting this folder: `rm -rf /var/folders/50/8lm05cmd1h548wdj0953sr000000gn/T/phpstan/`. Your folder might differ, and can be found by running this command: `php -r "echo sys_get_temp_dir();"`
- Have this package and others installed, and a pretty common setup with phpstan.neon
- Run the command on the folder where you created a service provider.

Sample output:

```
eiriks-iMac:my-project eirikmorland$ rm -rf /var/folders/50/8lm05cmd1h548wdj0953sr000000gn/T/phpstan/
eiriks-iMac:my-project eirikmorland$ ./vendor/bin/phpstan analyse drupal/modules/nymedia/jsonapi_safe_defaults/ --level=max
Note: Using configuration file /Users/xxx/phpstan.neon.
 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   src/JsonapiSafeDefaultsServiceProvider.php                                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
         Class Drupal\jsonapi_safe_defaults\JsonapiSafeDefaultsServiceProvider was not found while trying to analyse it - autoloading is probably not configured properly.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 6 errors                                                                                                 
                                                                                                                        

eiriks-iMac:my-project eirikmorland$ ./vendor/bin/phpstan analyse drupal/modules/nymedia/jsonapi_safe_defaults/ --level=max
Note: Using configuration file /Users/xxx/phpstan.neon.
 4/4 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ -------------------------------------------- 
  Line   src/JsonapiSafeDefaultsServiceProvider.php  
 ------ -------------------------------------------- 
  18     If condition is always true.                
 ------ -------------------------------------------- 

As you can see, it works as expected after warming up the cache. Which is not very desirable :)

With this PR applied, everything works like expected with and without cache