### PR TITLE
The Upgrade Status pipeline timesout on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,4 +131,4 @@ workflows:
       - build
       - test_drupal
       - test_drupal_project
-      - test_upgrade_status
+      # - test_upgrade_status


### PR DESCRIPTION
Disable the job for now until we can try to provide integration testing with it.