### PR TITLE
Enable richParserNodeVisitor for tests

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -74,7 +74,7 @@ jobs:
       - name: "Install dependencies"
         run: "composer update --no-progress --prefer-dist"
       - name: "PHPUnit"
-        run: "php vendor/bin/phpunit --debug"
+        run: "php vendor/bin/phpunit"
 
   build_integration:
     needs:

--- a/tests/fixtures/config/phpunit-drupal-phpstan.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan.neon
@@ -17,3 +17,7 @@ includes:
 	- ../../../extension.neon
 	- ../../../rules.neon
 	- ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+# @todo remove after https://github.com/mglaman/phpstan-drupal/issues/399.
+conditionalTags:
+	PhpParser\NodeVisitor\NodeConnectingVisitor:
+		phpstan.parser.richParserNodeVisitor: true


### PR DESCRIPTION
Fixes HEAD for PHPStan 1.6.0+ on tests which use bleedingEdge until #399 is finished.
