### PR TITLE
Move rules to `rules.neon`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,23 @@ Extension for [PHPStan](https://phpstan.org/) to allow analysis of Drupal code.
 
 When you are using [`phpstan/extension-installer`](https://github.com/phpstan/extension-installer), `phpstan.neon` will be automatically included.
 
-Otherwise add `phpstan.neon` to your Drupal project.
+<details>
+  <summary>Manual installation</summary>
 
-Make sure it has
+If you don't want to use `phpstan/extension-installer`, include `extension.neon` in your project's PHPStan config:
 
-```neon
+```
 includes:
-	- vendor/mglaman/phpstan-drupal/extension.neon
+    - vendor/mglaman/phpstan-drupal/extension.neon
 ```
 
-## Enabling rules one-by-one
-
-If you don't want to start using all the available strict rules at once but only one or two, you can! Just don't include
-the whole `rules.neon` from this package in your configuration, but look at its contents and copy only the rules you
-want to your configuration under the `services` key:
+To include Drupal specific analysis rules, include this file:
 
 ```
-services:
-	-
-		class: PHPStan\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
-		tags:
-			- phpstan.rules.rule
+includes:
+    - vendor/mglaman/phpstan-drupal/rules.neon
 ```
+</details>
 
 ## Excluding tests from analysis
 

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         },
         "phpstan": {
             "includes": [
-                "extension.neon"
+                "extension.neon",
+                "rules.neon"
             ]
         }
     },

--- a/extension.neon
+++ b/extension.neon
@@ -243,23 +243,6 @@ parametersSchema:
 			])
 		))
 	])
-rules:
-	- mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\AccessDeprecatedConstant
-	- mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule
-	- mglaman\PHPStanDrupal\Rules\Classes\PluginManagerInspectionRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\ConditionManagerCreateInstanceContextConfigurationRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\StaticServiceDeprecatedServiceRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\GetDeprecatedServiceRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\Tests\BrowserTestBaseDefaultThemeRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\ConfigEntityConfigExportRule
-	- mglaman\PHPStanDrupal\Rules\Deprecations\PluginAnnotationContextDefinitionsRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\ModuleLoadInclude
-	- mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes
-	- mglaman\PHPStanDrupal\Rules\Drupal\EntityQuery\EntityQueryHasAccessCheckRule
 services:
 	-
 		class: mglaman\PHPStanDrupal\Drupal\ServiceMap

--- a/rules.neon
+++ b/rules.neon
@@ -1,0 +1,17 @@
+rules:
+	- mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\AccessDeprecatedConstant
+	- mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule
+	- mglaman\PHPStanDrupal\Rules\Classes\PluginManagerInspectionRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\ConditionManagerCreateInstanceContextConfigurationRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\StaticServiceDeprecatedServiceRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\GetDeprecatedServiceRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\Tests\BrowserTestBaseDefaultThemeRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\ConfigEntityConfigExportRule
+	- mglaman\PHPStanDrupal\Rules\Deprecations\PluginAnnotationContextDefinitionsRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\ModuleLoadInclude
+	- mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes
+	- mglaman\PHPStanDrupal\Rules\Drupal\EntityQuery\EntityQueryHasAccessCheckRule

--- a/tests/fixtures/config/phpunit-drupal-phpstan.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan.neon
@@ -15,4 +15,5 @@ parameters:
 				class: Drupal\phpstan_fixtures\Entity\ContentEntityUsingDefaultStorage
 includes:
 	- ../../../extension.neon
+	- ../../../rules.neon
 	- ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION
Fixes #295

Allows manual configuration without extension-installer and cherry-picking rules.