### PR TITLE
Check getInterfaceNames over implementsInterface

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -114,3 +114,47 @@ jobs:
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token drupal/blazy
           ./vendor/bin/phpstan analyze web/modules/contrib/blazy --no-progress || if (($? == 255)); then false; else true; fi
+  build_integration_no_phpunit:
+    continue-on-error: ${{ matrix.experimental }}
+    runs-on: "ubuntu-latest"
+    name: "Build Integration (No PHPUnit) | PHP ${{ matrix.php-version }} | Drupal ${{ matrix.drupal }}"
+    strategy:
+      matrix:
+        experimental: [false]
+        php-version:
+          - "7.4"
+        drupal:
+          - "^8.9"
+          - "^9.0"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: composer:v2
+          extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv
+      - name: Setup Drupal
+        uses: bluehorndigital/setup-drupal@v1.0.1
+        with:
+          version: ${{ matrix.drupal }}
+          path: ~/drupal
+      - name: "Remove PHPUnit"
+        run: |
+          cd ~/drupal
+          composer --dev remove phpspec/prophecy-phpunit drupal/core-dev
+      - name: "require phpstan-drupal"
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require mglaman/phpstan-drupal *@dev
+          cp $GITHUB_WORKSPACE/tests/fixtures/config/drupal-phpstan.neon phpstan.neon
+      - name: "Test core/install.php"
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze web/core/install.php --debug
+      - name: "Test no crash"
+        run: |
+          cd ~/drupal
+          ./vendor/bin/phpstan analyze web/core/modules/dynamic_page_cache --debug || if (($? == 255)); then false; else true; fi

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -100,14 +100,18 @@ class DrupalAutoloader
         $this->addThemeNamespaces();
         $this->registerPs4Namespaces($this->namespaces);
         $this->loadLegacyIncludes();
-        require_once $this->drupalRoot . '/core/tests/bootstrap.php';
 
-        // class_alias is not supported by OptimizedDirectorySourceLocator or AutoloadSourceLocator,
-        // so we manually load this PHPUnit compatibility trait that exists in Drupal 8.
-        $phpunitCompatTraitFilepath = $this->drupalRoot . '/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php';
-        if (file_exists($phpunitCompatTraitFilepath)) {
-            require_once $phpunitCompatTraitFilepath;
-            $this->autoloader->addClassMap(['Drupal\\Tests\\PhpunitCompatibilityTrait' => $phpunitCompatTraitFilepath]);
+        // @todo stop requiring the bootstrap.php and just copy what is needed.
+        if (interface_exists(\PHPUnit\Framework\Test::class)) {
+            require_once $this->drupalRoot . '/core/tests/bootstrap.php';
+
+            // class_alias is not supported by OptimizedDirectorySourceLocator or AutoloadSourceLocator,
+            // so we manually load this PHPUnit compatibility trait that exists in Drupal 8.
+            $phpunitCompatTraitFilepath = $this->drupalRoot . '/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php';
+            if (file_exists($phpunitCompatTraitFilepath)) {
+                require_once $phpunitCompatTraitFilepath;
+                $this->autoloader->addClassMap(['Drupal\\Tests\\PhpunitCompatibilityTrait' => $phpunitCompatTraitFilepath]);
+            }
         }
 
         foreach ($this->moduleData as $extension) {

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -32,7 +32,8 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             throw new ShouldNotHappenException();
         }
 
-        $whitelist = [
+        $classReflection = $scopeClassReflection->getNativeReflection();
+        $allowed_list = [
             // Ignore tests.
             'PHPUnit\Framework\Test',
             // Typed data objects cannot use dependency injection.
@@ -45,9 +46,10 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             // @see https://www.drupal.org/project/drupal/issues/2913224
             'Drupal\Core\Entity\EntityInterface',
         ];
-        $classReflection = $scopeClassReflection->getNativeReflection();
-        foreach ($whitelist as $item) {
-            if ($classReflection->implementsInterface($item)) {
+        $implemented_interfaces = $classReflection->getInterfaceNames();
+
+        foreach ($allowed_list as $item) {
+            if (in_array($item, $implemented_interfaces, true)) {
                 return [];
             }
         }

--- a/tests/fixtures/drupal/modules/module_with_tests/tests/src/Kernel/DrupalStaticCallTest.php
+++ b/tests/fixtures/drupal/modules/module_with_tests/tests/src/Kernel/DrupalStaticCallTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\Tests\module_with_tests\Kernel;
+
+use Drupal;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\module_with_tests\Traits\ModuleWithTestsTrait;
+
+/**
+ * This is a dummy test class.
+ *
+ * @group module_with_tests
+ */
+class DrupalStaticCallTest extends KernelTestBase {
+
+    use ModuleWithTestsTrait;
+
+    /**
+     * A dummy test.
+     */
+    public function testModule() {
+        $request = Drupal::hasRequest();
+        $this->assertFalse($request);
+    }
+
+}

--- a/tests/src/DrupalIntegrationTest.php
+++ b/tests/src/DrupalIntegrationTest.php
@@ -60,6 +60,7 @@ final class DrupalIntegrationTest extends AnalyzerTestBase {
             __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Unit/ModuleWithTestsTest.php',
             __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Traits/ModuleWithTestsTrait.php',
             __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/TestSite/ModuleWithTestsTestSite.php',
+            __DIR__ . '/../fixtures/drupal/modules/module_with_tests/tests/src/Kernel/DrupalStaticCallTest.php',
         ];
         foreach ($paths as $path) {
             $errors = $this->runAnalyze($path);


### PR DESCRIPTION
See #167. Tries using `getInterfaceNames` over `classImplements` to handle missing PHPUnit