### PR TITLE
Fix type inspection for app.root service

### DIFF
--- a/src/Type/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/ServiceDynamicReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Constant\ConstantBooleanType;
+use Psr\Container\ContainerInterface;
 
 class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -26,7 +27,7 @@ class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
 
     public function getClass(): string
     {
-        return 'Symfony\Component\DependencyInjection\ContainerInterface';
+        return ContainerInterface::class;
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/ServiceDynamicReturnTypeExtension.php
@@ -55,6 +55,12 @@ class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtens
         if ($methodReflection->getName() === 'get') {
             $service = $this->serviceMap->getService($serviceId);
             if ($service instanceof DrupalServiceDefinition) {
+                // Work around Drupal misusing the SplString class for string
+                // pseudo-services such as 'app.root'.
+                // @see https://www.drupal.org/project/drupal/issues/3074585
+                if ($service->getClass() === 'SplString') {
+                    return new StringType();
+                }
                 return new ObjectType($service->getClass() ?? $serviceId);
             }
             return $returnType;

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
@@ -11,3 +11,8 @@ function phpstan_fixtures_IfConstantConditionRule() {
 function phpstan_fixtures_MissingReturnRule(): string {
 
 }
+
+function phpstan_fixtures_get_app_root(): string {
+    $app_root = \Drupal::getContainer()->get('app.root');
+    return $app_root . '/core/includes/install.inc';
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/AppRootParameter.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/AppRootParameter.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class AppRootParameter implements ContainerInjectionInterface {
+
+    private $appRoot;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function create(ContainerInterface $container)
+    {
+        return new self($container->get('app.root'));
+    }
+
+    /**
+     * AppRootParameter constructor.
+     *
+     * @param string $app_root
+     *   The app root.
+     */
+    public function __construct(string $app_root)
+    {
+        $this->appRoot = $app_root;
+    }
+
+    public function testUnion(): string {
+        return $this->appRoot . '/core';
+    }
+}

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -60,4 +60,10 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
             $this->assertEquals($errorMessages[$key], $error->getMessage());
         }
     }
+
+    public function testAppRootPseudoService() {
+        $errorMessages = [];
+        $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/src/AppRootParameter.php');
+        $this->assertCount(0, $errors, var_export($errors, TRUE));
+    }
 }


### PR DESCRIPTION
First of all, thanks for this great project, I started toying around with it recently and am liking it a lot. :+1: 

I found a quibble, though, which is what this PR is for:
I could not find a way with the current inspection to do something like:
```php
$app_root = $this->container->get('app.root');
$some_path = $app_root . '/core/includes/install.inc';
```

That would result in:

> Binary operation "." between SplString and '/core/incl…' results in an error.

Casting `$app_root` to a string is also not allowed, so I was pretty much out of options as far as I could tell.

This seemed to be a sensible way to fix it, but I'm certainly open to other suggestions.