### PR TITLE
Update ConfigEntityConfigExportRule.php

### DIFF
--- a/src/Rules/Deprecations/ConfigEntityConfigExportRule.php
+++ b/src/Rules/Deprecations/ConfigEntityConfigExportRule.php
@@ -4,8 +4,9 @@ namespace PHPStan\Rules\Deprecations;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 
 final class ConfigEntityConfigExportRule extends DeprecatedAnnotationsRuleBase
@@ -18,13 +19,13 @@ final class ConfigEntityConfigExportRule extends DeprecatedAnnotationsRuleBase
 
     protected function doProcessNode(ClassReflection $reflection, Node\Stmt\Class_ $node, Scope $scope): array
     {
-        $annotation = $reflection->getResolvedPhpDoc();
+        $phpDoc = $reflection->getResolvedPhpDoc();
         // Plugins should always be annotated, but maybe this class is missing its
         // annotation since it swaps an existing one.
-        if ($annotation === null || strpos('@ConfigEntityType(', $annotation->getPhpDocString()) === false) {
+        if ($phpDoc === null || !$this->isAnnotated($phpDoc)) {
             return [];
         }
-        $hasMatch = preg_match('/config_export\s?=\s?{/', $annotation->getPhpDocString());
+        $hasMatch = preg_match('/config_export\s?=\s?{/', $phpDoc->getPhpDocString());
         if ($hasMatch === false) {
             throw new ShouldNotHappenException('Unexpected error when trying to run match on phpDoc string.');
         }
@@ -34,5 +35,17 @@ final class ConfigEntityConfigExportRule extends DeprecatedAnnotationsRuleBase
             ];
         }
         return [];
+    }
+
+    private function isAnnotated(ResolvedPhpDocBlock $phpDoc): bool
+    {
+        foreach ($phpDoc->getPhpDocNodes() as $docNode) {
+            foreach ($docNode->children as $childNode) {
+                if (($childNode instanceof PhpDocTagNode) && $childNode->name === '@ConfigEntityType') {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Additional check to make sure the 'config_export' annotation property is needed.

I have an issue where a missing `config_export` key is reported on a class which extends a config entity.