### PR TITLE
plugin managers are not required to specify cache tags

### DIFF
--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -49,7 +49,6 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
         }
 
         $hasCacheBackendSet = false;
-        $hasCacheTags = false;
         $misnamedCacheTagWarnings = [];
 
         foreach ($node->stmts ?? [] as $statement) {
@@ -72,7 +71,6 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                     /** @var \PhpParser\Node\Expr\Array_ $cacheTags */
                     $cacheTags = $setCacheBackendArgs[2]->value;
                     if (count($cacheTags->items) > 0) {
-                        $hasCacheTags = true;
                         /** @var \PhpParser\Node\Expr\ArrayItem $item */
                         foreach ($cacheTags->items as $item) {
                             if (($item->value instanceof Node\Scalar\String_) &&
@@ -90,9 +88,6 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
         $errors = [];
         if (!$hasCacheBackendSet) {
             $errors[] = 'Missing cache backend declaration for performance.';
-        }
-        if (!$hasCacheTags) {
-            $errors[] = 'Plugin manager has cache backend specified but does not declare cache tags.';
         }
         foreach ($misnamedCacheTagWarnings as $cacheTagWarning) {
             $errors[] = sprintf('%s cache tag might be unclear and does not contain the cache key in it.', $cacheTagWarning);

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -65,9 +65,13 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
         $errorMessages = [
             '\Drupal calls should be avoided in classes, use dependency injection instead',
             'Call to an undefined method Drupal\Core\Entity\EntityManager::thisMethodDoesNotExist().',
+            'Call to deprecated method getDefinitions() of class Drupal\\Core\\Entity\\EntityManager:
+in drupal:8.0.0 and is removed from drupal:9.0.0.
+Use \\Drupal\\Core\\Entity\\EntityTypeManagerInterface::getDefinitions()
+instead.'
         ];
         $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/src/TestServicesMappingExtension.php');
-        $this->assertCount(2, $errors->getErrors());
+        $this->assertCount(3, $errors->getErrors(), var_export($errors->getErrors(), true));
         $this->assertCount(0, $errors->getInternalErrors());
         foreach ($errors->getErrors() as $key => $error) {
             $this->assertEquals($errorMessages[$key], $error->getMessage());


### PR DESCRIPTION
Fixes #112﻿
