### PR TITLE
Clean up PHPUnit bootstrap inclusion

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -102,15 +102,7 @@ class DrupalAutoloader
 
         // @todo stop requiring the bootstrap.php and just copy what is needed.
         if (interface_exists(\PHPUnit\Framework\Test::class)) {
-            require_once $this->drupalRoot . '/core/tests/bootstrap.php';
-
-            // class_alias is not supported by OptimizedDirectorySourceLocator or AutoloadSourceLocator,
-            // so we manually load this PHPUnit compatibility trait that exists in Drupal 8.
-            $phpunitCompatTraitFilepath = $this->drupalRoot . '/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php';
-            if (file_exists($phpunitCompatTraitFilepath)) {
-                require_once $phpunitCompatTraitFilepath;
-                $this->autoloader->addClassMap(['Drupal\\Tests\\PhpunitCompatibilityTrait' => $phpunitCompatTraitFilepath]);
-            }
+            require $this->drupalRoot . '/core/tests/bootstrap.php';
         }
 
         foreach ($this->moduleData as $extension) {


### PR DESCRIPTION
Remove unnecessary class map entry for PhpunitCompatibilityTrait, drop `require_once` for bootstrap.php to avoid any odd side effects later on.

Came from: https://www.drupal.org/project/upgrade_status/issues/3231048. Waiting for feedback before merge.