### PR TITLE
$serviceDefinition can also be a string

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -186,7 +186,9 @@ class DrupalAutoloader
                  */
                 if (is_array($serviceDefinition)) {
                     foreach (['tags', 'calls', 'configurator', 'factory'] as $key) {
-                        unset($serviceDefinition[$key]);
+                        if (isset($serviceDefinition[$key])) {
+                            unset($serviceDefinition[$key]);
+                        }
                     }
                 }
                 $this->serviceMap[$serviceId] = $serviceDefinition;

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -185,7 +185,9 @@ class DrupalAutoloader
                 - { name: route_enhancer }
                  */
                 if (is_array($serviceDefinition)) {
-                    unset($serviceDefinition['tags'], $serviceDefinition['calls'], $serviceDefinition['configurator'], $serviceDefinition['factory']);
+                    foreach (['tags', 'calls', 'configurator', 'factory'] as $key) {
+                        unset($serviceDefinition[$key]);
+                    }
                 }
                 $this->serviceMap[$serviceId] = $serviceDefinition;
             }

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -184,7 +184,9 @@ class DrupalAutoloader
                 tags:
                 - { name: route_enhancer }
                  */
-                unset($serviceDefinition['tags'], $serviceDefinition['calls'], $serviceDefinition['configurator'], $serviceDefinition['factory']);
+                if (is_array($serviceDefinition)) {
+                    unset($serviceDefinition['tags'], $serviceDefinition['calls'], $serviceDefinition['configurator'], $serviceDefinition['factory']);
+                }
                 $this->serviceMap[$serviceId] = $serviceDefinition;
             }
         }


### PR DESCRIPTION
Fixes #477

In our case, it seems `$serviceDefinition` can be a string containing `"@Drupal\services_defaults_test\TestInjection"`.