### PR TITLE
Add PHP8 testing to the matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,9 @@ jobs:
       - start-project
       - install-dependencies
       - run:
+          name: phpspec/prophecy-phpunit fix
+          command: composer require --dev phpspec/prophecy-phpunit:^2
+      - run:
           name: CodeSniffer
           command: ./vendor/bin/phpcs src
       - run:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "Downgrade dev dependencies"
-        run: "composer require phpunit/phpunit:6.5.14 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies"
+        run: "composer require phpunit/phpunit:6.5.14 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev:${{ matrix.drupal }} --with-all-dependencies"
         if: ${{ matrix.drupal == '^8.9' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
@@ -89,7 +89,7 @@ jobs:
           composer config preferred-install dist
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
-          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --with-all-dependencies
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:${{ matrix.drupal }} --with-all-dependencies
       - name: "require phpstan-drupal"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
   tests:
     continue-on-error: ${{ matrix.experimental }}
     runs-on: "ubuntu-latest"
-    name: "PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
+    name: "Tests | PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
     strategy:
       matrix:
         experimental: [false]
@@ -43,6 +43,9 @@ jobs:
       - name: "Downgrade dev dependencies"
         run: "composer require phpunit/phpunit:6.5.14 drush/drush:~9 drupal/core-recommended:${{ matrix.drupal }} drupal/core-dev:${{ matrix.drupal }} --with-all-dependencies"
         if: ${{ matrix.drupal == '^8.9' }}
+      - name: "Add phpspec/prophecy-phpunit"
+        run: "composer require --dev phpspec/prophecy-phpunit:^2"
+        if: ${{ matrix.drupal == '^9.0' }}
       - name: "PHPCS"
         run: "php vendor/bin/phpcs src"
       - name: "PHPStan"
@@ -53,7 +56,7 @@ jobs:
   build_integration:
     continue-on-error: ${{ matrix.experimental }}
     runs-on: "ubuntu-latest"
-    name: "PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
+    name: "Build Integration | PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
     strategy:
       matrix:
         experimental: [false]
@@ -90,6 +93,11 @@ jobs:
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:${{ matrix.drupal }} --with-all-dependencies
+      - name: "Add phpspec/prophecy-phpunit"
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require --dev phpspec/prophecy-phpunit:^2
+        if: ${{ matrix.drupal == '^9.0' }}
       - name: "require phpstan-drupal"
         run: |
           cd ~/drupal

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,11 +25,9 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-# @todo D9 is compat, but drupal/core-dev-pinned is not?
-# core-dev-pinned sets phar-io/manifest to 1.0.3, where ^2.0 is
-#          - php-version: "8.0"
-#            drupal: "^9.0"
-#            experimental: true
+          - php-version: "8.0"
+            drupal: "^9.0"
+            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
@@ -69,11 +67,9 @@ jobs:
           - php-version: "7.2"
             drupal: "~8.9"
             experimental: false
-# @todo D9 is compat, but drupal/core-dev-pinned is not?
-# core-dev-pinned sets phar-io/manifest to 1.0.3, where ^2.0 is
-#          - php-version: "8.0"
-#            drupal: "^9.0"
-#            experimental: true
+          - php-version: "8.0"
+            drupal: "^9.0"
+            experimental: true
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "phpstan/phpstan-deprecation-rules": "~0.12.0",
         "composer/installers": "^1.9",
         "drupal/core-recommended": "^8.8@alpha || ^9.0",
-        "drupal/core-dev-pinned": "^8.8@alpha || ^9.0",
+        "drupal/core-dev": "^8.8@alpha || ^9.0",
         "drush/drush": "^9.6 | ^10.0"
     },
     "minimum-stability": "dev",

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -14,7 +14,7 @@ class ServiceMap
         // @see notes in DrupalAutoloader.
         // This is all a work around due to inability to set container parameters.
         if (count($this->services) === 0) {
-            $this->services = $GLOBALS['drupalServiceMap'];
+            $this->services = $GLOBALS['drupalServiceMap'] ?? [];
             if (count($this->services) === 0) {
                 throw new ShouldNotHappenException('No Drupal service map was registered.');
             }

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -7,7 +7,7 @@ use PHPStan\ShouldNotHappenException;
 class ServiceMap
 {
     /** @var \PHPStan\Drupal\DrupalServiceDefinition[] */
-    private $services;
+    private $services = [];
 
     public function getService(string $id): ?DrupalServiceDefinition
     {


### PR DESCRIPTION
Unblocks #150

drupal/core-dev-pinned conflicts on PHP8 due to phar-io/manifest:1.0.3, we need ^2