### PR TITLE
Add test for setting an empty field's first item to null

### DIFF
--- a/tests/src/LinkItemTestBug3254966Test.php
+++ b/tests/src/LinkItemTestBug3254966Test.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests;
+
+use mglaman\PHPStanDrupal\Tests\Rules\DummyRule;
+
+class LinkItemTestBug3254966Test extends DrupalRuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new DummyRule();
+    }
+
+    public function testCrash(): void
+    {
+        $this->analyse(
+            [
+                __DIR__ . '/../fixtures/drupal/core/modules/link/tests/src/Kernel/LinkItemTest.php'
+            ],
+            []
+        );
+    }
+
+}


### PR DESCRIPTION
This verifies a Drupal core bug when processing LinkItemTest

Fixes #228﻿
