### PR TITLE
fix: Fix unpredictable false positive/negative of missing entity access check in function scope due to cache key conflict

### DIFF
--- a/src/Type/EntityQuery/EntityQueryType.php
+++ b/src/Type/EntityQuery/EntityQueryType.php
@@ -17,14 +17,17 @@ class EntityQueryType extends ObjectType
 
     public function withAccessCheck(): self
     {
-        $type = clone $this;
+        $type = new self(
+            $this->getClassName(),
+            $this->getSubtractedType(),
+            $this->getClassReflection()
+        );
         $type->hasAccessCheck = true;
-
         return $type;
     }
 
     protected function describeAdditionalCacheKey(): string
     {
-        return $this->hasAccessCheck ? 'with-access-check' : '';
+        return $this->hasAccessCheck ? 'with-access-check' : 'without-access-check';
     }
 }

--- a/src/Type/EntityQuery/EntityQueryType.php
+++ b/src/Type/EntityQuery/EntityQueryType.php
@@ -17,7 +17,10 @@ class EntityQueryType extends ObjectType
 
     public function withAccessCheck(): self
     {
-        $type = new self(
+        // The constructor of ObjectType is under backward compatibility promise.
+        // @see https://phpstan.org/developing-extensions/backward-compatibility-promise
+        // @phpstan-ignore-next-line
+        $type = new static(
             $this->getClassName(),
             $this->getSubtractedType(),
             $this->getClassReflection()

--- a/src/Type/EntityQuery/EntityQueryType.php
+++ b/src/Type/EntityQuery/EntityQueryType.php
@@ -22,4 +22,9 @@ class EntityQueryType extends ObjectType
 
         return $type;
     }
+
+    protected function describeAdditionalCacheKey(): string
+    {
+        return $this->hasAccessCheck ? 'with-access-check' : '';
+    }
 }

--- a/tests/src/Rules/EntityQueryHasAccessCheckRuleTest.php
+++ b/tests/src/Rules/EntityQueryHasAccessCheckRuleTest.php
@@ -86,5 +86,15 @@ final class EntityQueryHasAccessCheckRuleTest extends DrupalRuleTestCase
             [__DIR__ . '/data/bug-437.php'],
             []
         ];*/
+
+        yield 'bug-475.php' => [
+            [__DIR__.'/data/bug-475.php'],
+            []
+        ];
+
+        yield 'bug-475b.php' => [
+            [__DIR__.'/data/bug-475b.php'],
+            []
+        ];
     }
 }

--- a/tests/src/Rules/data/bug-475.php
+++ b/tests/src/Rules/data/bug-475.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Cache key differs outside of class so this is separate reproduction
+ *
+ * @return void
+ */
+function bug475Caching(): void
+{
+    // Here condition() return type will be cached as one that has no access check
+    \Drupal::entityQuery('node')
+        ->condition('field_test', 'foo', '=')
+        ->accessCheck(FALSE)
+        ->execute();
+
+    // Cache return on condition() will also be no access check, even though caller did, unless caller type changes cache key
+    \Drupal::entityQuery('node')
+        ->accessCheck(FALSE)
+        ->condition('field_test', 'foo', '=')
+        ->execute();
+}

--- a/tests/src/Rules/data/bug-475b.php
+++ b/tests/src/Rules/data/bug-475b.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bug475CacheKeyExample;
+
+/**
+ * Cache key differs if in class so this tests that too
+ *
+ * @return void
+ */
+class TestClass
+{
+    public function bug475Caching(): void
+    {
+        // Here condition() return type will be cached as one that has no access check
+        \Drupal::entityQuery('node')
+            ->condition('field_test', 'foo', '=')
+            ->accessCheck(FALSE)
+            ->execute();
+
+        // Cache return on condition() will also be no access check, even though caller did, unless caller type changes cache key
+        \Drupal::entityQuery('node')
+            ->accessCheck(FALSE)
+            ->condition('field_test', 'foo', '=')
+            ->execute();
+    }
+}


### PR DESCRIPTION
Fixes #475

The EntityQueryType was getting cached in function scope for a `condition` call and because it wasn't handled by dynamic return it reused. So if you had `condition` before `accessCheck` and then later on after it, the latter one could fail because it would return the cached without access check and there would be no subsequent access check (it happens before).

Added test case.

Still examining why this doesn't occur in class scope but it seems phpstan has additional cache key when it is just not sure of its granularity.