### PR TITLE
Make EntityFieldReflection aware of the book property added by book.module.

### DIFF
--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -4,8 +4,10 @@ namespace mglaman\PHPStanDrupal\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 
 /**
@@ -41,6 +43,12 @@ class EntityFieldReflection implements PropertyReflection
             return new ObjectType($objectType);
         }
 
+        if ($this->propertyName === 'book'
+            && $this->declaringClass->is('Drupal\node\NodeInterface')
+        ) {
+            return new ArrayType(new StringType(), new MixedType());
+        }
+
         if ($this->declaringClass->isSubclassOf('Drupal\Core\Entity\ContentEntityInterface')) {
             // Assume the property is a field.
             return new ObjectType('Drupal\Core\Field\FieldItemListInterface');
@@ -60,6 +68,12 @@ class EntityFieldReflection implements PropertyReflection
                 $objectType = 'Drupal\Core\Entity\EntityInterface';
             }
             return new ObjectType($objectType);
+        }
+
+        if ($this->propertyName === 'book'
+            && $this->declaringClass->is('Drupal\node\NodeInterface')
+        ) {
+            return new ArrayType(new StringType(), new MixedType());
         }
 
         // @todo Drupal allows $entity->field_myfield = 'string'; does this break that?

--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -4,10 +4,8 @@ namespace mglaman\PHPStanDrupal\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
-use PHPStan\Type\ArrayType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
-use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 
 /**

--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -43,12 +43,6 @@ class EntityFieldReflection implements PropertyReflection
             return new ObjectType($objectType);
         }
 
-        if ($this->propertyName === 'book'
-            && $this->declaringClass->is('Drupal\node\NodeInterface')
-        ) {
-            return new ArrayType(new StringType(), new MixedType());
-        }
-
         if ($this->declaringClass->isSubclassOf('Drupal\Core\Entity\ContentEntityInterface')) {
             // Assume the property is a field.
             return new ObjectType('Drupal\Core\Field\FieldItemListInterface');
@@ -68,12 +62,6 @@ class EntityFieldReflection implements PropertyReflection
                 $objectType = 'Drupal\Core\Entity\EntityInterface';
             }
             return new ObjectType($objectType);
-        }
-
-        if ($this->propertyName === 'book'
-            && $this->declaringClass->is('Drupal\node\NodeInterface')
-        ) {
-            return new ArrayType(new StringType(), new MixedType());
         }
 
         // @todo Drupal allows $entity->field_myfield = 'string'; does this break that?

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -28,6 +28,12 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             return false;
         }
 
+        foreach ($classReflection->getAncestors() as $ancestor) {
+            if (array_key_exists($propertyName, $ancestor->getPropertyTags())) {
+                return false;
+            }
+        }
+
         // We need to find a way to parse the entity annotation so that at the minimum the `entity_keys` are
         // supported. The real fix is Drupal developers _really_ need to start writing @property definitions in the
         // class doc if they don't get `get` methods.

--- a/stubs/Drupal/Core/Entity/EntityChangedInterface.stub
+++ b/stubs/Drupal/Core/Entity/EntityChangedInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface EntityChangedInterface extends EntityInterface {
+}

--- a/stubs/Drupal/Core/Entity/EntityPublishedInterface.stub
+++ b/stubs/Drupal/Core/Entity/EntityPublishedInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface EntityPublishedInterface extends EntityInterface {
+}

--- a/stubs/Drupal/Core/Entity/RevisionLogInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionLogInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface RevisionLogInterface extends RevisionableInterface {
+}

--- a/stubs/Drupal/Core/Entity/RevisionableInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface RevisionableInterface extends EntityInterface {
+}

--- a/stubs/Drupal/node/NodeInterface.stub
+++ b/stubs/Drupal/node/NodeInterface.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\node;
+
+use Drupal\Core\Entity\EntityPublishedInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\user\EntityOwnerInterface;
+use Drupal\Core\Entity\EntityChangedInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+
+/**
+ * @phpstan-type BookData array{
+ *      nid: int|numeric-string,
+ *      bid: int|numeric-string,
+ *      pid: int|numeric-string,
+ *      has_children: int|numeric-string|bool,
+ *      weight: int|numeric-string,
+ *      depth: int|numeric-string,
+ *      p1: int|numeric-string,
+ *      p2: int|numeric-string,
+ *      p3: int|numeric-string,
+ *      p4: int|numeric-string,
+ *      p5: int|numeric-string,
+ *      p6: int|numeric-string,
+ *      p7: int|numeric-string,
+ *      p8: int|numeric-string,
+ *      p9: int|numeric-string,
+ *      link_path: string,
+ *      link_title: string,
+ * }
+ *
+ * @property BookData $book
+ */
+interface NodeInterface extends ContentEntityInterface, EntityChangedInterface, EntityOwnerInterface, RevisionLogInterface, EntityPublishedInterface {
+
+}

