### PR TITLE
resolveFromStorage does not respect default phpDoc for generic storage interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
     "autoload-dev": {
         "psr-4": {
             "mglaman\\PHPStanDrupal\\Tests\\": "tests/src/"
-        }
+        },
+        "classmap": [
+            "tests/src/Type/data"
+        ]
     },
     "extra": {
         "branch-alias": {

--- a/src/Drupal/EntityDataRepository.php
+++ b/src/Drupal/EntityDataRepository.php
@@ -2,6 +2,9 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
 use PHPStan\Type\ObjectType;
 
 final class EntityDataRepository
@@ -34,6 +37,15 @@ final class EntityDataRepository
 
     public function resolveFromStorage(ObjectType $callerType): ?EntityData
     {
+        if ($callerType->equals(new ObjectType(EntityStorageInterface::class))) {
+            return null;
+        }
+        if ($callerType->equals(new ObjectType(ConfigEntityStorageInterface::class))) {
+            return null;
+        }
+        if ($callerType->equals(new ObjectType(ContentEntityStorageInterface::class))) {
+            return null;
+        }
         foreach ($this->entityData as $entityData) {
             $storageType = $entityData->getStorageType();
             if ($storageType !== null && $callerType->isSuperTypeOf($storageType)->yes()) {

--- a/tests/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtensionTest.php
+++ b/tests/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtensionTest.php
@@ -21,6 +21,7 @@ final class EntityTypeManagerGetStorageDynamicReturnTypeExtensionTest extends Ty
     public function dataFileAsserts(): iterable
     {
         yield from $this->gatherAssertTypes(__DIR__ . '/data/entity-type-manager.php');
+        yield from $this->gatherAssertTypes(__DIR__ . '/data/bug-377.php');
     }
 
     /**

--- a/tests/src/Type/data/bug-377.php
+++ b/tests/src/Type/data/bug-377.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace bug377;
+
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use function PHPStan\Testing\assertType;
+
+class Foo {
+    private EntityTypeManagerInterface $entityTypeManager;
+    private EntityStorageInterface $myEntityStorage;
+
+    public function __construct(EntityTypeManagerInterface $entityTypeManager)
+    {
+        $this->entityTypeManager = $entityTypeManager;
+        $this->myEntityStorage = $entityTypeManager->getStorage('node');
+    }
+
+    public function storageType() {
+        // @todo property typing overrides our internal typing to determine entity storage type.
+        assertType('Drupal\Core\Entity\EntityStorageInterface', $this->myEntityStorage);
+        assertType('Drupal\node\NodeStorage', $this->entityTypeManager->getStorage('node'));
+    }
+
+    public function entityType() {
+        $entity = $this->myEntityStorage->load('123');
+        assertType('Drupal\Core\Entity\EntityInterface|null', $entity);
+    }
+
+}

--- a/tests/src/Type/data/bug-377.php
+++ b/tests/src/Type/data/bug-377.php
@@ -2,29 +2,49 @@
 
 namespace bug377;
 
+use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeStorageInterface;
 use function PHPStan\Testing\assertType;
 
 class Foo {
     private EntityTypeManagerInterface $entityTypeManager;
     private EntityStorageInterface $myEntityStorage;
+    private ConfigEntityStorageInterface $configEntityStorage;
+    private ContentEntityStorageInterface $contentEntityStorage;
+    private NodeStorageInterface $nodeStorage;
 
     public function __construct(EntityTypeManagerInterface $entityTypeManager)
     {
         $this->entityTypeManager = $entityTypeManager;
         $this->myEntityStorage = $entityTypeManager->getStorage('node');
+        $this->configEntityStorage = $entityTypeManager->getStorage('block');
+        $this->contentEntityStorage = $entityTypeManager->getStorage('node');
+        $this->nodeStorage = $entityTypeManager->getStorage('node');
     }
 
     public function storageType() {
         // @todo property typing overrides our internal typing to determine entity storage type.
-        assertType('Drupal\Core\Entity\EntityStorageInterface', $this->myEntityStorage);
+        assertType(EntityStorageInterface::class, $this->myEntityStorage);
         assertType('Drupal\node\NodeStorage', $this->entityTypeManager->getStorage('node'));
+        assertType(ConfigEntityStorageInterface::class, $this->configEntityStorage);
+        assertType(ContentEntityStorageInterface::class, $this->contentEntityStorage);
+        assertType(NodeStorageInterface::class, $this->nodeStorage);
     }
 
     public function entityType() {
         $entity = $this->myEntityStorage->load('123');
         assertType('Drupal\Core\Entity\EntityInterface|null', $entity);
+        $entity = $this->configEntityStorage->load('123');
+        // @todo this can safely say it is ConfigEntityInterface as return type.
+        assertType('Drupal\Core\Entity\EntityInterface|null', $entity);
+        $entity = $this->contentEntityStorage->load('123');
+        // @todo this can safely say it is ConfigEntityInterface as return type.
+        assertType('Drupal\Core\Entity\EntityInterface|null', $entity);
+        $entity = $this->nodeStorage->load('123');
+        assertType('Drupal\node\Entity\Node|null', $entity);
     }
 
 }

--- a/tests/src/Type/data/container.php
+++ b/tests/src/Type/data/container.php
@@ -8,12 +8,14 @@ use Drupal\service_map\MyService;
 use Drupal\service_map\Override;
 use function PHPStan\Testing\assertType;
 
-$container = \Drupal::getContainer();
+function test(): void {
+    $container = \Drupal::getContainer();
 
-assertType(MyService::class, $container->get('service_map.my_service'));
-assertType('true', $container->has('service_map.my_service'));
-assertType('false', $container->has('unknown_service'));
-assertType(MyService::class, $container->get('service_map.concrete_service'));
-assertType(MyService::class, $container->get('service_map.concrete_service_with_a_parent_which_has_a_parent'));
-assertType(Override::class, $container->get('service_map.concrete_service_overriding_definition_of_its_parent'));
-assertType(Concrete::class, $container->get('service_map.concrete_overriding_its_parent_which_has_a_parent'));
+    assertType(MyService::class, $container->get('service_map.my_service'));
+    assertType('true', $container->has('service_map.my_service'));
+    assertType('false', $container->has('unknown_service'));
+    assertType(MyService::class, $container->get('service_map.concrete_service'));
+    assertType(MyService::class, $container->get('service_map.concrete_service_with_a_parent_which_has_a_parent'));
+    assertType(Override::class, $container->get('service_map.concrete_service_overriding_definition_of_its_parent'));
+    assertType(Concrete::class, $container->get('service_map.concrete_overriding_its_parent_which_has_a_parent'));
+}

--- a/tests/src/Type/data/drupal-class-resolver.php
+++ b/tests/src/Type/data/drupal-class-resolver.php
@@ -8,11 +8,13 @@ use function PHPStan\Testing\assertType;
 
 class Foo {}
 
-assertType(Foo::class, (new ClassResolver())->getInstanceFromDefinition(Foo::class));
-assertType(Foo::class, \Drupal::service('class_resolver')->getInstanceFromDefinition(Foo::class));
-assertType(Foo::class, \Drupal::classResolver()->getInstanceFromDefinition(Foo::class));
-assertType(Foo::class, \Drupal::classResolver(Foo::class));
-assertType(MyService::class, (new ClassResolver())->getInstanceFromDefinition('service_map.my_service'));
-assertType(MyService::class, \Drupal::service('class_resolver')->getInstanceFromDefinition('service_map.my_service'));
-assertType(MyService::class, \Drupal::classResolver()->getInstanceFromDefinition('service_map.my_service'));
-assertType(MyService::class, \Drupal::classResolver('service_map.my_service'));
+function test(): void {
+    assertType(Foo::class, (new ClassResolver())->getInstanceFromDefinition(Foo::class));
+    assertType(Foo::class, \Drupal::service('class_resolver')->getInstanceFromDefinition(Foo::class));
+    assertType(Foo::class, \Drupal::classResolver()->getInstanceFromDefinition(Foo::class));
+    assertType(Foo::class, \Drupal::classResolver(Foo::class));
+    assertType(MyService::class, (new ClassResolver())->getInstanceFromDefinition('service_map.my_service'));
+    assertType(MyService::class, \Drupal::service('class_resolver')->getInstanceFromDefinition('service_map.my_service'));
+    assertType(MyService::class, \Drupal::classResolver()->getInstanceFromDefinition('service_map.my_service'));
+    assertType(MyService::class, \Drupal::classResolver('service_map.my_service'));
+}

--- a/tests/src/Type/data/drupal-service-static.php
+++ b/tests/src/Type/data/drupal-service-static.php
@@ -5,4 +5,6 @@ namespace DrupalServiceStatic;
 use Drupal\service_map\MyService;
 use function PHPStan\Testing\assertType;
 
-assertType(MyService::class, \Drupal::service('service_map.my_service'));
+function test(): void {
+    assertType(MyService::class, \Drupal::service('service_map.my_service'));
+}

--- a/tests/src/Type/data/entity-type-manager.php
+++ b/tests/src/Type/data/entity-type-manager.php
@@ -3,7 +3,6 @@
 namespace EntityTypeManagerGetStorage;
 
 use function PHPStan\Testing\assertType;
-use function PHPUnit\Framework\assertInstanceOf;
 
 $etm = \Drupal::entityTypeManager();
 


### PR DESCRIPTION
Fixes #377

\mglaman\PHPStanDrupal\Drupal\EntityDataRepository::resolveFromStorage does not work correctly for generic storage types. If the entity storage if EntityStorageInterface then the first entity definition is selected.