### PR TITLE
Use a dependency that is already present and doesn't add new dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "nette/finder": "^2.5",
+        "symfony/finder": "~3.4.5|^4.2",
         "phpstan/phpstan": "^1.0",
         "symfony/yaml": "~3.4.5|^4.2",
         "webflo/drupal-finder": "^1.2"

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -4,8 +4,8 @@ namespace mglaman\PHPStanDrupal\Drupal;
 
 use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
 use DrupalFinder\DrupalFinder;
-use Nette\Utils\Finder;
 use PHPStan\DependencyInjection\Container;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
 
 class DrupalAutoloader
@@ -143,7 +143,7 @@ class DrupalAutoloader
                 }
                 $drushDir = dirname($reflect->getFileName(), $levels);
                 /** @var \SplFileInfo $file */
-                foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
+                foreach (Finder::create()->files()->name('*.inc')->in($drushDir . '/includes') as $file) {
                     require_once $file->getPathname();
                 }
             }
@@ -204,7 +204,7 @@ class DrupalAutoloader
     protected function loadLegacyIncludes(): void
     {
         /** @var \SplFileInfo $file */
-        foreach (Finder::findFiles('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
+        foreach (Finder::create()->files()->name('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
             require_once $file->getPathname();
         }
     }


### PR DESCRIPTION
There's no need to nette/finder - symfony has a finder that's already part of Drupal core and included by many many things...

```
composer/composer                2.2.4      requires   symfony/finder (^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0)
consolidation/annotated-command  4.5.1      requires   symfony/finder (^4.4.8|^5|^6)
consolidation/output-formatters  4.2.1      requires   symfony/finder (^4|^5|^6)
consolidation/robo               3.0.7      requires   symfony/finder (^4.4.9 || ^5 || ^6)
consolidation/site-alias         3.1.3      requires   symfony/finder (~2.3|^3|^4.4|^5)
drupal/core-dev                  9.3.2      requires   symfony/finder (^4.4)
drush/drush                      10.6.2     requires   symfony/finder (^3.4 || ^4.0 || ^5)
enlightn/security-checker        v1.9.0     requires   symfony/finder (^3|^4|^5)
symfony/dependency-injection     v4.4.34    conflicts  symfony/finder (<3.4)
```