### PR TITLE
Fix #lazy_builder callback analysis and static::class concatenation warning

### DIFF
--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ClosureType;
 use PHPStan\Type\Constant\ConstantArrayType;
@@ -15,6 +16,7 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\IntersectionType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
@@ -44,8 +46,9 @@ final class RenderCallbackRule implements Rule
         if (!$key instanceof Node\Scalar\String_) {
             return [];
         }
-        // @see https://www.drupal.org/node/2966725
 
+        // @todo this should be 3 rules.
+        // @see https://www.drupal.org/node/2966725
         $keysToCheck = ['#pre_render', '#post_render', '#access_callback', '#lazy_builder'];
         $keySearch = array_search($key->value, $keysToCheck, true);
         if ($keySearch === false) {
@@ -54,121 +57,132 @@ final class RenderCallbackRule implements Rule
         $keyChecked = $keysToCheck[$keySearch];
 
         $value = $node->value;
-        if (!$value instanceof Node\Expr\Array_) {
-            return [
-                RuleErrorBuilder::message(sprintf('The "%s" render array value expects an array of callbacks.', $keyChecked))
-                    ->line($node->getLine())->build()
-            ];
-        }
-        if (count($value->items) === 0) {
-            return [];
-        }
 
+        $errors = [];
+
+        if ($keyChecked === '#lazy_builder') {
+            if (!$value instanceof Node\Expr\Array_) {
+                return [
+                    RuleErrorBuilder::message(sprintf('The "%s" expects a callable array with arguments.', $keyChecked))
+                        ->line($node->getLine())->build()
+                ];
+            }
+            if (count($value->items) === 0) {
+                return [];
+            }
+            if ($value->items[0] === null) {
+                return [];
+            }
+            $errors[] = $this->doProcessNode($value->items[0]->value, $scope, $keyChecked, 0);
+        } elseif ($keyChecked === '#access_callback') {
+            $errors[] = $this->doProcessNode($value, $scope, $keyChecked, 0);
+        } else {
+            if (!$value instanceof Node\Expr\Array_) {
+                return [
+                    RuleErrorBuilder::message(sprintf('The "%s" render array value expects an array of callbacks.', $keyChecked))
+                        ->line($node->getLine())->build()
+                ];
+            }
+            if (count($value->items) === 0) {
+                return [];
+            }
+            foreach ($value->items as $pos => $item) {
+                if (!$item instanceof Node\Expr\ArrayItem) {
+                    continue;
+                }
+                $errors[] = $this->doProcessNode($item->value, $scope, $keyChecked, $pos);
+            }
+        }
+        return array_filter($errors);
+    }
+
+    private function doProcessNode(Node\Expr $node, Scope $scope, string $keyChecked, int $pos): ?RuleError
+    {
         $trustedCallbackType = new UnionType([
             new ObjectType('Drupal\Core\Security\TrustedCallbackInterface'),
             new ObjectType('Drupal\Core\Render\Element\RenderCallbackInterface'),
         ]);
-        $errors = [];
-        foreach ($value->items as $pos => $item) {
-            if (!$item instanceof Node\Expr\ArrayItem) {
-                continue;
-            }
-            // '#lazy_builder' has two items, callback and args. Others are direct callbacks.
-            // Lazy builder in Renderer: $elements['#lazy_builder'][0], $elements['#lazy_builder'][1]
-            if ($keyChecked === '#lazy_builder') {
-                if (!$item->value instanceof Node\Expr\Array_) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $scope->getType($item->value)->describe(VerbosityLevel::value()), $pos)
-                    )->line($item->value->getLine())->build();
-                    continue;
-                }
 
