### PR TITLE
fix TypeError in DrupalAutoloader

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -175,7 +175,7 @@ class DrupalAutoloader
                 // and thinking these are real services for PHPStan's container.
                 if (isset($serviceDefinition['arguments']) && is_array($serviceDefinition['arguments'])) {
                     array_walk($serviceDefinition['arguments'], function (&$argument) : void {
-                        if (is_array($argument)) {
+                        if (is_array($argument) || !is_string($argument)) {
                             // @todo fix for @http_kernel.controller.argument_metadata_factory
                             $argument = '';
                         } else {


### PR DESCRIPTION
fix : 
```
TypeError thrown in /project/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalAutoloader.php on line 183 while loading bootstrap file /project/vendor/mglaman/phpstan-drupal/drupal-autoloader.php: str_replace(): Argument #3 ($subject) must be of type array|string, bool given
```
#150 