### PR TITLE
Disable xdebug coverage in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,6 @@ version: 2.1
 defaults: &defaults
   docker:
     - image: circleci/php:7.3-cli
-      environment:
-        BOX_VERSION: 3.6.0
   working_directory: ~/repo
 aliases:
   - &composer-cache
@@ -15,6 +13,9 @@ commands:
       - run:
           name: Install PHP Extensions
           command: sudo docker-php-ext-install gd
+      - run:
+          name: Disable Xdebug PHP extension
+          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - checkout
       - restore_cache:
           keys:
@@ -98,9 +99,6 @@ jobs:
     <<: *defaults
     steps:
       - start-project
-      - run:
-          name: Disable Xdebug PHP extension
-          command: sudo rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
       - create-drupal-project:
           project: 'drupal/legacy-project:^8@alpha'
       - local-require

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ before_install: []
 install:
   - composer install --no-interaction
   - COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal-composer/drupal-project:8.x-dev $TRAVIS_BUILD_DIR/../drupal --no-interaction --no-progress
+before_script:
+  - if php --ri xdebug >/dev/null; then phpenv config-rm xdebug.ini; fi
 script:
   # Inspections
   - ./vendor/bin/phpcs src

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -6,7 +6,7 @@
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"
-         verbose="true">
+         verbose="false">
     <php>
         <ini name="error_reporting" value="32767"/>
         <ini name="memory_limit" value="-1"/>


### PR DESCRIPTION
Instead of getting coverage to run in the CI, just disable it. Coverage can be a local thing.

Fixes #155