### PR TITLE
Allow static calls to \Drupal in \Drupal\TestSite\TestSetupInterface

### DIFF
--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -50,6 +50,8 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             // and cannot use dependency injection. Function calls like
             // file_exists, stat, etc. will construct the class directly.
             'Drupal\Core\StreamWrapper\StreamWrapperInterface',
+            // Ignore Nightwatch test setup classes.
+            'Drupal\TestSite\TestSetupInterface',
         ];
 
         foreach ($allowed_list as $item) {

--- a/tests/src/Rules/GlobalDrupalDependencyInjectionRuleTest.php
+++ b/tests/src/Rules/GlobalDrupalDependencyInjectionRuleTest.php
@@ -53,6 +53,11 @@ final class GlobalDrupalDependencyInjectionRuleTest extends DrupalRuleTestCase {
             [],
         ];
 
+        yield [
+            __DIR__ . '/data/bug-515.php',
+            [],
+        ];
+
         if (PHP_VERSION_ID >= 80100) {
             yield [
                 __DIR__ . '/data/bug-500.php',

--- a/tests/src/Rules/data/bug-515.php
+++ b/tests/src/Rules/data/bug-515.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace NightwatchSetup;
+
+use Drupal\TestSite\TestSetupInterface;
+
+final class TestSetup implements TestSetupInterface {
+
+    public function setup()
+    {
+        \Drupal::service('module_installer')->install(['node', 'block']);
+    }
+}


### PR DESCRIPTION
fixes #515
