### PR TITLE
Allow magic methods for variables of type FieldItemListInterface

### DIFF
--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -58,7 +58,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
     {
         $classObject = new ObjectType($reflection->getName());
         $interfaceObject = self::getFieldItemListInterfaceObject();
-        return $classObject->isSuperTypeOf($interfaceObject);
+        return $interfaceObject->isSuperTypeOf($classObject);
     }
 
     protected static function getFieldItemListInterfaceObject() : ObjectType

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -5,6 +5,7 @@ namespace mglaman\PHPStanDrupal\Reflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 
 /**
@@ -33,7 +34,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if (self::classObjectIsSuperOfFieldItemList($reflection)) {
+        if (self::classObjectIsSuperOfFieldItemList($reflection)->yes()) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -46,21 +47,21 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($reflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName);
         }
-        if (self::classObjectIsSuperOfFieldItemList($reflection)) {
+        if (self::classObjectIsSuperOfFieldItemList($reflection)->yes()) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
         throw new \LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
     }
 
-    protected static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection)
+    protected static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection) : TrinaryLogic
     {
         $classObject = new ObjectType($reflection->getName());
         $interfaceObject = self::getFieldItemListInterfaceObject();
         return $classObject->isSuperTypeOf($interfaceObject);
     }
 
-    protected static function getFieldItemListInterfaceObject()
+    protected static function getFieldItemListInterfaceObject() : ObjectType
     {
         return new ObjectType('Drupal\Core\Field\FieldItemListInterface');
     }

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -5,6 +5,7 @@ namespace mglaman\PHPStanDrupal\Reflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\ObjectType;
 
 /**
  * Allows field access via magic methods
@@ -32,7 +33,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if ($reflection->getName() === 'Drupal\Core\Field\FieldItemListInterface' || $reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if (self::classObjectIsSuperOfFieldItemList($reflection)) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -45,10 +46,22 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($reflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName);
         }
-        if ($reflection->getName() === 'Drupal\Core\Field\FieldItemListInterface' || $reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if (self::classObjectIsSuperOfFieldItemList($reflection)) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
         throw new \LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
+    }
+
+    protected static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection)
+    {
+        $classObject = new ObjectType($reflection->getName());
+        $interfaceObject = self::getFieldItemListInterfaceObject();
+        return $classObject->isSuperTypeOf($interfaceObject);
+    }
+
+    protected static function getFieldItemListInterfaceObject()
+    {
+        return new ObjectType('Drupal\Core\Field\FieldItemListInterface');
     }
 }

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -32,7 +32,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if ($reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if ($reflection->getName() === 'Drupal\Core\Field\FieldItemListInterface' || $reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -45,7 +45,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($reflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName);
         }
-        if ($reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if ($reflection->getName() === 'Drupal\Core\Field\FieldItemListInterface' || $reflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -67,12 +67,12 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
         ];
         yield 'field item list: value' => [
             \Drupal\Core\Field\FieldItemList::class,
-            'target_id',
+            'value',
             true,
         ];
         yield 'field item list_interface: value' => [
             \Drupal\Core\Field\FieldItemListInterface::class,
-            'target_id',
+            'value',
             true,
         ];
         // @todo support more proeprties.

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -70,6 +70,11 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
             'target_id',
             true,
         ];
+        yield 'field item list_interface: value' => [
+            \Drupal\Core\Field\FieldItemListInterface::class,
+            'target_id',
+            true,
+        ];
         // @todo support more proeprties.
         yield 'field item list: format' => [
             \Drupal\Core\Field\FieldItemList::class,


### PR DESCRIPTION
So here is a thing.

If a variable was declared to be just the FieldItemListInterface, phpstan-drupal would not allow it to access things like ->value, since we require it to implement interface FieldItemListInterface. Which returns false if the variable is literally that interface.

You would need at lest level 2 to get this error.

An example:

```
/** @var \Drupal\Core\Field\FieldItemListInterface $field */
$field = $node->get('my_field');
$value = $field->value; // <- this fails with Access to an undefined property Drupal\Core\Field\FieldItemListInterface::$value
```

You don't actually need to typehint the field either, because the ->get method is supposed to return FieldItemListInterface.

```
$field = $node->get('my_field');
$value = $field->value; // <- fails with Access to an undefined property Drupal\Core\Field\FieldItemListInterface::$value
```

So currently you would have to do something like this:

```
/** @var \Drupal\Core\Field\FieldItemList $field */
$field = $node->get('my_field');
$value = $field->value; // <- does not fail.
```

With this PR you can do whichever of the variants you like, they all work :tada: 