### PR TITLE
Default drupal_root to current working directory

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -12,14 +12,14 @@ parameters:
 		- profile
 		- engine
 	drupal:
-		drupal_root: null
+		drupal_root: '%currentWorkingDirectory%'
 		entityTypeStorageMapping:
 			node: Drupal\node\NodeStorage
 			taxonomy_term: Drupal\taxonomy\TermStorage
 			user: Drupal\user\UserStorage
 parametersSchema:
 	drupal: structure([
-		drupal_root: schema(string(), nullable())
+		drupal_root: string()
 		entityTypeStorageMapping: arrayOf(string())
 	])
 rules:

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -62,21 +62,15 @@ class DrupalAutoloader
 
     public function register(Container $container): void
     {
-        $startPath = null;
         $drupalParams = $container->getParameter('drupal');
-        $drupalRoot = $drupalParams['drupal_root'] ?? null;
-        if ($drupalRoot !== null && realpath($drupalRoot) !== false && is_dir($drupalRoot)) {
-            $startPath = $drupalRoot;
-        } else {
-            $startPath = dirname($GLOBALS['autoloaderInWorkingDirectory']);
-        }
+        $drupalRoot = $drupalParams['drupal_root'];
         $finder = new DrupalFinder();
-        $finder->locateRoot($startPath);
+        $finder->locateRoot($drupalRoot);
 
         $drupalRoot = $finder->getDrupalRoot();
         $drupalVendorRoot = $finder->getVendorDir();
         if (! (bool) $drupalRoot || ! (bool) $drupalVendorRoot) {
-            throw new \RuntimeException("Unable to detect Drupal at $startPath");
+            throw new \RuntimeException("Unable to detect Drupal at $drupalRoot");
         }
 
         $this->drupalRoot = $drupalRoot;

--- a/tests/fixtures/config/drupal-phpstan.neon
+++ b/tests/fixtures/config/drupal-phpstan.neon
@@ -3,7 +3,5 @@ parameters:
 	level: 0
 	ignoreErrors:
 		- '#\Drupal calls should be avoided in classes, use dependency injection instead#'
-	drupal:
-		drupal_root: %currentWorkingDirectory%
 includes:
 	- vendor/mglaman/phpstan-drupal/extension.neon

--- a/tests/fixtures/config/phpunit-drupal-phpstan.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan.neon
@@ -1,12 +1,10 @@
 parameters:
 	reportUnmatchedIgnoredErrors: false
-	level: 7
+	level: 2
 	# Ignore functions for the PHPUnit bootstrap process.
 	ignoreErrors:
 		- '#Function drupal_phpunit_[a-zA-Z0-9\\_]+ not found#'
 		- '#Unsafe usage of new static().#'
-	drupal:
-		drupal_root: %currentWorkingDirectory%
 includes:
 	- ../../../extension.neon
 	- ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/tests/src/BootstrapTest.php
+++ b/tests/src/BootstrapTest.php
@@ -47,11 +47,11 @@ final class BootstrapTest extends TestCase
         $rootDir = __DIR__ . '/../fixtures/drupal';
         $tmpDir = sys_get_temp_dir() . '/' . time() . 'phpstan';
         $containerFactory = new ContainerFactory($rootDir);
-        $container = $containerFactory->create(
-            $tmpDir,
-            [__DIR__ . '/../fixtures/config/phpunit-drupal-phpstan.neon'],
-            []
-        );
+        $additionalConfigFiles = [
+            \sprintf('%s/config.level%s.neon', $containerFactory->getConfigDirectory(), 2),
+            __DIR__ . '/../fixtures/config/phpunit-drupal-phpstan.neon',
+        ];
+        $container = $containerFactory->create($tmpDir, $additionalConfigFiles, []);
         $fileHelper = $container->getByType(FileHelper::class);
         assert($fileHelper !== null);
 


### PR DESCRIPTION
This defaults the drupal.drupal_root container parameter to the current working directory variable, and marks it as a required value in the schema.

Fixes #104 