### PR TITLE
The entity property of an entity reference item can be null

### DIFF
--- a/stubs/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.stub
+++ b/stubs/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.stub
@@ -8,7 +8,7 @@ use Drupal\Core\TypedData\OptionsProviderInterface;
 
 /**
  * @template T of \Drupal\Core\Entity\EntityInterface
- * @property ?T $entity
+ * @property ?T|null $entity
  * @property string|int|null $target_id
  */
 class EntityReferenceItem extends FieldItemBase implements OptionsProviderInterface, PreconfiguredFieldUiOptionsInterface {


### PR DESCRIPTION
If someone deletes the entity, we don't do cascade referential integrity in Drupal

We had this before in https://github.com/mglaman/phpstan-drupal/pull/356 but it was lost at some point