### PR TITLE
Fix/render callback

### DIFF
--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Constant\ConstantArrayTypeAndMethod;
 use PHPStan\Type\Constant\ConstantIntegerType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
 
 final class RenderCallbackRule implements Rule
@@ -59,7 +60,10 @@ final class RenderCallbackRule implements Rule
             return [];
         }
 
-        $trustedCallbackType = new ObjectType('Drupal\Core\Security\TrustedCallbackInterface');
+        $trustedCallbackType = new UnionType([
+            new ObjectType('Drupal\Core\Security\TrustedCallbackInterface'),
+            new ObjectType('Drupal\Core\Render\Element\RenderCallbackInterface'),
+        ]);
         $errors = [];
         foreach ($value->items as $pos => $item) {
             if (!$item instanceof Node\Expr\ArrayItem) {

--- a/tests/fixtures/drupal/modules/pre_render_callback_rule/src/RenderCallbackInterfaceObject.php
+++ b/tests/fixtures/drupal/modules/pre_render_callback_rule/src/RenderCallbackInterfaceObject.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\pre_render_callback_rule;
+
+use Drupal\Core\Render\Element\RenderCallbackInterface;
+use Drupal\Core\Url;
+
+final class RenderCallbackInterfaceObject implements RenderCallbackInterface {
+
+    public function staticCallback(): array {
+        return [
+            '#type' => 'link',
+            '#url' => Url::fromRoute('<front>'),
+            '#title' => 'FooBar',
+            '#pre_render' => [
+                [$this, 'preRenderCallback'],
+            ]
+        ];
+    }
+
+    public static function preRenderCallback(array $element) {
+        return $element;
+    }
+
+}

--- a/tests/src/Rules/PreRenderCallbackRuleTest.php
+++ b/tests/src/Rules/PreRenderCallbackRuleTest.php
@@ -66,6 +66,10 @@ final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
             []
         ];
         yield [
+            __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/RenderCallbackInterfaceObject.php',
+            []
+        ];
+        yield [
             __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/FormWithClosure.php',
             [
                 [


### PR DESCRIPTION
Objects that implement Drupal\Core\Render\Element\RenderCallbackInterface are allowed to use their methods as render callbacks.