### PR TITLE
Use excludePath instead of excludes_analyse

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To exclude tests from analysis, add the following parameter
 
 ```
 parameters:
-	excludes_analyse:
+	excludePaths:
 		- *Test.php
 		- *TestBase.php
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "nette/finder": "^2.5",
-        "phpstan/phpstan": "^0.12.64",
+        "phpstan/phpstan": "^0.12.65",
         "symfony/yaml": "~3.4.5|^4.2",
         "webflo/drupal-finder": "^1.2"
     },

--- a/extension.neon
+++ b/extension.neon
@@ -1,7 +1,7 @@
 parameters:
 	bootstrapFiles:
 		- drupal-autoloader.php
-	excludes_analyse:
+	excludePaths:
 		- '*.api.php'
 		- '*/tests/fixtures/*.php'
 	fileExtensions:


### PR DESCRIPTION
The two can't be used together and `excludes_analyse` was deprecated in phpstan 0.12.65. See:
- https://phpstan.org/user-guide/ignoring-errors#excluding-whole-files
- https://newreleases.io/project/github/phpstan/phpstan/release/0.12.65
- https://github.com/phpstan/phpstan/issues/3749#issuecomment-754749316

Fixes #179