### PR TITLE
Rule for ConditionManager::createInstance() when 'context' is passed as array key

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -371,3 +371,6 @@ services:
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
 		tags: [phpstan.rules.rule]
+	-
+		class: mglaman\PHPStanDrupal\Rules\Deprecations\ConditionManagerCreateInstanceContextConfigurationRule
+		tags: [phpstan.rules.rule]

--- a/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
+++ b/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Deprecations;
+
+use Drupal\Core\Condition\ConditionManager;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\ObjectType;
+
+final class ConditionManagerCreateInstanceContextConfigurationRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+        if ($node->name->toString() !== 'createInstance') {
+            return [];
+        }
+        $args = $node->getArgs();
+        if (count($args) !== 2) {
+            return [];
+        }
+        $conditionManagerType = new ObjectType(ConditionManager::class);
+        $type = $scope->getType($node->var);
+        if (!$conditionManagerType->isSuperTypeOf($type)->yes()) {
+            return [];
+        }
+        $configuration = $args[1];
+        $configurationType = $scope->getType($configuration->value);
+        // Must be an array, return [] and allow parameter inspection rule to report error.
+        if (!$configurationType instanceof ConstantArrayType) {
+            return [];
+        }
+
+        foreach ($configurationType->getKeyTypes() as $keyType) {
+            if ($keyType instanceof ConstantStringType && $keyType->getValue() === 'context') {
+                return [
+                    RuleErrorBuilder::message('Passing context values to plugins via configuration is deprecated in drupal:9.1.0 and will be removed before drupal:10.0.0. Instead, call ::setContextValue() on the plugin itself. See https://www.drupal.org/node/3120980')
+                        ->line($node->getLine())
+                        ->build()
+                ];
+            }
+        }
+
+        return [];
+    }
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module
@@ -48,3 +48,14 @@ function phpstan_fixtures_using_deprecated_constants(): void {
     print FILE_INSECURE_EXTENSION_REGEX;
     print PREG_CLASS_PUNCTUATION;
 }
+
+function phpstan_fixtures_condition_manager_context(): void {
+    $condition_manager = \Drupal::service('plugin.manager.condition');
+    $configuration = [
+        'foo' => 'bar',
+        'context' => [
+            'entity:type' => 'node',
+        ],
+    ];
+    $foo = $condition_manager->createInstance('barbaz', $configuration);
+}

--- a/tests/src/Rules/ConditionManagerCreateInstanceContextConfigurationRuleTest.php
+++ b/tests/src/Rules/ConditionManagerCreateInstanceContextConfigurationRuleTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Deprecations\ConditionManagerCreateInstanceContextConfigurationRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class ConditionManagerCreateInstanceContextConfigurationRuleTest extends DrupalRuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new ConditionManagerCreateInstanceContextConfigurationRule();
+    }
+
+    public function testRule(): void
+    {
+        [$version] = explode('.', \Drupal::VERSION, 2);
+        if ($version !== '9') {
+            self::markTestSkipped('Only tested on Drupal 9.x.x');
+        }
+        $this->analyse(
+            [__DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/phpstan_fixtures.module'],
+            [
+                [
+                    'Passing context values to plugins via configuration is deprecated in drupal:9.1.0 and will be removed before drupal:10.0.0. Instead, call ::setContextValue() on the plugin itself. See https://www.drupal.org/node/3120980',
+                    60,
+                ]
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Fixes #337
