### PR TITLE
Mark \Drupal::VERSION as a dynamic constant

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,8 @@ parameters:
 		- install
 		- profile
 		- engine
+	dynamicConstantNames:
+		- Drupal::VERSION
 	scanFiles:
 		- stubs/Twig/functions.stub
 	stubFiles:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,5 @@ parameters:
 		- tests/src
 	excludePaths:
 		-  tests/src/Type/data/*.php
+	dynamicConstantNames:
+		- Drupal::VERSION

--- a/tests/src/Rules/GetDeprecatedServiceRuleTest.php
+++ b/tests/src/Rules/GetDeprecatedServiceRuleTest.php
@@ -20,7 +20,6 @@ final class GetDeprecatedServiceRuleTest extends DrupalRuleTestCase {
      */
     public function testRuleDrupal8(string $path, array $errorMessages): void
     {
-        // @phpstan-ignore-next-line
         if (version_compare('9.0.0', \Drupal::VERSION) !== 1) {
             self::markTestSkipped('Only tested on Drupal 8.x.x');
         }
@@ -34,7 +33,6 @@ final class GetDeprecatedServiceRuleTest extends DrupalRuleTestCase {
     public function testRuleDrupal9(string $path, array $errorMessages): void
     {
         [$version] = explode('.', \Drupal::VERSION, 2);
-        // @phpstan-ignore-next-line
         if ($version !== '9') {
             self::markTestSkipped('Only tested on Drupal 9.x.x');
         }


### PR DESCRIPTION
Fixes #325. The \Drupal::VERSION constant changes based on what is installed.
