### PR TITLE
Respect @property annotations on Entity classes

### DIFF
--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -20,6 +20,9 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
+        // @todo Have this run after PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
+        // We should not have to check for the property tags if we could get this to run after PHPStan's
+        // existing annotation property reflection.
         if ($classReflection->hasNativeProperty($propertyName) || array_key_exists($propertyName, $classReflection->getPropertyTags())) {
             // Let other parts of PHPStan handle this.
             return false;
@@ -57,8 +60,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
     protected static function classObjectIsSuperOfFieldItemList(\ReflectionClass $reflection) : TrinaryLogic
     {
         $classObject = new ObjectType($reflection->getName());
-        $interfaceObject = self::getFieldItemListInterfaceObject();
-        return $interfaceObject->isSuperTypeOf($classObject);
+        return self::getFieldItemListInterfaceObject()->isSuperTypeOf($classObject);
     }
 
     protected static function getFieldItemListInterfaceObject() : ObjectType

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -20,7 +20,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
-        if ($classReflection->hasNativeProperty($propertyName)) {
+        if ($classReflection->hasNativeProperty($propertyName) || array_key_exists($propertyName, $classReflection->getPropertyTags())) {
             // Let other parts of PHPStan handle this.
             return false;
         }

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Entity/ReflectionEntityTest.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Entity/ReflectionEntityTest.php
@@ -7,6 +7,9 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\user\UserInterface;
 
+/**
+ * @property \Drupal\Core\Field\EntityReferenceFieldItemListInterface $user_id
+ */
 final class ReflectionEntityTest extends ContentEntityBase {
 
     public static function baseFieldDefinitions(EntityTypeInterface $entity_type)

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\module_installer_config_test\Entity\TestConfigType;
+use Drupal\phpstan_fixtures\Entity\ReflectionEntityTest;
 use mglaman\PHPStanDrupal\Reflection\EntityFieldsViaMagicReflectionExtension;
 use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
 use PHPStan\Testing\PHPStanTestCase;
@@ -51,6 +52,12 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
             // @phpstan-ignore-next-line
             TestConfigType::class,
             'foobar',
+            false
+        ];
+        yield 'annotated properties are skipped on content entities' => [
+            // @phpstan-ignore-next-line
+            ReflectionEntityTest::class,
+            'user_id',
             false
         ];
         // @todo really entity is only supported on EntityFieldItemList

--- a/tests/src/Type/EntityPropertyTypeTest.php
+++ b/tests/src/Type/EntityPropertyTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Type;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class EntityPropertyTypeTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public function dataFileAsserts(): iterable
+    {
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/entity-properties.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Type/data/entity-properties.php
+++ b/tests/src/Type/data/entity-properties.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DrupalEntity;
+
+use Drupal\node\Entity\Node;
+use Drupal\phpstan_fixtures\Entity\ReflectionEntityTest;
+use function PHPStan\Testing\assertType;
+
+$node = Node::create(['type' => 'page']);
+assertType('Drupal\Core\Field\FieldItemListInterface', $node->uid);
+
+$entity = ReflectionEntityTest::create();
+assertType('Drupal\Core\Field\EntityReferenceFieldItemListInterface', $entity->user_id);


### PR DESCRIPTION
Fixes #172 and possibly another issue, since I'm sure I stole it from somewhere?

Updates EntityFieldsViaMagicReflectionExtensionTest to test annotated properties are skipped in the same way as explicit properties, adding an annotation to ReflectionEntityTest fixture.

No integration test to make sure annotations are actually respected, not sure if this is needed, or how to implement?