### PR TITLE
Detect when a class extends a class that has been flagged as @internal

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -77,6 +77,11 @@ services:
 		class: mglaman\PHPStanDrupal\Reflection\EntityFieldsViaMagicReflectionExtension
 		tags: [phpstan.broker.propertiesClassReflectionExtension]
 	-
+		class: mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule
+		tags: [phpstan.rules.rule]
+		arguments:
+			reflectionProvider: @reflectionProvider
+	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes
 		tags: [phpstan.rules.rule]
 		arguments:

--- a/src/Internal/NamespaceCheck.php
+++ b/src/Internal/NamespaceCheck.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Internal;
+
+use PhpParser\Node\Stmt\Class_;
+
+/**
+ * @internal
+ */
+final class NamespaceCheck
+{
+    public static function isDrupalNamespace(Class_ $class): bool
+    {
+        // @phpstan-ignore-next-line
+        if (!isset($class->namespacedName)) {
+            return false;
+        }
+
+        return 'Drupal' === (string) $class->namespacedName->slice(0, 1);
+    }
+
+    public static function isSharedNamespace(Class_ $class): bool
+    {
+        if (!isset($class->extends)) {
+            return false;
+        }
+
+        // @phpstan-ignore-next-line
+        if (!isset($class->namespacedName)) {
+            return false;
+        }
+
+        if (!self::isDrupalNamespace($class)) {
+            return false;
+        }
+
+        return (string) $class->namespacedName->slice(0, 2) === (string) $class->extends->slice(0, 2);
+    }
+}

--- a/src/Rules/Classes/ClassExtendsInternalClassRule.php
+++ b/src/Rules/Classes/ClassExtendsInternalClassRule.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Classes;
+
+use mglaman\PHPStanDrupal\Internal\NamespaceCheck;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class ClassExtendsInternalClassRule implements Rule
+{
+    /**
+     * @var ReflectionProvider
+     */
+    private $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        /** @var Class_ $node */
+        if (!isset($node->extends)) {
+            return [];
+        }
+
+        $extendedClassName = $node->extends->toString();
+        if (!$this->reflectionProvider->hasClass($extendedClassName)) {
+            return [];
+        }
+
+        $extendedClassReflection = $this->reflectionProvider->getClass($extendedClassName);
+        if (!$extendedClassReflection->isInternal()) {
+            return [];
+        }
+
+        // @phpstan-ignore-next-line
+        if (!isset($node->namespacedName)) {
+            return $this->buildError(null, $extendedClassName);
+        }
+
+        $currentClassName = $node->namespacedName->toString();
+
+        if (!NamespaceCheck::isDrupalNamespace($node)) {
+            return $this->buildError($currentClassName, $extendedClassName);
+        }
+
+        if (NamespaceCheck::isSharedNamespace($node)) {
+            return [];
+        }
+
+        return $this->buildError($currentClassName, $extendedClassName);
+    }
+
+    private function buildError(?string $currentClassName, string $extendedClassName): array
+    {
+        return [
+            RuleErrorBuilder::message(\sprintf(
+                '%s extends @internal class %s.',
+                $currentClassName !== null ? \sprintf('Class %s', $currentClassName) : 'Anonymous class',
+                $extendedClassName
+            ))->build()
+        ];
+    }
+}

--- a/tests/fixtures/drupal/modules/module_with_internal_classes/module_with_internal_classes.info.yml
+++ b/tests/fixtures/drupal/modules/module_with_internal_classes/module_with_internal_classes.info.yml
@@ -1,0 +1,3 @@
+name: module_with_internal_classes
+type: module
+core: 8.x

