### PR TITLE
Add generic callable check for RenderCallbackRule

### DIFF
--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -192,6 +192,9 @@ final class RenderCallbackRule implements Rule
                     sprintf("%s callback %s at key '%s' is not callable.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)
                 )->line($errorLine)->build();
             }
+        } elseif ($type->isCallable()->yes()) {
+            // If the value has been marked as callable or callable-string, we cannot resolve the callable, trust it.
+            return null;
         } else {
             return RuleErrorBuilder::message(
                 sprintf("%s value '%s' at key '%s' is invalid.", $keyChecked, $type->describe(VerbosityLevel::value()), $pos)

--- a/stubs/Drupal/Core/Cache/CacheableDependencyInterface.stub
+++ b/stubs/Drupal/Core/Cache/CacheableDependencyInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Cache;
+
+interface CacheableDependencyInterface {
+
+}

--- a/stubs/Drupal/Core/Cache/CacheableMetadata.stub
+++ b/stubs/Drupal/Core/Cache/CacheableMetadata.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Cache;
+
+class CacheableMetadata implements RefinableCacheableDependencyInterface {
+
+}

--- a/stubs/Drupal/Core/Cache/RefinableCacheableDependencyInterface.stub
+++ b/stubs/Drupal/Core/Cache/RefinableCacheableDependencyInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Cache;
+
+interface RefinableCacheableDependencyInterface extends CacheableDependencyInterface {
+
+}

--- a/stubs/Drupal/Core/Render/AttachmentsInterface.stub
+++ b/stubs/Drupal/Core/Render/AttachmentsInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Render;
+
+interface AttachmentsInterface {
+
+}

--- a/stubs/Drupal/Core/Render/BubbleableMetadata.stub
+++ b/stubs/Drupal/Core/Render/BubbleableMetadata.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Core\Render;
+
+use Drupal\Core\Cache\CacheableMetadata;
+
+class BubbleableMetadata extends CacheableMetadata implements AttachmentsInterface {
+
+}

--- a/stubs/Drupal/filter/FilterProcessResult.stub
+++ b/stubs/Drupal/filter/FilterProcessResult.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\filter;
+
+use Drupal\Core\Render\BubbleableMetadata;
+
+class FilterProcessResult extends BubbleableMetadata {
+
+    /**
+     * @param callable-string $callback
+     * @param array<int|string, mixed> $args
+     */
+    public function createPlaceholder($callback, array $args): string {
+
+    }
+}

--- a/tests/src/Rules/RenderCallbackRuleTest.php
+++ b/tests/src/Rules/RenderCallbackRuleTest.php
@@ -111,6 +111,10 @@ final class RenderCallbackRuleTest extends DrupalRuleTestCase {
                 ]
             ]
         ];
+        yield [
+            __DIR__ . '/../../fixtures/drupal/core/modules/filter/src/FilterProcessResult.php',
+            []
+        ];
     }
 
 


### PR DESCRIPTION
Fixes #449. 

If the node is callable or callable-string, trust it. Fixes analysis on FilterProcessResult.
