### PR TITLE
Add translatable interface stub for content entities

### DIFF
--- a/stubs/Drupal/Core/Entity/TranslatableInterface.stub
+++ b/stubs/Drupal/Core/Entity/TranslatableInterface.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\Core\TypedData;
+
+interface TranslatableInterface {
+
+  /**
+   * @param string $langcode
+   * @return static
+   */
+  public function getTranslation(string $langcode): static;
+
+  /**
+   * @return static
+   */
+  public function getUntranslated(): static;
+
+  /**
+   * @param string $langcode
+   * @param array<string, mixed> $values
+   * @return static
+   */
+  public function addTranslation(string $langcode, array $values = []): static;
+
+}

--- a/tests/src/Type/ContentEntityTranslationTypeTest.php
+++ b/tests/src/Type/ContentEntityTranslationTypeTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Type;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class ContentEntityTranslationTypeTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/content-entity-translation.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Type/data/content-entity-translation.php
+++ b/tests/src/Type/data/content-entity-translation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DrupalContentEntityTranslation;
+
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+use function PHPStan\Testing\assertType;
+
+assertType(Node::class, $node = Node::create(['type' => 'page', 'title' => 'foo']));
+assertType(Node::class, $node->getTranslation('en'));
+assertType(Node::class, $node->getUntranslated());
+assertType(Node::class, $node->addTranslation('de', ['title' => 'baz']));
+
+assertType(Term::class, $node = Term::create(['vid' => 'test', 'name' => 'foo']));
+assertType(Term::class, $node->getTranslation('en'));
+assertType(Term::class, $node->getUntranslated());
+assertType(Term::class, $node->addTranslation('de', ['title' => 'baz']));


### PR DESCRIPTION
This is a stub for the `TranslatableInterface`. Note that this stub will be unnecessary for Drupal 10.1+ (see https://www.drupal.org/project/drupal/issues/3269177). Nevertheless, it may be useful for users that run a prior version of Drupal.

This change is a little bit aggressive because it creates a stub for the `TranslatableInterface` directly, although only tests for content entities are provided. We could be more passive by basing the stub on the `ContentEntityBase`.