--- a/tests/fixtures/drupal/modules/module_with_internal_classes/src/Foo/ExternalClass.php
+++ b/tests/fixtures/drupal/modules/module_with_internal_classes/src/Foo/ExternalClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\module_with_internal_classes\Foo;
+
+class ExternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/module_with_internal_classes/src/Foo/InternalClass.php
+++ b/tests/fixtures/drupal/modules/module_with_internal_classes/src/Foo/InternalClass.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\module_with_internal_classes\Foo;
+
+/**
+ * @internal
+ */
+class InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/DoesNotExtendsAnyClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/DoesNotExtendsAnyClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+final class DoesNotExtendsAnyClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreExternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreExternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\Core\PHPStanDrupalTests\ExternalClass;
+
+final class ExtendsDrupalCoreExternalClass extends ExternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreInternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\Core\InternalClass;
+
+final class ExtendsDrupalCoreInternalClass extends InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCorePHPStanDrupalTestsInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCorePHPStanDrupalTestsInternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\Core\PHPStanDrupalTests\InternalClass;
+
+final class ExtendsDrupalCorePHPStanDrupalTestsInternalClass extends InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsInternalClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+final class ExtendsInternalClass extends InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesExternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesExternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\module_with_internal_classes\Foo\ExternalClass;
+
+final class ExtendsPHPStanDrupalModuleWithInternalClassesExternalClass extends ExternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesInternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\module_with_internal_classes\Foo\InternalClass;
+
+final class ExtendsPHPStanDrupalModuleWithInternalClassesInternalClass extends InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsRootInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsRootInternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+use Drupal\phpstan_fixtures\InternalClass;
+
+final class ExtendsRootInternalClass extends InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/InternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/InternalClass.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures\Internal;
+
+/**
+ * @internal
+ */
+class InternalClass {
+
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/WithAnAnonymousClassExtendingAnInternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Internal/WithAnAnonymousClassExtendingAnInternalClass.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace fixtures\drupal\modules\phpstan_fixtures\src\Internal;
+
+use Drupal\module_with_internal_classes\Foo\InternalClass;
+
+final class WithAnAnonymousClassExtendingAnInternalClass
+{
+    public function foo(): void
+    {
+        $foo = new class() extends InternalClass {};
+    }
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/InternalClass.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/InternalClass.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\phpstan_fixtures;
+
+/**
+ * @internal
+ */
+class InternalClass {
+
+}

--- a/tests/src/Rules/ClassExtendsInternalClassRuleTest.php
+++ b/tests/src/Rules/ClassExtendsInternalClassRuleTest.php
@@ -1,0 +1,194 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class ClassExtendsInternalClassRuleTest extends DrupalRuleTestCase
+{
+    private const DRUPAL_CORE_STUBS_MAIN_DIRECTORY = __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/PHPStanDrupalTests';
+
+    protected function getRule(): Rule
+    {
+        return new ClassExtendsInternalClassRule($this->createReflectionProvider());
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::cleanDrupalCoreStubs();
+        foreach (self::getDrupalCoreStubs() as $filepath => $content) {
+            $directory = \dirname($filepath);
+            if (!is_dir($directory)) {
+                \mkdir($directory, 0777, true);
+            }
+            \file_put_contents($filepath, $content);
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        self::cleanDrupalCoreStubs();
+    }
+
+    /**
+     * @dataProvider pluginData
+     */
+    public function testRule(string $path, array $errorMessages): void
+    {
+        $this->analyse([$path], $errorMessages);
+    }
+
+    public function pluginData(): \Generator
+    {
+        yield 'extends an internal class from a non-shared namespace: phpstan_fixtures extends an internal class from Drupal core.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreInternalClass.php',
+            [
+                [
+                    'Class Drupal\phpstan_fixtures\Internal\ExtendsDrupalCoreInternalClass extends @internal class Drupal\Core\InternalClass.',
+                    7
+                ],
+            ],
+        ];
+        yield 'extends an internal class from a non-shared namespace: phpstan_fixtures extends an internal class from Drupal core with a deeper namespace.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCorePHPStanDrupalTestsInternalClass.php',
+            [
+                [
+                    'Class Drupal\phpstan_fixtures\Internal\ExtendsDrupalCorePHPStanDrupalTestsInternalClass extends @internal class Drupal\Core\PHPStanDrupalTests\InternalClass.',
+                    7
+                ],
+            ],
+        ];
+        yield 'extends an internal class from a non-shared namespace: phpstan_fixtures extends an internal class from module module_with_internal_classes.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesInternalClass.php',
+            [
+                [
+                    'Class Drupal\phpstan_fixtures\Internal\ExtendsPHPStanDrupalModuleWithInternalClassesInternalClass extends @internal class Drupal\module_with_internal_classes\Foo\InternalClass.',
+                    7
+                ],
+            ],
+        ];
+        yield 'extends an internal class from a non-shared namespace: anonymous class extends from an internal class from module module_with_internal_classes.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/WithAnAnonymousClassExtendingAnInternalClass.php',
+            [
+                [
+                    'Anonymous class extends @internal class Drupal\module_with_internal_classes\Foo\InternalClass.',
+                    13
+                ],
+            ],
+        ];
+        yield 'extends an internal class from a non-shared namespace: Drupal Core extends an internal class from module phpstan_fixtures.' => [
+            __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/PHPStanDrupalTests/ExtendsPhpStanFixturesInternalClass.php',
+            [
+                [
+                    'Class Drupal\Core\PHPStanDrupalTests\ExtendsPhpStanFixturesInternalClass extends @internal class Drupal\phpstan_fixtures\InternalClass.',
+                    7
+                ],
+            ],
+        ];
+        yield 'extends an internal class from a shared namespace: Drupal Core extends from an internal class from itself.' => [
+            __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/PHPStanDrupalTests/ExtendsRootInternalClass.php',
+            [],
+        ];
+        yield 'extends an internal class from a shared namespace: Drupal Core extends from an internal class from itself with a deeper namespace.' => [
+            __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/PHPStanDrupalTests/ExtendsInternalClass.php',
+            [],
+        ];
+        yield 'extends an internal class from a shared namespace: phpstan_fixtures extends from an internal class from itself.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsRootInternalClass.php',
+            [],
+        ];
+        yield 'extends an internal class from a shared namespace: phpstan_fixtures extends from an internal class from itself with a deeper namespace.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsInternalClass.php',
+            [],
+        ];
+        yield 'does not extend an internal class: does not extends any class.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/DoesNotExtendsAnyClass.php',
+            [],
+        ];
+        yield 'does not extend an internal class: phpstan_fixtures extends an external class from Drupal Core.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsDrupalCoreExternalClass.php',
+            [],
+        ];
+        yield 'does not extend an internal class: phpstan_fixtures extends an external class from module module_with_internal_classes.' => [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Internal/ExtendsPHPStanDrupalModuleWithInternalClassesExternalClass.php',
+            [],
+        ];
+    }
+
+    private static function cleanDrupalCoreStubs(): void {
+        foreach (\array_keys(\iterator_to_array(self::getDrupalCoreStubs())) as $filepath) {
+            if (!is_file($filepath)) {
+                continue;
+            }
+            \unlink($filepath);
+        }
+
+        if (is_dir(self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY)) {
+            \rmdir(self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY);
+        }
+    }
+
+    private static function getDrupalCoreStubs(): \Generator {
+        yield __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/InternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core;
+
+/**
+ * @internal
+ */
+class InternalClass {}
+CODE;
+
+        yield self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY . '/InternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core\PHPStanDrupalTests;
+
+/**
+ * @internal
+ */
+class InternalClass {}
+CODE;
+
+        yield self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY . '/ExtendsRootInternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core\PHPStanDrupalTests;
+
+use Drupal\Core\InternalClass;
+
+class ExtendsRootInternalClass extends InternalClass {}
+CODE;
+
+        yield self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY . '/ExtendsInternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core\PHPStanDrupalTests;
+
+class ExtendsInternalClass extends InternalClass {}
+CODE;
+        yield self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY . '/ExtendsPhpStanFixturesInternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core\PHPStanDrupalTests;
+
+use Drupal\phpstan_fixtures\InternalClass;
+
+class ExtendsPhpStanFixturesInternalClass extends InternalClass {}
+CODE;
+        yield self::DRUPAL_CORE_STUBS_MAIN_DIRECTORY . '/ExternalClass.php' => <<<'CODE'
+<?php
+
+namespace Drupal\Core\PHPStanDrupalTests;
+
+class ExternalClass {}
+CODE;
+    }
+}


### PR DESCRIPTION
See #183

In this PR, a shared namespace for Drupal starts with `Drupal\project_name`.

It means:
* a class inside `Drupal\Core` can extends an internal class from `Drupal\Core`
* a class inside `Drupal\my_module` can extends an internal class from `Drupal\my_module`
* a class inside `Drupal\my_module` cannot extends an internal class from `Drupal\Core` or `\Drupal\another_module`
* a class inside `Drupal\Component` cannot extends an internal class from `Drupal\Core` or `\Drupal\another_module`
* a class inside `Drupal\Core` cannot extends an internal class from `Drupal\Component` or `\Drupal\another_module`
* etc..

For the part detecting calls to internal methods, I think it can be handled in another PR 🤔 