### PR TITLE
Improve test matrix for D8 + D9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,12 +20,6 @@ jobs:
           - "~8.9"
           - "~9.0"
         include:
-          - php-version: "7.1"
-            drupal: "~8.8"
-          - php-version: "7.1"
-            drupal: "~8.9"
-          - php-version: "7.2"
-            drupal: "~8.8"
           - php-version: "7.2"
             drupal: "~8.9"
           - php-version: "8.0"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,6 @@ jobs:
           - "7.3"
           - "7.4"
         drupal:
-          - "~8.8"
           - "~8.9"
           - "~9.0"
         include:
@@ -36,6 +35,7 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
+          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade PHPUnit"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -24,6 +24,7 @@ jobs:
         include:
           - php-version: "7.2"
             drupal: "~8.9"
+            experimental: false
           - php-version: "8.0"
             drupal: "~9.0"
             experimental: true

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
   tests:
     continue-on-error: ${{ matrix.experimental }}
     runs-on: "ubuntu-latest"
-    name: "PHP ${{ matrix.php-version }} Unit Tests"
+    name: "PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
     strategy:
       matrix:
         experimental: [false]
@@ -61,3 +61,16 @@ jobs:
         run: |
           cd ~/drupal
           ./vendor/bin/phpstan analyze web/core/install.php --debug
+      - name: "Test BrowserTestBase is autoloaded"
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze web/core/modules/dynamic_page_cache | grep -q "Class Drupal\Tests\BrowserTestBase not found and could not be autoloaded." && false || true
+      - name: "Verify test fixtures are ignored."
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze web/core/modules/migrate_drupal --no-progress | grep -q "tests/fixtures" && false || true
+      - name: 'Check "Cannot redeclare token_theme() due to blazy_test.module"'
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token drupal/blazy
+          ./vendor/bin/phpstan analyze web/modules/contrib/blazy --no-progress || if (($? == 255)); then false; else true; fi

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,10 +1,11 @@
-name: PHP Composer
-
+name: Tests
 on:
-  pull_request:
   push:
-    branches:
-      - master
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: 0 0 * * *
 
 jobs:
   tests:
