### PR TITLE
The entity property can return NULL

### DIFF
--- a/stubs/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.stub
+++ b/stubs/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.stub
@@ -8,7 +8,7 @@ use Drupal\Core\TypedData\OptionsProviderInterface;
 
 /**
  * @property string|integer $target_id
- * @property \Drupal\Core\Entity\EntityInterface $entity
+ * @property \Drupal\Core\Entity\EntityInterface|null $entity
  */
 class EntityReferenceItem extends FieldItemBase implements OptionsProviderInterface, PreconfiguredFieldUiOptionsInterface {
 }

--- a/tests/src/Type/data/field-types.php
+++ b/tests/src/Type/data/field-types.php
@@ -69,7 +69,7 @@ $entity_reference_field = $node->get('field_entity_reference')->first();
 assert($entity_reference_field instanceof EntityReferenceItem);
 assertType(EntityReferenceItem::class, $entity_reference_field);
 assertType('int|string', $entity_reference_field->target_id);
-assertType('Drupal\Core\Entity\EntityInterface', $entity_reference_field->entity);
+assertType('Drupal\Core\Entity\EntityInterface|null', $entity_reference_field->entity);
 
 // FloatItem.
 $float_field = $node->get('field_float')->first();


### PR DESCRIPTION
If you delete the entity that is referenced by an ER field, the entity property will return NULL

Code needs to be aware of that and handle it.

Without this change, code that is being defensive for when entity is NULL shows linting errors on phpstan level 6