-                if (count($item->value->items) !== 2 || $item->value->items[0] === null) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback %s at key '%s' is not valid. First value must be a callback and second value its arguments.", $keyChecked, $scope->getType($item->value)->describe(VerbosityLevel::value()), $pos)
-                    )->line($item->value->getLine())->build();
-                    continue;
-                }
-                // Replace $item with our nested callback.
-                $item = $item->value->items[0];
-            }
-            $errorLine = $item->value->getLine();
-            $type = $this->getType($item->value, $scope);
+        $errorLine = $node->getLine();
+        $type = $this->getType($node, $scope);
 
-            if ($type instanceof ConstantStringType) {
-                if (!$type->isCallable()->yes()) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
-                    )->line($errorLine)->build();
-                    continue;
-                }
-                // We can determine if the callback is callable through the type system. However, we cannot determine
-                // if it is just a function or a static class call (MyClass::staticFunc).
-                if ($this->reflectionProvider->hasFunction(new \PhpParser\Node\Name($type->getValue()), null)) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback %s at key '%s' is not trusted.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
-                    )->line($errorLine)
-                        ->tip('Change record: https://www.drupal.org/node/2966725.')
-                        ->build();
-                }
-            } elseif ($type instanceof ConstantArrayType) {
-                if (!$type->isCallable()->yes()) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
-                    )->line($errorLine)->build();
-                    continue;
-                }
-                $typeAndMethodName = $type->findTypeAndMethodName();
-                if ($typeAndMethodName === null) {
-                    throw new \PHPStan\ShouldNotHappenException();
-                }
-
-                if (!$trustedCallbackType->isSuperTypeOf($typeAndMethodName->getType())->yes()) {
-                    $errors[] = RuleErrorBuilder::message(
-                        sprintf("%s callback class '%s' at key '%s' does not implement Drupal\Core\Security\TrustedCallbackInterface.", $keyChecked, $typeAndMethodName->getType()->describe(VerbosityLevel::value()), $pos)
-                    )->line($errorLine)->tip('Change record: https://www.drupal.org/node/2966725.')->build();
-                }
-            } elseif ($type instanceof ClosureType) {
-                if ($scope->isInClass()) {
-                    $classReflection = $scope->getClassReflection();
-                    if ($classReflection === null) {
-                        throw new \PHPStan\ShouldNotHappenException();
-                    }
-                    $classType = new ObjectType($classReflection->getName());
-                    $formType = new ObjectType('\Drupal\Core\Form\FormInterface');
-                    if ($formType->isSuperTypeOf($classType)->yes()) {
-                        $errors[] = RuleErrorBuilder::message(
-                            sprintf("%s may not contain a closure at key '%s' as forms may be serialized and serialization of closures is not allowed.", $keyChecked, $pos)
-                        )->line($errorLine)->build();
-                    }
-                }
-            } elseif ($type instanceof IntersectionType) {
-                // Try to provide a tip for this weird occurrence.
-                $tip = '';
-                if ($item->value instanceof Node\Expr\BinaryOp\Concat) {
-                    $leftStringType = $scope->getType($item->value->left)->toString();
-                    $rightStringType = $scope->getType($item->value->right)->toString();
-                    if ($leftStringType instanceof GenericClassStringType && $rightStringType instanceof ConstantStringType) {
-                        $methodName = str_replace(':', '', $rightStringType->getValue());
-                        $tip = "Refactor concatenation of `static::class` with method name to an array callback: [static::class, '$methodName']";
-                    }
-                }
-
-                if ($tip === '') {
-                    $tip = 'If this error is unexpected, open an issue with the error and sample code https://github.com/mglaman/phpstan-drupal/issues/new';
-                }
-
-                $errors[] = RuleErrorBuilder::message(
-                    sprintf("%s value '%s' at key '%s' is invalid.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
-                )->line($errorLine)->tip($tip)->build();
-            } else {
-                $errors[] = RuleErrorBuilder::message(
-                    sprintf("%s value '%s' at key '%s' is invalid.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+        if ($type instanceof ConstantStringType) {
+            if (!$type->isCallable()->yes()) {
+                return RuleErrorBuilder::message(
+                    sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
                 )->line($errorLine)->build();
             }
+            // We can determine if the callback is callable through the type system. However, we cannot determine
+            // if it is just a function or a static class call (MyClass::staticFunc).
+            if ($this->reflectionProvider->hasFunction(new \PhpParser\Node\Name($type->getValue()), null)) {
+                return RuleErrorBuilder::message(
+                    sprintf("%s callback %s at key '%s' is not trusted.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+                )->line($errorLine)
+                    ->tip('Change record: https://www.drupal.org/node/2966725.')
+                    ->build();
+            }
+        } elseif ($type instanceof ConstantArrayType) {
+            if (!$type->isCallable()->yes()) {
+                return RuleErrorBuilder::message(
+                    sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+                )->line($errorLine)->build();
+            }
+            $typeAndMethodName = $type->findTypeAndMethodName();
+            if ($typeAndMethodName === null) {
+                throw new \PHPStan\ShouldNotHappenException();
+            }
+
+            if (!$trustedCallbackType->isSuperTypeOf($typeAndMethodName->getType())->yes()) {
+                return RuleErrorBuilder::message(
+                    sprintf("%s callback class '%s' at key '%s' does not implement Drupal\Core\Security\TrustedCallbackInterface.", $keyChecked, $typeAndMethodName->getType()->describe(VerbosityLevel::value()), $pos)
+                )->line($errorLine)->tip('Change record: https://www.drupal.org/node/2966725.')->build();
+            }
+        } elseif ($type instanceof ClosureType) {
+            if ($scope->isInClass()) {
+                $classReflection = $scope->getClassReflection();
+                if ($classReflection === null) {
+                    throw new \PHPStan\ShouldNotHappenException();
+                }
+                $classType = new ObjectType($classReflection->getName());
+                $formType = new ObjectType('\Drupal\Core\Form\FormInterface');
+                if ($formType->isSuperTypeOf($classType)->yes()) {
+                    return RuleErrorBuilder::message(
+                        sprintf("%s may not contain a closure at key '%s' as forms may be serialized and serialization of closures is not allowed.", $keyChecked, $pos)
+                    )->line($errorLine)->build();
+                }
+            }
+        } elseif ($type instanceof ThisType) {
+            if (!$type->isCallable()->yes()) {
+                return RuleErrorBuilder::message(
+                    sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+                )->line($errorLine)->build();
+            }
+        } elseif ($type instanceof IntersectionType) {
+            // Try to provide a tip for this weird occurrence.
+            $tip = '';
+            if ($node instanceof Node\Expr\BinaryOp\Concat) {
+                $leftStringType = $scope->getType($node->left)->toString();
+                $rightStringType = $scope->getType($node->right)->toString();
+                if ($leftStringType instanceof GenericClassStringType && $rightStringType instanceof ConstantStringType) {
+                    $methodName = str_replace(':', '', $rightStringType->getValue());
+                    $tip = "Refactor concatenation of `static::class` with method name to an array callback: [static::class, '$methodName']";
+                }
+            }
+
+            if ($tip === '') {
+                $tip = 'If this error is unexpected, open an issue with the error and sample code https://github.com/mglaman/phpstan-drupal/issues/new';
+            }
+
+            return RuleErrorBuilder::message(
+                sprintf("%s value '%s' at key '%s' is invalid.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+            )->line($errorLine)->tip($tip)->build();
+        } else {
+            return RuleErrorBuilder::message(
+                sprintf("%s value '%s' at key '%s' is invalid.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
+            )->line($errorLine)->build();
         }
 
-        return $errors;
+        return null;
     }
 
     private function getType(Node\Expr $node, Scope $scope):  Type

--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -83,7 +83,7 @@ final class RenderCallbackRule implements Rule
                     continue;
                 }
 
-                if (count($item->value->items) !== 2) {
+                if (count($item->value->items) !== 2 || $item->value->items[0] === null) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf("%s callback %s at key '%s' is not valid. First value must be a callback and second value its arguments.", $keyChecked, $scope->getType($item->value)->describe(VerbosityLevel::value()), $pos)
                     )->line($item->value->getLine())->build();

--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -60,6 +60,7 @@ final class RenderCallbackRule implements Rule
 
         $errors = [];
 
+        // @todo Move into its own rule.
         if ($keyChecked === '#lazy_builder') {
             if (!$value instanceof Node\Expr\Array_) {
                 return [
@@ -73,10 +74,13 @@ final class RenderCallbackRule implements Rule
             if ($value->items[0] === null) {
                 return [];
             }
+            // @todo take $value->items[1] and validate parameters against the callback.
             $errors[] = $this->doProcessNode($value->items[0]->value, $scope, $keyChecked, 0);
         } elseif ($keyChecked === '#access_callback') {
+            // @todo move into its own rule.
             $errors[] = $this->doProcessNode($value, $scope, $keyChecked, 0);
         } else {
+            // @todo keep here.
             if (!$value instanceof Node\Expr\Array_) {
                 return [
                     RuleErrorBuilder::message(sprintf('The "%s" render array value expects an array of callbacks.', $keyChecked))
@@ -114,7 +118,7 @@ final class RenderCallbackRule implements Rule
             }
             // We can determine if the callback is callable through the type system. However, we cannot determine
             // if it is just a function or a static class call (MyClass::staticFunc).
-            if ($this->reflectionProvider->hasFunction(new \PhpParser\Node\Name($type->getValue()), null)) {
+            if ($this->reflectionProvider->hasFunction(new Node\Name($type->getValue()), null)) {
                 return RuleErrorBuilder::message(
                     sprintf("%s callback %s at key '%s' is not trusted.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
                 )->line($errorLine)
@@ -185,6 +189,7 @@ final class RenderCallbackRule implements Rule
         return null;
     }
 
+    // @todo move to a helper, as Drupal uses `service:method` references a lot.
     private function getType(Node\Expr $node, Scope $scope):  Type
     {
         $type = $scope->getType($node);

--- a/tests/fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php
+++ b/tests/fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\pre_render_callback_rule;
+
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\Url;
+
+class LazyBuilderWithConstant implements TrustedCallbackInterface {
+
+    public function staticCallback(): array {
+        return [
+            '#lazy_builder' => [
+                [[self::class, 'lazyBuilder'], ['baz', true]],
+                [[static::class, 'lazyBuilder'], ['mars', false]],
+                [[$this, 'lazyBuilder'], ['mars', false]],
+                [self::class . '::lazyBuilder', ['baz', true]],
+                [static::class . '::lazyBuilder', ['mars', false]],
+            ]
+        ];
+    }
+
+    public static function lazyBuilder(string $foo, bool $bar) {
+        return [
+            '#markup' => "$foo $bar",
+        ];
+    }
+
+    public static function trustedCallbacks()
+    {
+        return ['lazyBuilder'];
+    }
+}

--- a/tests/fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php
+++ b/tests/fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php
@@ -9,13 +9,21 @@ class LazyBuilderWithConstant implements TrustedCallbackInterface {
 
     public function staticCallback(): array {
         return [
-            '#lazy_builder' => [
-                [[self::class, 'lazyBuilder'], ['baz', true]],
-                [[static::class, 'lazyBuilder'], ['mars', false]],
-                [[$this, 'lazyBuilder'], ['mars', false]],
-                [self::class . '::lazyBuilder', ['baz', true]],
-                [static::class . '::lazyBuilder', ['mars', false]],
-            ]
+            'foo' => [
+                '#lazy_builder' => [[self::class, 'lazyBuilder'], ['baz', true]],
+            ],
+            'bar' => [
+                '#lazy_builder' => [[static::class, 'lazyBuilder'], ['mars', false]],
+            ],
+            'baz' => [
+                '#lazy_builder' => [[$this, 'lazyBuilder'], ['mars', false]],
+            ],
+            'abc' => [
+                '#lazy_builder' => [self::class . '::lazyBuilder', ['baz', true]],
+            ],
+            'def' => [
+                '#lazy_builder' => [static::class . '::lazyBuilder', ['mars', false]],
+            ],
         ];
     }
 

--- a/tests/fixtures/drupal/modules/pre_render_callback_rule/src/RenderArrayWithPreRenderCallback.php
+++ b/tests/fixtures/drupal/modules/pre_render_callback_rule/src/RenderArrayWithPreRenderCallback.php
@@ -5,7 +5,7 @@ namespace Drupal\pre_render_callback_rule;
 use Drupal\Core\Security\TrustedCallbackInterface;
 use Drupal\Core\Url;
 
-final class RenderArrayWithPreRenderCallback implements TrustedCallbackInterface {
+class RenderArrayWithPreRenderCallback implements TrustedCallbackInterface {
 
     public function staticCallback(): array {
         return [
@@ -14,6 +14,9 @@ final class RenderArrayWithPreRenderCallback implements TrustedCallbackInterface
             '#title' => 'FooBar',
             '#pre_render' => [
                 [self::class, 'preRenderCallback'],
+                [static::class, 'preRenderCallback'],
+                self::class . '::preRenderCallback',
+                static::class . '::preRenderCallback',
                 [$this, 'preRenderCallback'],
                 static function(array $element): array {
                     return $element;

--- a/tests/src/Rules/PreRenderCallbackRuleTest.php
+++ b/tests/src/Rules/PreRenderCallbackRuleTest.php
@@ -65,7 +65,13 @@ final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
         ];
         yield [
             __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/RenderArrayWithPreRenderCallback.php',
-            []
+            [
+                [
+                    "#pre_render value 'non-empty-string' at key '3' is invalid.",
+                    19,
+                    "Refactor concatenation of `static::class` with method name to an array callback: [static::class, 'preRenderCallback']"
+                ]
+            ]
         ];
         yield [
             __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/RenderCallbackInterfaceObject.php',

--- a/tests/src/Rules/PreRenderCallbackRuleTest.php
+++ b/tests/src/Rules/PreRenderCallbackRuleTest.php
@@ -78,6 +78,16 @@ final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
             []
         ];
         yield [
+            __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php',
+            [
+                [
+                    "#lazy_builder value 'non-empty-string' at key '4' is invalid.",
+                    17,
+                    "Refactor concatenation of `static::class` with method name to an array callback: [static::class, 'lazyBuilder']"
+                ]
+            ]
+        ];
+        yield [
             __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/FormWithClosure.php',
             [
                 [

--- a/tests/src/Rules/PreRenderCallbackRuleTest.php
+++ b/tests/src/Rules/PreRenderCallbackRuleTest.php
@@ -81,8 +81,8 @@ final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
             __DIR__ . '/../../fixtures/drupal/modules/pre_render_callback_rule/src/LazyBuilderWithConstant.php',
             [
                 [
-                    "#lazy_builder value 'non-empty-string' at key '4' is invalid.",
-                    17,
+                    "#lazy_builder value 'non-empty-string' at key '0' is invalid.",
+                    25,
                     "Refactor concatenation of `static::class` with method name to an array callback: [static::class, 'lazyBuilder']"
                 ]
             ]
@@ -95,6 +95,10 @@ final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
                     35
                 ]
             ]
+        ];
+        yield [
+            __DIR__ . '/../../fixtures/drupal/core/lib/Drupal/Core/Access/RouteProcessorCsrf.php',
+            []
         ];
     }
 


### PR DESCRIPTION
Fixes #301

- Handle concatenation of static::class with string as callback
- Properly handle lazy builder callbacks
