### PR TITLE
Don't try to check interfaces that don't exist

### DIFF
--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -47,7 +47,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
         ];
         $classReflection = $scopeClassReflection->getNativeReflection();
         foreach ($whitelist as $item) {
-            if ($classReflection->implementsInterface($item)) {
+            if (interface_exists($item) && $classReflection->implementsInterface($item)) {
                 return [];
             }
         }


### PR DESCRIPTION
If phpunit is not installed, `GlobalDrupalDependencyInjectionRule` will crash:
```
         Internal error: Interface PHPUnit\Framework\Test does not exist       
         Run PHPStan with --debug option and post the stack trace to:          
         https://github.com/phpstan/phpstan/issues/new?template=Bug_report.md  
```
This PR makes sure the interface exists before calling `implementsInterface()`.