### PR TITLE
Use PHPUnit\Framework\Test interface instead of TestCase class

### DIFF
--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -34,7 +34,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
 
         $whitelist = [
             // Ignore tests.
-            'PHPUnit\Framework\TestCase',
+            'PHPUnit\Framework\Test',
             // Typed data objects cannot use dependency injection.
             'Drupal\Core\TypedData\TypedDataInterface',
             // Render elements cannot use dependency injection.


### PR DESCRIPTION
I recently started getting errors when running phpstan on my drupal code:

> Internal error: Internal error: PHPUnit\Framework\TestCase is not an interface in file <filename.php>
> Run PHPStan with --debug option and post the stack trace to: https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md

This traced down to \PHPStan\Rules\Drupal\GlobalDrupalDependencyInjectionRule:48 where a list of interface names are checked. Though, the first item of this list is an abstract class and not an interface.