### PR TITLE
Add a rule for loadIncludes. Fix #124

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -23,7 +23,6 @@ parametersSchema:
 		entityTypeStorageMapping: arrayOf(string())
 	])
 rules:
-	- PHPStan\Rules\Drupal\LoadIncludes
 	- PHPStan\Rules\Classes\PluginManagerInspectionRule
 	- PHPStan\Rules\Drupal\Coder\DiscouragedFunctionsRule
 	- PHPStan\Rules\Drupal\GlobalDrupalDependencyInjectionRule
@@ -44,3 +43,8 @@ services:
 	-
 		class: PHPStan\Reflection\EntityFieldsViaMagicReflectionExtension
 		tags: [phpstan.broker.propertiesClassReflectionExtension]
+	-
+		class: PHPStan\Rules\Drupal\LoadIncludes
+		tags: [phpstan.rules.rule]
+		arguments:
+			- %drupal.drupal_root%

--- a/extension.neon
+++ b/extension.neon
@@ -23,6 +23,7 @@ parametersSchema:
 		entityTypeStorageMapping: arrayOf(string())
 	])
 rules:
+	- PHPStan\Rules\Drupal\LoadIncludes
 	- PHPStan\Rules\Classes\PluginManagerInspectionRule
 	- PHPStan\Rules\Drupal\Coder\DiscouragedFunctionsRule
 	- PHPStan\Rules\Drupal\GlobalDrupalDependencyInjectionRule

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -118,6 +118,15 @@ class ExtensionDiscovery
      */
     public function scan($type)
     {
+        static $scanresult;
+        if (!$scanresult) {
+            $scanresult = [];
+        }
+
+        if (isset($scanresult[$type])) {
+            return $scanresult[$type];
+        }
+
         $searchdirs = [];
         // Search the core directory.
         $searchdirs[static::ORIGIN_CORE] = 'core';
@@ -152,7 +161,8 @@ class ExtensionDiscovery
         $files = $this->sort($files, $origin_weights);
 
         // Process and return the list of extensions keyed by extension name.
-        return $this->process($files);
+        $scanresult[$type] = $this->process($files);
+        return $scanresult[$type];
     }
 
     /**

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -99,7 +99,5 @@ class LoadIncludes implements Rule
         } catch (\Throwable $e) {
             return [sprintf('A file could not be loaded from %s::loadInclude', $type->getClassName())];
         }
-
-        return [];
     }
 }

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -14,6 +14,22 @@ use PHPStan\ShouldNotHappenException;
 
 class LoadIncludes implements Rule
 {
+
+    /**
+     * The project root.
+     *
+     * @var string
+     */
+    protected $projectRoot;
+
+    /**
+     * LoadIncludes constructor.
+     */
+    public function __construct($project_root)
+    {
+        $this->projectRoot = $project_root;
+    }
+
     public function getNodeType(): string
     {
         return Node\Expr\MethodCall::class;
@@ -46,7 +62,7 @@ class LoadIncludes implements Rule
             }
             // Try to invoke it similarily as the module handler itself.
             $finder = new DrupalFinder();
-            $finder->locateRoot(dirname($GLOBALS['autoloaderInWorkingDirectory']));
+            $finder->locateRoot($this->projectRoot);
             $drupal_root = $finder->getDrupalRoot();
             $extensionDiscovery = new ExtensionDiscovery($drupal_root);
             $modules = $extensionDiscovery->scan('module');

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Drupal;
+
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use DrupalFinder\DrupalFinder;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Drupal\ExtensionDiscovery;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+
+class LoadIncludes implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        try {
+            $method_name = $node->name;
+            if ($method_name instanceof Node\Identifier) {
+                $method_name = $method_name->name;
+            }
+            if ($method_name !== 'loadInclude') {
+                return [];
+            }
+            $var_name = $node->var->name;
+            if ($var_name instanceof Node\Identifier) {
+                $var_name = $var_name->name;
+            }
+            if (!$var_name) {
+                return [];
+            }
+            $type = $scope->getVariableType($var_name);
+            $reflected = new \ReflectionClass($type->getClassName());
+            $implements = $reflected->implementsInterface(ModuleHandlerInterface::class);
+            if (!$implements) {
+                return [];
+            }
+            // Try to invoke it similarily as the module handler itself.
+            $finder = new DrupalFinder();
+            $finder->locateRoot(dirname($GLOBALS['autoloaderInWorkingDirectory']));
+            $drupal_root = $finder->getDrupalRoot();
+            $extensionDiscovery = new ExtensionDiscovery($drupal_root);
+            $modules = $extensionDiscovery->scan('module');
+            $module_arg = $node->args[0]->value->value;
+            $type_arg = $node->args[1]->value->value;
+            $name_arg = !empty($node->args[2]) ? $node->args[2] : null;
+            if (!$name_arg) {
+                $name_arg = $module_arg;
+            } else {
+                $name_arg = $name_arg->value->value;
+            }
+            if (empty($modules[$module_arg])) {
+                return [];
+            }
+            /** @var \PHPStan\Drupal\Extension $module */
+            $module = $modules[$module_arg];
+            $file = $drupal_root . '/' . $module->getPath() . "/$name_arg.$type_arg";
+            if (is_file($file)) {
+                require_once $file;
+                return [];
+            }
+            return ['File could not be loaded from ModuleHandler::loadInclude'];
+        } catch (\Throwable $e) {
+        }
+
+        return [];
+    }
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
@@ -16,3 +16,14 @@ function phpstan_fixtures_get_app_root(): string {
     $app_root = \Drupal::getContainer()->get('app.root');
     return $app_root . '/core/includes/install.inc';
 }
+
+function phpstan_fixtures_module_load_includes_test(): array {
+    $module_handler = \Drupal::moduleHandler();
+    $module_handler->loadInclude('locale', 'fetch.inc');
+    return _locale_translation_default_update_options();
+}
+
+function phpstan_fixtures_module_load_includes_negative_test(): void {
+    $module_handler = \Drupal::moduleHandler();
+    $module_handler->loadInclude('phpstan_fixtures', 'fetch.inc');
+}

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -38,7 +38,7 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
 
     public function testExtensionReportsError() {
         $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module');
-        $this->assertCount(2, $errors->getErrors(), var_export($errors, true));
+        $this->assertCount(3, $errors->getErrors(), var_export($errors, true));
         $this->assertCount(0, $errors->getInternalErrors(), var_export($errors, true));
 
         $errors = $errors->getErrors();
@@ -46,6 +46,8 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
         $this->assertEquals('If condition is always false.', $error->getMessage());
         $error = array_shift($errors);
         $this->assertEquals('Function phpstan_fixtures_MissingReturnRule() should return string but return statement is missing.', $error->getMessage());
+        $error = array_shift($errors);
+        $this->assertStringContainsString('phpstan_fixtures/phpstan_fixtures.fetch.inc could not be loaded from Drupal\\Core\\Extension\\ModuleHandlerInterface::loadInclude', $error->getMessage());
     }
 
     public function testExtensionTestSuiteAutoloading() {


### PR DESCRIPTION
I went a different direction with fixing #124. Since it is the actual static analisis that will need to uncover the calls to loadInclude from the module handler service, I made this a rule instead. This way we can actually uncover when calls are being made but the files do not exist.

A bonus is that we actually get the files included, and functions that are not recognized will now be recognized