### PR TITLE
Add phpstan prophecy suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "suggest": {},
+    "suggest": {
+        "phpstan/phpstan-deprecation-rules": "For catching deprecations, especially in Drupal core.",
+        "jangregor/phpstan-prophecy": "Provides a prophecy/prophecy extension for phpstan/phpstan."
+    },
     "autoload": {
         "files": [
             "drupal-phpunit-hack.php"

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,10 @@
                 "extension.neon"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,7 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
-    "suggest": {
-        "phpstan/phpstan-deprecation-rules": "For catching deprecations, especially in Drupal core."
-    },
+    "suggest": {},
     "autoload": {
         "files": [
             "drupal-phpunit-hack.php"


### PR DESCRIPTION
Hi @mglaman

This PR fixes #263. It also removes `phpstan-deprecation-rule` from the list, as the package is part of the dev dependencies.

Hope this helps!