### PR TITLE
Allow EntityReferenceFieldItemListInterface::referencedEntities to work with generic

### DIFF
--- a/stubs/Drupal/Core/Field/EntityReferenceFieldItemListInterface.stub
+++ b/stubs/Drupal/Core/Field/EntityReferenceFieldItemListInterface.stub
@@ -13,4 +13,9 @@ use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
  */
 interface EntityReferenceFieldItemListInterface extends FieldItemListInterface {
 
+  /**
+   * @return array<int, T>
+   */
+  public function referencedEntities();
+
 }

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Entity/ReflectionEntityTest.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Entity/ReflectionEntityTest.php
@@ -9,6 +9,7 @@ use Drupal\user\UserInterface;
 
 /**
  * @property \Drupal\Core\Field\EntityReferenceFieldItemListInterface $user_id
+ * @property \Drupal\Core\Field\EntityReferenceFieldItemListInterface<\Drupal\entity_test\Entity\EntityTest> $related
  */
 final class ReflectionEntityTest extends ContentEntityBase {
 
@@ -34,6 +35,14 @@ final class ReflectionEntityTest extends ContentEntityBase {
                     'placeholder' => '',
                 ],
             ]);
+
+        $fields['related'] = BaseFieldDefinition::create('entity_reference')
+            ->setLabel(t('Related entities'))
+            ->setDescription(t('The IDs of the related entities.'))
+            ->setSetting('target_type', 'entity_test')
+            ->setSetting('handler', 'default')
+            ->setTranslatable(TRUE)
+            ->setDisplayConfigurable('form', FALSE);
         return $fields;
     }
 

--- a/tests/src/Type/data/entity-properties.php
+++ b/tests/src/Type/data/entity-properties.php
@@ -11,3 +11,6 @@ assertType('Drupal\Core\Field\FieldItemListInterface', $node->uid);
 
 $entity = ReflectionEntityTest::create();
 assertType('Drupal\Core\Field\EntityReferenceFieldItemListInterface', $entity->user_id);
+assertType('Drupal\Core\Field\EntityReferenceFieldItemListInterface<Drupal\entity_test\Entity\EntityTest>', $entity->related);
+// Value of array is derived from 'related' generic.
+assertType('array<int, Drupal\entity_test\Entity\EntityTest>', $entity->related->referencedEntities());


### PR DESCRIPTION
Allow `\Drupal\Core\Field\EntityReferenceFieldItemListInterface::referencedEntities` to work with generic.

E.g practical usage with entity bundle classes:

```php
/**
 * @property  \Drupal\Core\Field\EntityReferenceFieldItemListInterface<Drupal\mycontent\Entity\BlockContent\MyBlockContent> $things
 */
class Entity {

  /**
   * @return array<\Drupal\mycontent\Entity\BlockContent\MyBlockContent>
   */
  public function getThings(): array {
    return $this->things->referencedEntities();
  }

}
```

Currently, PHPStan error prints:

> phpstan: Method Entity::getThings() should return array<\Drupal\mycontent\Entity\BlockContent\MyBlockContent> but returns array<Drupal\Core\Entity\EntityInterface>.

PR resolves this.