### PR TITLE
Allow ::referencedEntities on field items

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -282,6 +282,9 @@ services:
 		class: mglaman\PHPStanDrupal\Reflection\EntityFieldsViaMagicReflectionExtension
 		tags: [phpstan.broker.propertiesClassReflectionExtension]
 	-
+		class: mglaman\PHPStanDrupal\Reflection\EntityFieldMethodsViaMagicReflectionExtension
+		tags: [phpstan.broker.methodsClassReflectionExtension]
+	-
 		class: mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule
 		tags: [phpstan.rules.rule]
 		arguments:

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -19,16 +19,30 @@ class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassRefle
             // Let other parts of PHPStan handle this.
             return false;
         }
-        $interfaceObject = new ObjectType('Drupal\Core\Field\EntityReferenceFieldItemListInterface');
+        $interfaceObject = new ObjectType('Drupal\Core\Field\FieldItemListInterface');
         $objectType = new ObjectType($classReflection->getName());
-        if ($interfaceObject->isSuperTypeOf($objectType)->yes()) {
-            return FieldItemListMethodReflection::canHandleMethod($classReflection, $methodName);
+        if (!$interfaceObject->isSuperTypeOf($objectType)->yes()) {
+            return false;
         }
+
+        if ($methodName === 'referencedEntities') {
+            return true;
+        }
+
         return false;
     }
 
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {
-        return new FieldItemListMethodReflection($methodName);
+        if ($methodName === 'referencedEntities') {
+            $entityReferenceFieldItemListInterfaceType = new ObjectType('Drupal\Core\Field\EntityReferenceFieldItemListInterface');
+            $classReflection = $entityReferenceFieldItemListInterfaceType->getClassReflection();
+            assert($classReflection !== null);
+        }
+
+        return new FieldItemListMethodReflection(
+            $classReflection,
+            $methodName
+        );
     }
 }

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -15,13 +15,13 @@ class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassRefle
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
-        if ($classReflection->hasNativeMethod($methodName)) {
+        if ($classReflection->hasNativeMethod($methodName) || array_key_exists($methodName, $classReflection->getMethodTags())) {
             // Let other parts of PHPStan handle this.
             return false;
         }
-        $reflection = $classReflection->getNativeReflection();
         $interfaceObject = new ObjectType('Drupal\Core\Field\EntityReferenceFieldItemListInterface');
-        if (EntityFieldsViaMagicReflectionExtension::classObjectIsSuperOfInterface($reflection, $interfaceObject)->yes()) {
+        $objectType = new ObjectType($classReflection->getName());
+        if ($interfaceObject->isSuperTypeOf($objectType)->yes()) {
             return FieldItemListMethodReflection::canHandleMethod($classReflection, $methodName);
         }
         return false;

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -16,7 +16,7 @@ class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassRefle
     {
         $reflection = $classReflection->getNativeReflection();
         if (EntityFieldsViaMagicReflectionExtension::classObjectIsSuperOfFieldItemList($reflection)) {
-            return FieldItemListPropertyReflection::canHandleMethod($classReflection, $methodName);
+            return FieldItemListMethodReflection::canHandleMethod($classReflection, $methodName);
         }
         return false;
     }

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -5,6 +5,7 @@ namespace mglaman\PHPStanDrupal\Reflection;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
 
 /**
  * Allows some common methods on fields.
@@ -14,8 +15,13 @@ class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassRefle
 
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
+        if ($classReflection->hasNativeMethod($methodName)) {
+            // Let other parts of PHPStan handle this.
+            return false;
+        }
         $reflection = $classReflection->getNativeReflection();
-        if (EntityFieldsViaMagicReflectionExtension::classObjectIsSuperOfFieldItemList($reflection)) {
+        $interfaceObject = new ObjectType('Drupal\Core\Field\EntityReferenceFieldItemListInterface');
+        if (EntityFieldsViaMagicReflectionExtension::classObjectIsSuperOfInterface($reflection, $interfaceObject)->yes()) {
             return FieldItemListMethodReflection::canHandleMethod($classReflection, $methodName);
         }
         return false;
@@ -25,5 +31,4 @@ class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassRefle
     {
         return new FieldItemListMethodReflection($methodName);
     }
-
 }

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace mglaman\PHPStanDrupal\Reflection;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodsClassReflectionExtension;
+use PHPStan\Reflection\MethodReflection;
+
+/**
+ * Allows some common methods on fields.
+ */
+class EntityFieldMethodsViaMagicReflectionExtension implements MethodsClassReflectionExtension
+{
+
+    public function hasMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        $reflection = $classReflection->getNativeReflection();
+        if (EntityFieldsViaMagicReflectionExtension::classObjectIsSuperOfFieldItemList($reflection)) {
+            return FieldItemListPropertyReflection::canHandleMethod($classReflection, $methodName);
+        }
+        return false;
+    }
+
+    public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
+    {
+        return new FieldItemListMethodReflection($methodName);
+    }
+
+}

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -20,10 +20,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
-        // @todo Have this run after PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
-        // We should not have to check for the property tags if we could get this to run after PHPStan's
-        // existing annotation property reflection.
-        if ($classReflection->hasNativeProperty($propertyName) || array_key_exists($propertyName, $classReflection->getPropertyTags())) {
+        if ($classReflection->hasNativeProperty($propertyName)) {
             // Let other parts of PHPStan handle this.
             return false;
         }
@@ -60,16 +57,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
     public static function classObjectIsSuperOfInterface(\ReflectionClass $reflection, ObjectType $interfaceObject) : TrinaryLogic
     {
         $classObject = new ObjectType($reflection->getName());
-        return self::getFieldItemListInterfaceObject()->isSuperTypeOf($classObject);
-        $ancestors = $classObject->getAncestorWithClassName($interfaceObject->getClassName());
-        $ancestors2 = $interfaceObject->getAncestorWithClassName($classObject->getClassName());
-        if ($interfaceObject->isSuperTypeOf($classObject)) {
-            return TrinaryLogic::createYes();
-        }
-        if ($interfaceObject->getAncestorWithClassName($classObject->getClassName())) {
-            return TrinaryLogic::createYes();
-        }
-        return TrinaryLogic::createNo();
+        return $interfaceObject->isSuperTypeOf($classObject);
     }
 
     protected static function getFieldItemListInterfaceObject() : ObjectType

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -57,7 +57,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         throw new \LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
     }
 
-    protected static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection) : TrinaryLogic
+    public static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection) : TrinaryLogic
     {
         $classObject = new ObjectType($reflection->getName());
         return self::getFieldItemListInterfaceObject()->isSuperTypeOf($classObject);

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -20,7 +20,10 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
-        if ($classReflection->hasNativeProperty($propertyName)) {
+        // @todo Have this run after PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
+        // We should not have to check for the property tags if we could get this to run after PHPStan's
+        // existing annotation property reflection.
+        if ($classReflection->hasNativeProperty($propertyName) || array_key_exists($propertyName, $classReflection->getPropertyTags())) {
             // Let other parts of PHPStan handle this.
             return false;
         }

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -37,7 +37,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if (self::classObjectIsSuperOfFieldItemList($reflection)->yes()) {
+        if (self::classObjectIsSuperOfInterface($reflection, self::getFieldItemListInterfaceObject())->yes()) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -50,17 +50,26 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($reflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName);
         }
-        if (self::classObjectIsSuperOfFieldItemList($reflection)->yes()) {
+        if (self::classObjectIsSuperOfInterface($reflection, self::getFieldItemListInterfaceObject())->yes()) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
         throw new \LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
     }
 
-    public static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection) : TrinaryLogic
+    public static function classObjectIsSuperOfInterface(\ReflectionClass $reflection, ObjectType $interfaceObject) : TrinaryLogic
     {
         $classObject = new ObjectType($reflection->getName());
         return self::getFieldItemListInterfaceObject()->isSuperTypeOf($classObject);
+        $ancestors = $classObject->getAncestorWithClassName($interfaceObject->getClassName());
+        $ancestors2 = $interfaceObject->getAncestorWithClassName($classObject->getClassName());
+        if ($interfaceObject->isSuperTypeOf($classObject)) {
+            return TrinaryLogic::createYes();
+        }
+        if ($interfaceObject->getAncestorWithClassName($classObject->getClassName())) {
+            return TrinaryLogic::createYes();
+        }
+        return TrinaryLogic::createNo();
     }
 
     protected static function getFieldItemListInterfaceObject() : ObjectType

--- a/src/Reflection/FieldItemListMethodReflection.php
+++ b/src/Reflection/FieldItemListMethodReflection.php
@@ -21,35 +21,21 @@ use PHPStan\Type\Type;
 class FieldItemListMethodReflection implements MethodReflection
 {
 
-    /**
-     * @var string
-     */
-    private $name;
+    /** @var ClassReflection */
+    private $declaringClass;
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    /** @var string */
+    private $methodName;
 
-    public static function canHandleMethod(ClassReflection $classReflection, string $methodName): bool
+    public function __construct(ClassReflection $declaringClass, string $methodName)
     {
-        $method_names = [
-            'referencedEntities',
-        ];
-        return in_array($methodName, $method_names, true);
+        $this->declaringClass = $declaringClass;
+        $this->methodName = $methodName;
     }
 
     public function getDeclaringClass(): ClassReflection
     {
-        if ($this->name !== 'referencedEntities') {
-            throw new ShouldNotHappenException('Only ::referencedEntities is currently handled by ' . __CLASS__);
-        }
-        $objectType = new ObjectType(EntityReferenceFieldItemListInterface::class);
-        $classReflection = $objectType->getClassReflection();
-        if ($classReflection === null) {
-            throw new ShouldNotHappenException('Could not get class reflection for ' . EntityReferenceFieldItemListInterface::class);
-        }
-        return $classReflection;
+        return $this->declaringClass;
     }
 
     public function isStatic(): bool
@@ -74,7 +60,7 @@ class FieldItemListMethodReflection implements MethodReflection
 
     public function getName(): string
     {
-        return $this->name;
+        return $this->methodName;
     }
 
     public function getPrototype(): ClassMemberReflection

--- a/src/Reflection/FieldItemListMethodReflection.php
+++ b/src/Reflection/FieldItemListMethodReflection.php
@@ -8,6 +8,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ClassMemberReflection;
 use PHPStan\Reflection\ReflectionProviderStaticAccessor;
 use PHPStan\Reflection\TrivialParametersAcceptor;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
@@ -20,6 +21,9 @@ use PHPStan\Type\Type;
 class FieldItemListMethodReflection implements MethodReflection
 {
 
+    /**
+     * @var string
+     */
     private $name;
 
     public function __construct(string $name)
@@ -37,9 +41,15 @@ class FieldItemListMethodReflection implements MethodReflection
 
     public function getDeclaringClass(): ClassReflection
     {
-        $reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
-
-        return $reflectionProvider->getClass(EntityReferenceFieldItemListInterface::class);
+        if ($this->name !== 'referencedEntities') {
+            throw new ShouldNotHappenException('Only ::referencedEntities is currently handled by ' . __CLASS__);
+        }
+        $objectType = new ObjectType(EntityReferenceFieldItemListInterface::class);
+        $classReflection = $objectType->getClassReflection();
+        if ($classReflection === null) {
+            throw new ShouldNotHappenException('Could not get class reflection for ' . EntityReferenceFieldItemListInterface::class);
+        }
+        return $classReflection;
     }
 
     public function isStatic(): bool

--- a/src/Reflection/FieldItemListMethodReflection.php
+++ b/src/Reflection/FieldItemListMethodReflection.php
@@ -27,6 +27,14 @@ class FieldItemListMethodReflection implements MethodReflection
         $this->name = $name;
     }
 
+    public static function canHandleMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        $method_names = [
+            'referencedEntities',
+        ];
+        return in_array($methodName, $method_names, true);
+    }
+
     public function getDeclaringClass(): ClassReflection
     {
         $reflectionProvider = ReflectionProviderStaticAccessor::getInstance();

--- a/src/Reflection/FieldItemListMethodReflection.php
+++ b/src/Reflection/FieldItemListMethodReflection.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace mglaman\PHPStanDrupal\Reflection;
+
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ClassMemberReflection;
+use PHPStan\Reflection\ReflectionProviderStaticAccessor;
+use PHPStan\Reflection\TrivialParametersAcceptor;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * Allows field access to common methods.
+ */
+class FieldItemListMethodReflection implements MethodReflection
+{
+
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        $reflectionProvider = ReflectionProviderStaticAccessor::getInstance();
+
+        return $reflectionProvider->getClass(EntityReferenceFieldItemListInterface::class);
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return null;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getPrototype(): ClassMemberReflection
+    {
+        return $this;
+    }
+
+    /**
+     * @return \PHPStan\Reflection\ParametersAcceptor[]
+     */
+    public function getVariants(): array
+    {
+        return [
+            new TrivialParametersAcceptor(),
+        ];
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return '';
+    }
+
+    public function isFinal(): TrinaryLogic
+    {
+        return TrinaryLogic::createYes();
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+
+    public function getThrowType(): ?Type
+    {
+        return null;
+    }
+
+    public function hasSideEffects(): TrinaryLogic
+    {
+        return TrinaryLogic::createNo();
+    }
+}

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -29,6 +29,14 @@ class FieldItemListPropertyReflection implements PropertyReflection
         $this->propertyName = $propertyName;
     }
 
+    public static function canHandleMethod(ClassReflection $classReflection, string $methodName): bool
+    {
+        $method_names = [
+            'referencedEntities',
+        ];
+        return in_array($methodName, $method_names, true);
+    }
+
     public static function canHandleProperty(ClassReflection $classReflection, string $propertyName): bool
     {
         // @todo use the class reflection and be more specific about handled properties.

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -29,14 +29,6 @@ class FieldItemListPropertyReflection implements PropertyReflection
         $this->propertyName = $propertyName;
     }
 
-    public static function canHandleMethod(ClassReflection $classReflection, string $methodName): bool
-    {
-        $method_names = [
-            'referencedEntities',
-        ];
-        return in_array($methodName, $method_names, true);
-    }
-
     public static function canHandleProperty(ClassReflection $classReflection, string $propertyName): bool
     {
         // @todo use the class reflection and be more specific about handled properties.

--- a/tests/src/Reflection/EntityFieldMethodsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldMethodsViaMagicReflectionExtensionTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Reflection;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\module_installer_config_test\Entity\TestConfigType;
+use mglaman\PHPStanDrupal\Reflection\EntityFieldMethodsViaMagicReflectionExtension;
+use mglaman\PHPStanDrupal\Reflection\EntityFieldsViaMagicReflectionExtension;
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\PHPStanTestCase;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+
+final class EntityFieldMethodsViaMagicReflectionExtensionTest extends PHPStanTestCase {
+
+    use AdditionalConfigFilesTrait;
+
+    /**
+     * @var \mglaman\PHPStanDrupal\Reflection\EntityFieldMethodsViaMagicReflectionExtension
+     */
+    private $extension;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extension = new EntityFieldMethodsViaMagicReflectionExtension();
+    }
+
+    /**
+     * @dataProvider dataHasMethod
+     *
+     * @param string $method
+     * @param bool $result
+     */
+    public function testHasMethod(string $class, string $method, bool $result): void
+    {
+        $reflection = $this->createReflectionProvider()->getClass($class);
+        self::assertEquals($result, $this->extension->hasMethod($reflection, $method));
+    }
+
+    public function dataHasMethod(): \Generator
+    {
+        // Technically it does not have this method. But we allow it for now.
+        yield 'field item list: referencedEntities' => [
+            FieldItemListInterface::class,
+            'referencedEntities',
+            true,
+        ];
+
+        // A content entity for sure does not have this method.
+        yield 'Content entity: referencedEntities' => [
+            EntityTest::class,
+            'referencedEntities',
+            false,
+        ];
+    }
+
+}

--- a/tests/src/Reflection/EntityFieldMethodsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldMethodsViaMagicReflectionExtensionTest.php
@@ -2,20 +2,12 @@
 
 namespace mglaman\PHPStanDrupal\Tests\Reflection;
 
-use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Field\EntityReferenceFieldItemList;
-use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
-use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\entity_test\Entity\EntityTest;
-use Drupal\module_installer_config_test\Entity\TestConfigType;
+use Drupal\node\Entity\Node;
 use mglaman\PHPStanDrupal\Reflection\EntityFieldMethodsViaMagicReflectionExtension;
-use mglaman\PHPStanDrupal\Reflection\EntityFieldsViaMagicReflectionExtension;
 use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
 use PHPStan\Testing\PHPStanTestCase;
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectType;
-use PHPStan\Type\StringType;
 
 final class EntityFieldMethodsViaMagicReflectionExtensionTest extends PHPStanTestCase {
 
@@ -55,6 +47,7 @@ final class EntityFieldMethodsViaMagicReflectionExtensionTest extends PHPStanTes
 
         // A content entity for sure does not have this method.
         yield 'Content entity: referencedEntities' => [
+            // @phpstan-ignore-next-line
             EntityTest::class,
             'referencedEntities',
             false,


### PR DESCRIPTION
OK, so this PR adds a bit to the legacy that is allowed things on a field item.

Currently we just assume that if an object is of the type FieldItemListInterface (or super type of) then we can access the properties entity, value and target_id.

Technically this might be true, as accessing ->entity on a text item would probably just give you null? But my claim is that if we are blindly allowing things that might be from another field, we might as well allow methods that might be on another field. For example ::referencedEntities.

Ideally I would see some sort of elaborate entity field mapping thing, where you can actually specify that field_coupon would be an entityreference item (and its class) but that's more of a refactor than this PR (and my time) allows. So here is a stab at allowing that specific method as well, together with those specific properties that we already allow.