### PR TITLE
Only error on defaultTheme for testing profiles

### DIFF
--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -39,6 +39,21 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
             return [];
         }
         $defaultProperties = $reflection->getNativeReflection()->getDefaultProperties();
+        $profile = $defaultProperties['profile'] ?? null;
+
+        $testingProfilesWithoutThemes = [
+            'testing',
+            'nightwatch_testing',
+            'testing_config_overrides',
+            'testing_missing_dependencies',
+            'testing_multilingual',
+            'testing_multilingual_with_english',
+            'testing_requirements',
+        ];
+        if ($profile !== null && !in_array($profile, $testingProfilesWithoutThemes, true)) {
+            return [];
+        }
+
         $defaultTheme = $defaultProperties['defaultTheme'] ?? null;
 
         if ($defaultTheme === null || $defaultTheme === '') {

--- a/tests/src/Rules/BrowserTestBaseDefaultThemeRuleTest.php
+++ b/tests/src/Rules/BrowserTestBaseDefaultThemeRuleTest.php
@@ -42,6 +42,10 @@ final class BrowserTestBaseDefaultThemeRuleTest extends DrupalRuleTestCase {
             []
         ];
         yield [
+            __DIR__ . '/../../fixtures/drupal/core/tests/Drupal/FunctionalTests/Installer/InstallerExistingConfigMultilingualTest.php',
+            []
+        ];
+        yield [
             __DIR__ . '/../../fixtures/drupal/modules/module_with_tests/tests/src/Functional/ExtendsDefaultThemeTest.php',
             []
         ];


### PR DESCRIPTION
Fixes #198

Only errors for `defaultTheme` when a testing profile is used.
