### PR TITLE
Include new 8.8.x test namespaces for modules

### DIFF
--- a/src/Drupal/Bootstrap.php
+++ b/src/Drupal/Bootstrap.php
@@ -183,7 +183,7 @@ class Bootstrap
             // @see drupal_phpunit_get_extension_namespaces
             $module_test_dir = $module_dir . '/tests/src';
             if (is_dir($module_test_dir)) {
-                $suite_names = ['Unit', 'Kernel', 'Functional', 'FunctionalJavascript'];
+                $suite_names = ['Unit', 'Kernel', 'Functional', 'FunctionalJavascript', 'Build'];
                 foreach ($suite_names as $suite_name) {
                     $suite_dir = $module_test_dir . '/' . $suite_name;
                     if (is_dir($suite_dir)) {


### PR DESCRIPTION
This is a follow for https://github.com/mglaman/phpstan-drupal/pull/88. It loads the build tests that are provided by a module or a theme.