--- a/stubs/Drupal/node/user/EntityOwnerInterface.stub
+++ b/stubs/Drupal/node/user/EntityOwnerInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\user;
+
+interface EntityOwnerInterface {
+}

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -72,10 +72,10 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
             'target_id',
             true,
         ];
-        yield 'field item list: value' => [
+        yield 'field item list: value (read from interface stub)' => [
             \Drupal\Core\Field\FieldItemList::class,
             'value',
-            true,
+            false,
         ];
         yield 'field item list_interface: value' => [
             \Drupal\Core\Field\FieldItemListInterface::class,

--- a/tests/src/Type/EntityPropertyTypeTest.php
+++ b/tests/src/Type/EntityPropertyTypeTest.php
@@ -13,7 +13,8 @@ final class EntityPropertyTypeTest extends TypeInferenceTestCase
 
     public function dataFileAsserts(): iterable
     {
-        yield from $this->gatherAssertTypes(__DIR__ . '/data/entity-properties.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/entity-properties.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/book-module.php');
     }
 
     /**

--- a/tests/src/Type/data/book-module.php
+++ b/tests/src/Type/data/book-module.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace BookModuleProperty;
+
+use Drupal\node\Entity\Node;
+use function PHPStan\Testing\assertType;
+
+$node = Node::create(['type' => 'book']);
+assertType('array{nid: int|numeric-string, bid: int|numeric-string, pid: int|numeric-string, has_children: bool|int|numeric-string, weight: int|numeric-string, depth: int|numeric-string, p1: int|numeric-string, p2: int|numeric-string, p3: int|numeric-string, p4: int|numeric-string, p5: int|numeric-string, p6: int|numeric-string, p7: int|numeric-string, p8: int|numeric-string, p9: int|numeric-string, link_path: string, link_title: string}', $node->book);


### PR DESCRIPTION
# Problem / motivation

As of Drupal 9.5, 10.0, and 10.1, the book module adds a "book" property to Node instances that have been enabled as books.

PHPStan is not aware of this and thus reports messages like `Property Drupal\node\NodeInterface::$book (Drupal\Core\Field\FieldItemListInterface) does not accept array.`

# Proposed resolution

Tell PHPStan to expect a `book` property on Nodes that is an array.

# Additional notes

I wanted to be more specific about what's in this array, but I'm not certain how to do that in PHPStan - its API documentation is somewhat minimal. If you have suggestions, I would be happy to update this merge request.

The `book` property is an array that contains the following keys/types:

| Array key | Data type |
|--------|--------|
| `nid` | `int` (or `numeric-string`) |
| `bid` | `int` (or `numeric-string`) |
| `pid` | `int` (or `numeric-string`) |
| `has_children` | `int`  (or `numeric-string` or `bool`) |
| `weight` | `int` (or `numeric-string`) | 
| `depth` | `int` (or `numeric-string`) | 
| `p1` | `int` (or `numeric-string`) | 
| `p2` | `int` (or `numeric-string`) | 
| `p3` | `int` (or `numeric-string`) | 
| `p4` | `int` (or `numeric-string`) | 
| `p5` | `int` (or `numeric-string`) | 
| `p6` | `int` (or `numeric-string`) | 
| `p7` | `int` (or `numeric-string`) | 
| `p8` | `int` (or `numeric-string`) | 
| `p9` | `int` (or `numeric-string`) | 
| `link_path` | `string` |
| `link_title` | `string` |

... See [book_schema() in 10.1.x core for more info](https://git.drupalcode.org/project/drupal/-/blob/10.1.x/core/modules/book/book.install#L23-126). While many of these fields are stored as integers in the database, the book module usually queries them and dumps the query result into the array, and due to the way the database layer works, they come out as strings containing the integers that were stored in the database.