@@ -35,18 +36,18 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
-          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
+          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
-      - name: "Downgrade PHPUnit"
-        run: "composer require phpunit/phpunit:^7.5 --with-all-dependencies"
-        if: ${{ matrix.drupal == '~8.8' || matrix.drupal == '~8.9' }}
+      - name: "Downgrade dev dependencies"
+        run: "composer require phpunit/phpunit:^7.5 drupal/core-recommended:${{ matrix.drupal }} --with-all-dependencies"
+        if: ${{ matrix.drupal == '~8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"
         run: "php vendor/bin/phpstan analyze src"
       - name: "PHPUnit"
-        run: "php vendor/bin/phpunit"
+        run: "php vendor/bin/phpunit --debug"
 
       - name: Setup Drupal
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,8 +2,6 @@ name: PHP Composer
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,16 +6,20 @@ on:
 
 jobs:
   tests:
+    continue-on-error: ${{ matrix.experimental }}
     runs-on: "ubuntu-latest"
     name: "PHP ${{ matrix.php-version }} Unit Tests"
     strategy:
       matrix:
+        experimental: [false]
         php-version:
           - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"
-          - "8.0"
+        include:
+          - php-version: "8.0"
+            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,6 +2,8 @@ name: PHP Composer
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:
@@ -13,8 +15,6 @@ jobs:
       matrix:
         experimental: [false]
         php-version:
-          - "7.1"
-          - "7.2"
           - "7.3"
           - "7.4"
         drupal:
@@ -22,6 +22,14 @@ jobs:
           - "~8.9"
           - "~9.0"
         include:
+          - php-version: "7.1"
+            drupal: "~8.8"
+          - php-version: "7.1"
+            drupal: "~8.9"
+          - php-version: "7.2"
+            drupal: "~8.8"
+          - php-version: "7.2"
+            drupal: "~8.9"
           - php-version: "8.0"
             drupal: "~9.0"
             experimental: true

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,6 @@ jobs:
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"
-        run: "php vendor/bin/phpstan analayze stc"
+        run: "php vendor/bin/phpstan analyze stc"
       - name: "PHPUnit"
         run: "php vendor/bin/phpunit"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,7 +38,7 @@ jobs:
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade PHPUnit"
         run: "composer require phpunit/phpunit:^7.5"
-        if: ${{ matrix.drupal == "~8.8" || matrix.drupal == "~8.9" }}
+        if: ${{ matrix.drupal == '~8.8' || matrix.drupal == '~8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,6 +20,7 @@ jobs:
         drupal:
           - "~8.8"
           - "~8.9"
+          - "~9.0"
         include:
           - php-version: "8.0"
             drupal: "~9.0"
@@ -35,6 +36,9 @@ jobs:
           tools: composer:v2
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
+      - name: "Downgrade PHPUnit"
+        run: "composer require phpunit/phpunit:^7.5"
+        if: ${{ matrix.drupal == "~8.8" || matrix.drupal == "~8.9" }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -37,7 +37,7 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade PHPUnit"
-        run: "composer require phpunit/phpunit:^7.5"
+        run: "composer require phpunit/phpunit:^7.5 --with-all-dependencies"
         if: ${{ matrix.drupal == '~8.8' || matrix.drupal == '~8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,8 +17,12 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+        drupal:
+          - "~8.8"
+          - "~8.9"
         include:
           - php-version: "8.0"
+            drupal: "~9.0"
             experimental: true
     steps:
       - name: "Checkout"
@@ -37,3 +41,23 @@ jobs:
         run: "php vendor/bin/phpstan analyze src"
       - name: "PHPUnit"
         run: "php vendor/bin/phpunit"
+
+      - name: Setup Drupal
+        run: |
+          COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction
+          cd ~/drupal
+          composer config minimum-stability dev
+          composer config prefer-stable true
+          composer config preferred-install dist
+          composer config repositories.0 path $GITHUB_WORKSPACE
+          composer config repositories.1 composer https://packages.drupal.org/8
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --no-suggest
+      - name: "require phpstan-drupal"
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require mglaman/phpstan-drupal *@dev
+          cp $GITHUB_WORKSPACE/tests/fixtures/config/drupal-phpstan.neon phpstan.neon
+      - name: "Test core/install.php"
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze web/core/install.php --debug

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,31 +5,31 @@ on:
   pull_request:
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  tests:
+    runs-on: "ubuntu-latest"
+    name: "PHP ${{ matrix.php-version }} Unit Tests"
+    strategy:
+      matrix:
+        php-version:
+          - "7.1"
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Validate composer.json and composer.lock
-      run: composer validate
-
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v2
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-
-    - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
-
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
-
-    # - name: Run test suite
-    #   run: composer run-script test
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: composer:v2
+      - name: "Install dependencies"
+        run: "composer update --no-progress --prefer-dist"
+      - name: "PHPCS"
+        run: "php vendor/bin/phpcs src"
+      - name: "PHPStan"
+        run: "php vendor/bin/phpstan analayze stc"
+      - name: "PHPUnit"
+        run: "php vendor/bin/phpunit"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,8 +1,10 @@
 name: PHP Composer
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   tests:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,35 @@
+name: PHP Composer
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      if: steps.composer-cache.outputs.cache-hit != 'true'
+      run: composer install --prefer-dist --no-progress --no-suggest
+
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+    # - name: Run test suite
+    #   run: composer run-script test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -34,6 +34,6 @@ jobs:
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"
-        run: "php vendor/bin/phpstan analyze stc"
+        run: "php vendor/bin/phpstan analyze src"
       - name: "PHPUnit"
         run: "php vendor/bin/phpunit"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,18 +16,18 @@ jobs:
       matrix:
         experimental: [false]
         php-version:
-          - "7.3"
+#          - "7.3"
           - "7.4"
         drupal:
-          - "~8.9"
-          - "~9.0"
-        include:
-          - php-version: "7.2"
-            drupal: "~8.9"
-            experimental: false
-          - php-version: "8.0"
-            drupal: "~9.0"
-            experimental: true
+          - "^8.9"
+          - "^9.0"
+#        include:
+#          - php-version: "7.2"
+#            drupal: "~8.9"
+#            experimental: false
+#          - php-version: "8.0"
+#            drupal: "~9.0"
+#            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -41,7 +41,7 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade dev dependencies"
-        run: "composer require phpunit/phpunit:^7.5 drupal/core-recommended:${{ matrix.drupal }} --with-all-dependencies"
+        run: "composer require phpunit/phpunit:^7.5 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} --with-all-dependencies"
         if: ${{ matrix.drupal == '~8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
@@ -50,6 +50,38 @@ jobs:
       - name: "PHPUnit"
         run: "php vendor/bin/phpunit --debug"
 
+  build_integration:
+    continue-on-error: ${{ matrix.experimental }}
+    runs-on: "ubuntu-latest"
+    name: "PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
+    strategy:
+      matrix:
+        experimental: [false]
+        php-version:
+#          - "7.3"
+          - "7.4"
+        drupal:
+          - "^8.9"
+          - "^9.0"
+#        include:
+#          - php-version: "7.2"
+#            drupal: "~8.9"
+#            experimental: false
+#          - php-version: "8.0"
+#            drupal: "~9.0"
+#            experimental: true
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: composer:v2
+          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
+      - name: "Install dependencies"
+        run: "composer update --no-dev --no-progress --prefer-dist"
       - name: Setup Drupal
         run: |
           COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -102,7 +102,7 @@ jobs:
       - name: "Test core/tests/Drupal/Tests/UnitTestCase.php"
         run: |
           cd ~/drupal
-          ./vendor/bin/phpstan analyze web/core/tests/Drupal/Tests/UnitTestCase.php --debug
+          ./vendor/bin/phpstan analyze web/core/tests/Drupal/Tests/SkippedDeprecationTest.php --debug
       - name: "Test BrowserTestBase is autoloaded"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -99,6 +99,10 @@ jobs:
         run: |
           cd ~/drupal
           ./vendor/bin/phpstan analyze web/core/install.php --debug
+      - name: "Test core/tests/Drupal/Tests/UnitTestCase.php"
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze core/tests/Drupal/Tests/UnitTestCase.php --debug
       - name: "Test BrowserTestBase is autoloaded"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,8 +41,8 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade dev dependencies"
-        run: "composer require phpunit/phpunit:^7.5 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} --with-all-dependencies"
-        if: ${{ matrix.drupal == '~8.9' }}
+        run: "composer require phpunit/phpunit:^7.5 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies"
+        if: ${{ matrix.drupal == '^8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"
@@ -80,8 +80,6 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: composer:v2
           extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
-      - name: "Install dependencies"
-        run: "composer update --no-dev --no-progress --prefer-dist"
       - name: Setup Drupal
         run: |
           COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         experimental: [false]
         php-version:
-#          - "7.3"
+          - "7.3"
           - "7.4"
         drupal:
           - "^8.9"
@@ -58,7 +58,7 @@ jobs:
       matrix:
         experimental: [false]
         php-version:
-#          - "7.3"
+          - "7.3"
           - "7.4"
         drupal:
           - "^8.9"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,9 +25,9 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-#          - php-version: "8.0"
-#            drupal: "~9.0"
-#            experimental: true
+          - php-version: "8.0"
+            drupal: "^9.0"
+            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -67,9 +67,9 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-#          - php-version: "8.0"
-#            drupal: "~9.0"
-#            experimental: true
+          - php-version: "8.0"
+            drupal: "^9.0"
+            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,9 +25,11 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-          - php-version: "8.0"
-            drupal: "^9.0"
-            experimental: true
+# @todo D9 is compat, but drupal/core-dev-pinned is not?
+# core-dev-pinned sets phar-io/manifest to 1.0.3, where ^2.0 is
+#          - php-version: "8.0"
+#            drupal: "^9.0"
+#            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -67,9 +69,11 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-          - php-version: "8.0"
-            drupal: "^9.0"
-            experimental: true
+# @todo D9 is compat, but drupal/core-dev-pinned is not?
+# core-dev-pinned sets phar-io/manifest to 1.0.3, where ^2.0 is
+#          - php-version: "8.0"
+#            drupal: "^9.0"
+#            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -89,7 +89,7 @@ jobs:
           composer config preferred-install dist
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
-          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }}
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies
       - name: "require phpstan-drupal"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,10 +21,10 @@ jobs:
         drupal:
           - "^8.9"
           - "^9.0"
-#        include:
-#          - php-version: "7.2"
-#            drupal: "~8.9"
-#            experimental: false
+        include:
+          - php-version: "7.2"
+            drupal: "~8.9"
+            experimental: false
 #          - php-version: "8.0"
 #            drupal: "~9.0"
 #            experimental: true
@@ -63,10 +63,10 @@ jobs:
         drupal:
           - "^8.9"
           - "^9.0"
-#        include:
-#          - php-version: "7.2"
-#            drupal: "~8.9"
-#            experimental: false
+        include:
+          - php-version: "7.2"
+            drupal: "~8.9"
+            experimental: false
 #          - php-version: "8.0"
 #            drupal: "~9.0"
 #            experimental: true

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade dev dependencies"
-        run: "composer require phpunit/phpunit:^7.5 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies"
+        run: "composer require phpunit/phpunit:6.5.14 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies"
         if: ${{ matrix.drupal == '^8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
@@ -89,7 +89,7 @@ jobs:
           composer config preferred-install dist
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
-          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --no-suggest
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }}
       - name: "require phpstan-drupal"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -102,7 +102,7 @@ jobs:
       - name: "Test core/tests/Drupal/Tests/UnitTestCase.php"
         run: |
           cd ~/drupal
-          ./vendor/bin/phpstan analyze core/tests/Drupal/Tests/UnitTestCase.php --debug
+          ./vendor/bin/phpstan analyze web/core/tests/Drupal/Tests/UnitTestCase.php --debug
       - name: "Test BrowserTestBase is autoloaded"
         run: |
           cd ~/drupal

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ composer.lock
 .circleci/config_local.yml
 
 # Fix PHPUnit compatibility mutated class.
-/src/TestCase.php
+/tests/fixtures/TestCase.php
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ composer.lock
 /vendor/
 /clover.xml
 .circleci/config_local.yml
+
+# Fix PHPUnit compatibility mutated class.
+/src/TestCase.php
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpunit/phpunit": "^7.5 || ^8.0",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.6",
-        "drupal/core-recommended": "^8.8@alpha",
+        "drupal/core-recommended": "^8.8@alpha || ^9.0",
         "drush/drush": "^9.6"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.6",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",
-        "drush/drush": "^9.6"
+        "drush/drush": "^9.6 | ^10.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^0.12.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5 || ^8.0",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.6",
         "drupal/core-recommended": "^8.8@alpha",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,11 @@
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^0.12.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "phpunit/phpunit": "^7.5 || ^8.0",
+        "phpunit/phpunit": "^7.5 || ^8.0 || ^9",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.9",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",
+        "drupal/core-dev-pinned": "^8.8@alpha || ^9.0",
         "drush/drush": "^9.6 | ^10.0"
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "squizlabs/php_codesniffer": "^3.3",
         "phpunit/phpunit": "^7.5 || ^8.0",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
-        "composer/installers": "2",
+        "composer/installers": "^1.9",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",
         "drush/drush": "^9.6 | ^10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "phpstan/phpstan-deprecation-rules": "For catching deprecations, especially in Drupal core."
     },
     "autoload": {
+        "files": [
+            "drupal-phpunit-hack.php"
+        ],
         "psr-4": {
             "PHPStan\\": "src/"
         }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require-dev": {
         "phpstan/phpstan-strict-rules": "^0.12.0",
         "squizlabs/php_codesniffer": "^3.3",
-        "phpunit/phpunit": "^7.5 || ^8.0 || ^9",
+        "phpunit/phpunit": "^6.5 || ^7.5 || ^8.0 || ^9",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.9",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "nette/finder": "^2.5",
         "phpstan/phpstan": "^0.12.64",
         "symfony/yaml": "~3.4.5|^4.2",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "squizlabs/php_codesniffer": "^3.3",
         "phpunit/phpunit": "^7.5 || ^8.0",
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
-        "composer/installers": "^1.6",
+        "composer/installers": "2",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",
         "drush/drush": "^9.6 | ^10.0"
     },

--- a/drupal-phpunit-hack.php
+++ b/drupal-phpunit-hack.php
@@ -25,7 +25,7 @@ $alteredCode = file_get_contents($alteredFile);
 $alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
 $alteredCode = str_replace("__DIR__ . '/../Util/", "'$phpunit_dir/src/Util/", $alteredCode);
 // Only write when necessary.
-$filename = __DIR__ . '/src/TestCase.php';
+$filename = __DIR__ . '/tests/fixtures/TestCase.php';
 
 if (!file_exists($filename) || md5_file($filename) !== md5($alteredCode)) {
     file_put_contents($filename, $alteredCode);

--- a/drupal-phpunit-hack.php
+++ b/drupal-phpunit-hack.php
@@ -25,7 +25,7 @@ $alteredCode = file_get_contents($alteredFile);
 $alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
 $alteredCode = str_replace("__DIR__ . '/../Util/", "'$phpunit_dir/src/Util/", $alteredCode);
 // Only write when necessary.
-$filename = 'TestCase.php';
+$filename = __DIR__ . '/src/TestCase.php';
 
 if (!file_exists($filename) || md5_file($filename) !== md5($alteredCode)) {
     file_put_contents($filename, $alteredCode);

--- a/drupal-phpunit-hack.php
+++ b/drupal-phpunit-hack.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * @file
+ *
+ * Implements PHPUnit compatibility hack provided by ClassWriter
+ *
+ * This ensures we can run our PHPUnit tests against 8.9 and 9, and more.
+ *
+ * @see \Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter::mutateTestBase()
+ */
+$autoloader = null;
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    $autoloader = require __DIR__ . '/vendor/autoload.php';
+}
+if (!$autoloader instanceof \Composer\Autoload\ClassLoader) {
+    return;
+}
+
+// Inspired by Symfony's simple-phpunit remove typehints from TestCase.
+$alteredFile = $autoloader->findFile('PHPUnit\Framework\TestCase');
+$phpunit_dir = dirname($alteredFile, 3);
+// Mutate TestCase code to make it compatible with Drupal 8 and 9 tests.
+$alteredCode = file_get_contents($alteredFile);
+$alteredCode = preg_replace('/^    ((?:protected|public)(?: static)? function \w+\(\)): void/m', '    $1', $alteredCode);
+$alteredCode = str_replace("__DIR__ . '/../Util/", "'$phpunit_dir/src/Util/", $alteredCode);
+// Only write when necessary.
+$filename = 'TestCase.php';
+
+if (!file_exists($filename) || md5_file($filename) !== md5($alteredCode)) {
+    file_put_contents($filename, $alteredCode);
+}
+include $filename;

--- a/tests/fixtures/drupal/modules/drush_command/src/Commands/TestDrushCommands.php
+++ b/tests/fixtures/drupal/modules/drush_command/src/Commands/TestDrushCommands.php
@@ -14,7 +14,7 @@ class TestDrushCommands extends DrushCommands {
     public function example() {
         if (drush_is_osx()) {
             $this->io()->writeln('macOS');
-        } elseif (drush_is_cygwin() || drush_is_mingw()) {
+        } elseif (drush_is_windows()) {
             $this->io()->writeln('Windows');
         } else {
             $this->io()->writeln('Linux ¯\_(ツ)_/¯');

--- a/tests/src/DeprecationRulesTest.php
+++ b/tests/src/DeprecationRulesTest.php
@@ -10,6 +10,9 @@ class DeprecationRulesTest extends AnalyzerTestBase
      */
     public function testDeprecationRules(string $path, int $count, array $errorMessages)
     {
+        if (version_compare('9.0.0', \Drupal::VERSION) !== 1) {
+            $this->markTestSkipped('Only tested on Drupal 8.x.x');
+        }
         $errors = $this->runAnalyze($path);
         $this->assertCount($count, $errors->getErrors(), var_export($errors, true));
         foreach ($errors->getErrors() as $key => $error) {

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -76,8 +76,11 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
         }
     }
 
-    public function testServiceMapping()
+    public function testServiceMapping8()
     {
+        if (version_compare('9.0.0', \Drupal::VERSION) !== 1) {
+            $this->markTestSkipped('Only tested on Drupal 8.x.x');
+        }
         $errorMessages = [
             '\Drupal calls should be avoided in classes, use dependency injection instead',
             'Call to an undefined method Drupal\Core\Entity\EntityManager::thisMethodDoesNotExist().',
@@ -88,6 +91,23 @@ instead.'
         ];
         $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/src/TestServicesMappingExtension.php');
         $this->assertCount(3, $errors->getErrors());
+        $this->assertCount(0, $errors->getInternalErrors());
+        foreach ($errors->getErrors() as $key => $error) {
+            $this->assertEquals($errorMessages[$key], $error->getMessage());
+        }
+    }
+
+    public function testServiceMapping9()
+    {
+        if (version_compare('9.0.0', \Drupal::VERSION) === 1) {
+            $this->markTestSkipped('Only tested on Drupal 9.x.x');
+        }
+        // @todo: the actual error should be the fact `entity.manager` does not exist.
+        $errorMessages = [
+            '\Drupal calls should be avoided in classes, use dependency injection instead',
+        ];
+        $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/src/TestServicesMappingExtension.php');
+        $this->assertCount(1, $errors->getErrors());
         $this->assertCount(0, $errors->getInternalErrors());
         foreach ($errors->getErrors() as $key => $error) {
             $this->assertEquals($errorMessages[$key], $error->getMessage());

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -6,10 +6,11 @@ use PHPStan\Analyser\Error;
 
 final class DrupalIntegrationTest extends AnalyzerTestBase {
 
-    public function testInstallPhp() {
+    public function testInstallPhp(): void
+    {
         $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/core/install.php');
-        $this->assertCount(0, $errors->getErrors());
-        $this->assertCount(0, $errors->getInternalErrors());
+        self::assertCount(0, $errors->getErrors());
+        self::assertCount(0, $errors->getInternalErrors());
     }
 
     public function testTestSuiteAutoloading() {
@@ -42,35 +43,36 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
         $is_d9 = version_compare('9.0.0', \Drupal::VERSION) !== 1;
         $errors = $this->runAnalyze(__DIR__ . '/../fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module');
         // @todo this only broke on D9.
-        $this->assertCount($is_d9 ? 4 : 3, $errors->getErrors(), var_export($errors, true));
-        $this->assertCount(0, $errors->getInternalErrors(), var_export($errors, true));
+        self::assertCount($is_d9 ? 4 : 3, $errors->getErrors(), var_export($errors, true));
+        self::assertCount(0, $errors->getInternalErrors(), var_export($errors, true));
 
         $errors = $errors->getErrors();
         $error = array_shift($errors);
-        $this->assertEquals('If condition is always false.', $error->getMessage());
+        self::assertEquals('If condition is always false.', $error->getMessage());
         $error = array_shift($errors);
-        $this->assertEquals('Function phpstan_fixtures_MissingReturnRule() should return string but return statement is missing.', $error->getMessage());
+        self::assertEquals('Function phpstan_fixtures_MissingReturnRule() should return string but return statement is missing.', $error->getMessage());
         if ($is_d9) {
             $error = array_shift($errors);
-            $this->assertEquals('Binary operation "." between SplString and \'/core/includes…\' results in an error.', $error->getMessage());
+            self::assertEquals('Binary operation "." between SplString and \'/core/includes…\' results in an error.', $error->getMessage());
         }
         $error = array_shift($errors);
-        $this->assertStringContainsString('phpstan_fixtures/phpstan_fixtures.fetch.inc could not be loaded from Drupal\\Core\\Extension\\ModuleHandlerInterface::loadInclude', $error->getMessage());
+
+        self::assertNotFalse(strpos($error->getMessage(), 'phpstan_fixtures/phpstan_fixtures.fetch.inc could not be loaded from Drupal\\Core\\Extension\\ModuleHandlerInterface::loadInclude'));
     }
 
-    public function testExtensionTestSuiteAutoloading()
+    public function testExtensionTestSuiteAutoloading(): void
     {
         $paths = [
             __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Unit/ModuleWithTestsTest.php',
-//            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php',
-//            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php',
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php',
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php',
         ];
         foreach ($paths as $path) {
             $errors = $this->runAnalyze($path);
-            $this->assertCount(0, $errors->getErrors(), implode(PHP_EOL, array_map(static function (Error $error) {
+            self::assertCount(0, $errors->getErrors(), implode(PHP_EOL, array_map(static function (Error $error) {
                 return $error->getMessage();
             }, $errors->getErrors())));
-            $this->assertCount(0, $errors->getInternalErrors(), implode(PHP_EOL, $errors->getInternalErrors()));
+            self::assertCount(0, $errors->getInternalErrors(), implode(PHP_EOL, $errors->getInternalErrors()));
         }
     }
 

--- a/tests/src/DrushIntegrationTest.php
+++ b/tests/src/DrushIntegrationTest.php
@@ -9,9 +9,16 @@ final class DrushIntegrationTest extends AnalyzerTestBase
      */
     public function testPaths($path) {
         $errors = $this->runAnalyze($path);
-        $this->assertCount(0, $errors->getErrors(), var_export($errors, TRUE));
+        $errorMessages = [
+            'Call to deprecated function drush_is_windows():
+. Use \\Consolidation\\SiteProcess\\Util\\Escape.',
+        ];
+        $this->assertCount(1, $errors->getErrors(), var_export($errors, TRUE));
         $this->assertCount(0, $errors->getInternalErrors(), var_export($errors, TRUE));
-    }
+        foreach ($errors->getErrors() as $key => $error) {
+            $this->assertEquals($errorMessages[$key], $error->getMessage());
+        }
+        }
 
     public function dataPaths(): \Generator
     {


### PR DESCRIPTION
This moves from TravisCI to GitHub Actions. It also ensures we're testing on D9.

PHP8 was skipped due to `drupal/core-dev-pinned` referencing `phar-io/manifest:1.0.3` which does not support PHP 8. However, using `drupal/core-dev` would allow `phar-io/manifest:^2.0`. Moving that to another PR.