### PR TITLE
Optimize BrowserTestBaseDefaultThemeRule

### DIFF
--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -30,6 +30,28 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
             return [];
         }
 
+        // Only inspect tests.
+        // @todo replace this str_ends_with() when php 8 is required.
+        if (0 !== substr_compare($node->namespacedName->getLast(), 'Test', -4)) {
+            return [];
+        }
+
+        // Do some cheap preflight tests to make sure the class is in a
+        // namespace that makes sense to inspect.
+        $parts = $node->namespacedName->parts;
+        // The namespace is too short to be a test so skip inspection.
+        if (count($parts) < 3) {
+            return [];
+        }
+        // If the 4th component matches it's a module test. If the 2nd, core.
+        if ($parts[3] !== 'Functional'
+            && $parts [3] !== 'FunctionalJavascript'
+            && $parts[1] !== 'FunctionalTests'
+            && $parts[1] !== 'FunctionalJavascriptTests') {
+            return [];
+        }
+
+
         $classType = $scope->resolveTypeByName($node->namespacedName);
         assert($classType instanceof ObjectType);
 


### PR DESCRIPTION
Avoid inspecting classes we know aren't tests or Functional/Browser tests.

Fixes https://github.com/mglaman/phpstan-drupal/issues/318