### PR TITLE
Add debug to find failures for test_upgrade_status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,10 @@ jobs:
           command: |
             cp ~/repo/tests/fixtures/config/circleci-phpunit.xml /tmp/drupal/core/phpunit.xml
             cd /tmp/drupal
+            mkdir private
             ./vendor/bin/phpunit -c core modules/upgrade_status --debug --stop-on-failure
+      - store_artifacts:
+          path: /tmp/drupal/private
 workflows:
   version: 2
   tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           command: |
             cd /tmp/drupal
             composer require phpstan/phpstan-deprecation-rules drupal/git_deploy
-            git clone --branch 8.x-1.x https://git.drupalcode.org/project/upgrade_status.git /tmp/drupal/modules
+            git clone --branch 8.x-1.x https://git.drupalcode.org/project/upgrade_status.git /tmp/drupal/modules/upgrade_status
       - run:
           name: Start builtin
           command: php -S 127.0.0.1:8080 -t /tmp/drupal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
           command: |
             cd /tmp/drupal
             composer require phpstan/phpstan-deprecation-rules drupal/git_deploy
-            curl -L https://ftp.drupal.org/files/projects/upgrade_status-8.x-1.x-dev.tar.gz | tar -zx -C /tmp/drupal/modules
+            git clone --branch 8.x-1.x https://git.drupalcode.org/project/upgrade_status.git /tmp/drupal/modules
       - run:
           name: Start builtin
           command: php -S 127.0.0.1:8080 -t /tmp/drupal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,12 @@ jobs:
           command: |
             cp ~/repo/tests/fixtures/config/circleci-phpunit.xml /tmp/drupal/core/phpunit.xml
             cd /tmp/drupal
-            mkdir private
+            mkdir /tmp/browser_output
             ./vendor/bin/phpunit -c core modules/upgrade_status --debug --stop-on-failure
       - store_artifacts:
-          path: /tmp/drupal/private
+          path: /tmp/browser_output
+      - store_artifacts:
+          path: /tmp/drupal/sites/simpletest/browser_output
 workflows:
   version: 2
   tests:

--- a/tests/fixtures/config/circleci-phpunit.xml
+++ b/tests/fixtures/config/circleci-phpunit.xml
@@ -28,7 +28,7 @@
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/drupal/private"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/browser_output"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->

--- a/tests/fixtures/config/circleci-phpunit.xml
+++ b/tests/fixtures/config/circleci-phpunit.xml
@@ -8,7 +8,8 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
 <!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
  https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
  result printer that links to the html output results for functional tests.
@@ -27,7 +28,7 @@
     <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/>
     <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value=""/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/tmp/drupal/private"/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->


### PR DESCRIPTION
```
<input data-drupal-selector="edit-contrib-data-data-upgrade-status-test-error" type="checkbox" id="edit-contrib-data-data-upgrade-status-test-error" name="contrib[data][data][upgrade_status_test_error]" value="upgrade_status_test_error" class="form-checkbox">
```

The test expects `custom[data][data][upgrade_status_test_error]` but we have `contrib[data][data][upgrade_status_test_error]`.

![Screen Shot 2019-12-16 at 9 33 21 AM](https://user-images.githubusercontent.com/3698644/70919791-1e087a80-1fe7-11ea-9532-ebf46f9e4bc8.png)
