### PR TITLE
Explicit allowed class checks for #lazy_builder

### DIFF
--- a/tests/fixtures/config/phpunit-drupal-phpstan.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan.neon
@@ -17,7 +17,3 @@ includes:
 	- ../../../extension.neon
 	- ../../../rules.neon
 	- ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
-# @todo remove after https://github.com/mglaman/phpstan-drupal/issues/399.
-conditionalTags:
-	PhpParser\NodeVisitor\NodeConnectingVisitor:
-		phpstan.parser.richParserNodeVisitor: true

--- a/tests/src/Rules/RenderCallbackRuleTest.php
+++ b/tests/src/Rules/RenderCallbackRuleTest.php
@@ -7,7 +7,7 @@ use mglaman\PHPStanDrupal\Drupal\ServiceMap;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
 use mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule;
 
-final class PreRenderCallbackRuleTest extends DrupalRuleTestCase {
+final class RenderCallbackRuleTest extends DrupalRuleTestCase {
 
     protected function getRule(): \PHPStan\Rules\Rule
     {


### PR DESCRIPTION
Fixes #399 by removing calls to `parent` attributes.
