### PR TITLE
Add 'translation' and 'batch' to hook includes

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -125,6 +125,8 @@ class DrupalAutoloader
                 'tokens',
                 'search_api',
                 'pathauto',
+                'translation',
+                'batch',
             ];
             foreach ($magic_hook_info_includes as $hook_info_include) {
                 if (file_exists($module_dir . "/$module_name.$hook_info_include.inc")) {


### PR DESCRIPTION
Locale module (and some other contrib modules, like webform) use '.batch.inc' and '.translation.inc' for some code.
Added these to the list of $magic_hook_info_includes so these files are loaded as well.