### PR TITLE
add support for class string service ids

### DIFF
--- a/tests/fixtures/drupal/modules/service_map/service_map.services.yml
+++ b/tests/fixtures/drupal/modules/service_map/service_map.services.yml
@@ -1,6 +1,8 @@
 services:
   service_map.my_service:
     class: Drupal\service_map\MyService
+  Drupal\service_map\MyService:
+    class: Drupal\service_map\MyService
   GuzzleHttp\Client: '@http_client'
   Drupal\Core\Config\ConfigFactoryInterface: '@config.factory'
   Drupal\Core\Messenger\MessengerInterface: '@messenger'

--- a/tests/src/Type/data/container.php
+++ b/tests/src/Type/data/container.php
@@ -18,4 +18,5 @@ function test(): void {
     assertType(MyService::class, $container->get('service_map.concrete_service_with_a_parent_which_has_a_parent'));
     assertType(Override::class, $container->get('service_map.concrete_service_overriding_definition_of_its_parent'));
     assertType(Concrete::class, $container->get('service_map.concrete_overriding_its_parent_which_has_a_parent'));
+    assertType(MyService::class, $container->get(MyService::class));
 }

--- a/tests/src/Type/data/drupal-class-resolver.php
+++ b/tests/src/Type/data/drupal-class-resolver.php
@@ -17,4 +17,9 @@ function test(): void {
     assertType(MyService::class, \Drupal::service('class_resolver')->getInstanceFromDefinition('service_map.my_service'));
     assertType(MyService::class, \Drupal::classResolver()->getInstanceFromDefinition('service_map.my_service'));
     assertType(MyService::class, \Drupal::classResolver('service_map.my_service'));
+
+    assertType(MyService::class, (new ClassResolver())->getInstanceFromDefinition(MyService::class));
+    assertType(MyService::class, \Drupal::service('class_resolver')->getInstanceFromDefinition(MyService::class));
+    assertType(MyService::class, \Drupal::classResolver()->getInstanceFromDefinition(MyService::class));
+    assertType(MyService::class, \Drupal::classResolver(MyService::class));
 }

--- a/tests/src/Type/data/drupal-service-static.php
+++ b/tests/src/Type/data/drupal-service-static.php
@@ -7,4 +7,5 @@ use function PHPStan\Testing\assertType;
 
 function test(): void {
     assertType(MyService::class, \Drupal::service('service_map.my_service'));
+    assertType(MyService::class, \Drupal::service(MyService::class));
 }


### PR DESCRIPTION
According to [this docs page](https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/services-and-dependency-injection-in-drupal-8#s-defining-services-by-fully-qualified-name-of-php-namespace) using the fully qualified class name when interacting with services is a supported approach.

This PR adds the correct return type hint when this approach is used.