### PR TITLE
Add field type stubs for file module

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -44,6 +44,8 @@ parameters:
 		- stubs/Drupal/Core/TypedData/TypedData.stub
 		- stubs/Drupal/Core/TypedData/TypedDataInterface.stub
 		- stubs/Drupal/Core/TypedData/Plugin/DataType/Map.stub
+		- stubs/Drupal/file/Plugin/Field/FieldType/FileItem.stub
+		- stubs/Drupal/file/Plugin/Field/FieldType/FileUriItem.stub
 		- stubs/Drupal/link/LinkItemInterface.stub
 		- stubs/Drupal/link/Plugin/Field/FieldType/LinkItem.stub
 	drupal:

--- a/stubs/Drupal/file/Plugin/Field/FieldType/FileItem.stub
+++ b/stubs/Drupal/file/Plugin/Field/FieldType/FileItem.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\file\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+
+/**
+ * @property bool $display
+ * @property string $description
+ */
+class FileItem extends EntityReferenceItem {
+
+}

--- a/stubs/Drupal/file/Plugin/Field/FieldType/FileUriItem.stub
+++ b/stubs/Drupal/file/Plugin/Field/FieldType/FileUriItem.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\file\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\Plugin\Field\FieldType\UriItem;
+
+/**
+ * @property string $url
+ */
+class FileUriItem extends UriItem {
+
+}

--- a/tests/src/Type/data/field-types.php
+++ b/tests/src/Type/data/field-types.php
@@ -18,6 +18,8 @@ use Drupal\Core\Field\Plugin\Field\FieldType\StringLongItem;
 use Drupal\Core\Field\Plugin\Field\FieldType\TimestampItem;
 use Drupal\Core\Field\Plugin\Field\FieldType\UriItem;
 use Drupal\Core\Field\Plugin\Field\FieldType\UuidItem;
+use Drupal\file\Plugin\Field\FieldType\FileItem;
+use Drupal\file\Plugin\Field\FieldType\FileUriItem;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
 use Drupal\node\Entity\Node;
 use function PHPStan\Testing\assertType;
@@ -131,3 +133,16 @@ $uuid_field = $node->get('field_uuid')->first();
 assert($uuid_field instanceof UuidItem);
 assertType(UuidItem::class, $uuid_field);
 assertType('string', $uuid_field->value);
+
+// FileItem.
+$file_field = $node->get('field_file')->first();
+assert($file_field instanceof FileItem);
+assertType(FileItem::class, $file_field);
+assertType('bool', $file_field->display);
+assertType('string', $file_field->description);
+
+// FileUriItem.
+$file_uri_field = $node->get('field_file')->first();
+assert($file_uri_field instanceof FileUriItem);
+assertType(FileUriItem::class, $file_uri_field);
+assertType('string', $file_uri_field->url);


### PR DESCRIPTION
As the title says, adds stubs for field types defined by the core file module.