### PR TITLE
Fixes extension autoloader to behave like Drupal core

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -234,24 +234,12 @@ class DrupalAutoloader
             $module_dir = $this->drupalRoot . '/' . $module->getPath();
             $this->namespaces["Drupal\\$module_name"] = $module_dir . '/src';
 
-            // @see drupal_phpunit_get_extension_namespaces
+            // Extensions can have a \Drupal\Tests\extension namespace for test cases, traits, and other classes such
+            // as those that extend \Drupal\TestSite\TestSetupInterface.
+            // @see drupal_phpunit_get_extension_namespaces()
             $module_test_dir = $module_dir . '/tests/src';
             if (is_dir($module_test_dir)) {
-                $suite_names = ['Unit', 'Kernel', 'Functional', 'FunctionalJavascript', 'Build'];
-                foreach ($suite_names as $suite_name) {
-                    $suite_dir = $module_test_dir . '/' . $suite_name;
-                    if (is_dir($suite_dir)) {
-                        // Register the PSR-4 directory for PHPUnit-based suites.
-                        $this->namespaces["Drupal\\Tests\\$module_name\\$suite_name"] = $suite_dir;
-                    }
-
-                    // Extensions can have a \Drupal\extension\Traits namespace for
-                    // cross-suite trait code.
-                    $trait_dir = $module_test_dir . '/Traits';
-                    if (is_dir($trait_dir)) {
-                        $this->namespaces["Drupal\\Tests\\$module_name\\Traits"] = $trait_dir;
-                    }
-                }
+                $this->namespaces["Drupal\\Tests\\$module_name"] = $module_test_dir;
             }
 
             $servicesFileName = $module_dir . '/' . $module_name . '.services.yml';

--- a/tests/fixtures/drupal/modules/module_with_tests/module_with_tests.info.yml
+++ b/tests/fixtures/drupal/modules/module_with_tests/module_with_tests.info.yml
@@ -1,0 +1,3 @@
+type: module
+name: Module with tests
+core: 8.x

--- a/tests/fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php
+++ b/tests/fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Tests\module_with_tests\TestSite;
+
+use Drupal\TestSite\TestSetupInterface;
+
+class ModuleWithTestsTestSite implements TestSetupInterface {
+
+  protected $modules = [];
+
+  public function setup() {
+    $this->modules = ['module_with_tests', 'views'];
+  }
+
+}

--- a/tests/fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php
+++ b/tests/fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Drupal\Tests\module_with_tests\Traits;
+
+trait ModuleWithTestsTrait {
+
+  protected function dummyTrait() {
+    return TRUE;
+  }
+
+}

--- a/tests/fixtures/drupal/modules/module_with_tests/tests/src/Unit/ModuleWithTestsTest.php
+++ b/tests/fixtures/drupal/modules/module_with_tests/tests/src/Unit/ModuleWithTestsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\Tests\module_with_tests\Unit;
+
+use Drupal\Tests\module_with_tests\Traits\ModuleWithTestsTrait;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * This is a dummy test class.
+ *
+ * @group module_with_tests
+ */
+class ModuleWithTestsTest extends UnitTestCase {
+
+  use ModuleWithTestsTrait;
+
+  /**
+   * A dummy test.
+   */
+  public function testModule() {
+    $this->assertTrue($this->dummyTrait());
+  }
+
+}

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -37,6 +37,18 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
         $this->assertEquals('Function phpstan_fixtures_MissingReturnRule() should return string but return statement is missing.', $error->getMessage());
     }
 
+    public function testExtensionTestSuiteAutoloading() {
+        $paths = [
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Unit/ModuleWithTestsTest.php',
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php',
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php',
+        ];
+        foreach ($paths as $path) {
+            $errors = $this->runAnalyze($path);
+            $this->assertCount(0, $errors, print_r($errors, true));
+        }
+    }
+
     public function testServiceMapping() {
         $errorMessages = [
             '\Drupal calls should be avoided in classes, use dependency injection instead',


### PR DESCRIPTION
See [drupal-check #124](https://github.com/mglaman/drupal-check/issues/124).

The autoloader infers that the behavior should match [drupal_phpunit_get_extension_namespaces](https://api.drupal.org/api/drupal/core%21tests%21bootstrap.php/function/drupal_phpunit_get_extension_namespaces/8.9.x), but the logic behind this does not match that function.

This removes the hard-coded namespaces and only adds the two necessary namespaces for extensions:

1. `\Drupal\module_name` -> module_root/src
2. `\Drupal\Tests\module_name` -> module_root/tests/src

I wasn't sure about tests so I added a module that implement a couple of test namespaces, but I didn't add all the current possibilities.