### PR TITLE
BrowserTestBaseDefaultThemeRule namespace check

### DIFF
--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -29,10 +29,6 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
         if ($node->namespacedName === null) {
             return [];
         }
-        $testNamespacePart = (string) $node->namespacedName->slice(1, 3);
-        if ($testNamespacePart !== 'Tests\\Functional' && $testNamespacePart !== 'Tests\\FunctionalJavascript') {
-            return [];
-        }
 
         // Only inspect tests.
         // @todo replace this str_ends_with() when php 8 is required.

--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -29,6 +29,10 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
         if ($node->namespacedName === null) {
             return [];
         }
+        $testNamespacePart = (string) $node->namespacedName->slice(1, 3);
+        if ($testNamespacePart !== 'Tests\\Functional' && $testNamespacePart !== 'Tests\\FunctionalJavascript') {
+            return [];
+        }
 
         $classType = $scope->resolveTypeByName($node->namespacedName);
         assert($classType instanceof ObjectType);


### PR DESCRIPTION
Uses a namespace check before performing reflections in BrowserTestBaseDefaultThemeRule. This seems to shave 3-5s off of the sample set of analyzing the `action` module.

Fixes #318