### PR TITLE
Replace only in string arguments

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -115,6 +115,12 @@ jobs:
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token drupal/blazy
           ./vendor/bin/phpstan analyze web/modules/contrib/blazy --no-progress || if (($? == 255)); then false; else true; fi
           COMPOSER_MEMORY_LIMIT=-1 composer remove drupal/token drupal/blazy
+      - name: 'CDN 3.x PHP8'
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/cdn:3.x-dev
+          ./vendor/bin/phpstan analyze web/modules/contrib/cdn --no-progress || if (($? == 255)); then false; else true; fi
+          COMPOSER_MEMORY_LIMIT=-1 composer remove drupal/cdn:3.x-dev
       - name: 'Check "Cannot redeclare video_embed_media_media_bundle_insert()"'
         run: |
           cd ~/drupal

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -167,10 +167,10 @@ class DrupalAutoloader
                 // and thinking these are real services for PHPStan's container.
                 if (isset($serviceDefinition['arguments']) && is_array($serviceDefinition['arguments'])) {
                     array_walk($serviceDefinition['arguments'], function (&$argument) : void {
-                        if (is_array($argument) || !is_string($argument)) {
+                        if (is_array($argument)) {
                             // @todo fix for @http_kernel.controller.argument_metadata_factory
                             $argument = '';
-                        } else {
+                        } elseif (is_string($argument)) {
                             $argument = str_replace('@', '', $argument);
                         }
                     });

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -167,10 +167,10 @@ class DrupalAutoloader
                 // and thinking these are real services for PHPStan's container.
                 if (isset($serviceDefinition['arguments']) && is_array($serviceDefinition['arguments'])) {
                     array_walk($serviceDefinition['arguments'], function (&$argument) : void {
-                        if (is_array($argument)) {
+                        if (is_array($argument) || !is_string($argument)) {
                             // @todo fix for @http_kernel.controller.argument_metadata_factory
                             $argument = '';
-                        } elseif (is_string($argument)) {
+                        } else {
                             $argument = str_replace('@', '', $argument);
                         }
                     });


### PR DESCRIPTION
This fix blocking `drupal/upgrade_status` on PHP 8 

The https://github.com/mglaman/phpstan-drupal/pull/161 missed to fix when arguments are int, bool, null

Related to #150 