### PR TITLE
Provide a stub for twig_escape_filter

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,8 @@ parameters:
 		- install
 		- profile
 		- engine
+	scanFiles:
+		- stubs/Twig/functions.stub
 	drupal:
 		drupal_root: '%currentWorkingDirectory%'
 		entityMapping:

--- a/stubs/Twig/functions.stub
+++ b/stubs/Twig/functions.stub
@@ -1,0 +1,16 @@
+<?php
+
+use Twig\Environment;
+
+/**
+ * Escapes a string.
+ *
+ * @param mixed  $string     The value to be escaped
+ * @param string $strategy   The escaping strategy
+ * @param string $charset    The charset
+ * @param bool   $autoescape Whether the function is called by the auto-escaping feature (true) or by the developer (false)
+ *
+ * @return string
+ */
+function twig_escape_filter(Environment $env, $string, $strategy = 'html', $charset = null, $autoescape = false) {
+}


### PR DESCRIPTION
twig_escape_filter is a hidden function inside a class file so not discovered
though normal discovery or autoloading so providing scan stub allows its use
to be analyzed.

Fixes #310