### PR TITLE
Add rule for unnecessary dependency injection in controllers

### DIFF
--- a/src/Rules/Drupal/UnnecessaryDependencyInjectionRule.php
+++ b/src/Rules/Drupal/UnnecessaryDependencyInjectionRule.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types = 1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal\Core\Controller\ControllerBase;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+final class UnnecessaryDependencyInjectionRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+
+        // Check whether the controller extends the ControllerBase class.
+        if (!$scope->isInClass()) {
+            return [];
+        }
+        $classReflection = $scope->getClassReflection();
+        $parentClasses = $classReflection->getParentClassesNames();
+        if (!in_array(ControllerBase::class, $parentClasses, true)) {
+            return [];
+        }
+
+        // Check whether the method is called in the create method.
+        if ($scope->getFunctionName() !== 'create') {
+            return [];
+        }
+
+        // Identify the service name.
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+        $method_name = $node->name->toString();
+        if ($method_name !== 'get') {
+            return [];
+        }
+        $methodReflection = $scope->getMethodReflection($scope->getType($node->var), $node->name->toString());
+        if ($methodReflection === null) {
+            return [];
+        }
+        $declaringClass = $methodReflection->getDeclaringClass();
+        if ($declaringClass->getName() !== 'Symfony\Component\DependencyInjection\ContainerInterface') {
+            return [];
+        }
+
+        $serviceNameArg = $node->args[0];
+        assert($serviceNameArg instanceof Node\Arg);
+        $serviceName = $serviceNameArg->value;
+        if (!$serviceName instanceof Node\Scalar\String_) {
+            return [];
+        }
+        $service = $serviceName->value;
+
+        // Impose the rule for services contained in the controller base.
+        $controllerBaseServices = [
+            'entity_type.manager' => 'entityTypeManager()',
+            'entity.form_builder' => 'entityFormBuilder()',
+            'config.factory' => 'config($name)',
+            'keyvalue' => 'keyValue($collection)',
+            'state' => 'state()',
+            'module_handler' => 'moduleHandler()',
+            'form_builder' => 'formBuilder()',
+            'current_user' => 'currentUser()',
+            'language_manager' => 'languageManager()',
+            'logger.factory' => 'getLogger($channel)',
+            'messenger' => 'messenger()',
+            'redirect.destination' => 'getRedirectDestination()',
+            'string_translation' => 'getStringTranslation()',
+            'cache.*' => 'cache($bin)',
+        ];
+
+        if (substr($service, 0, 6) === 'cache.' ||
+            in_array($service, array_keys($controllerBaseServices), true)
+        ) {
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'The %s service is already defined in %s. Use the parent method %s instead.',
+                    $service,
+                    ControllerBase::class,
+                    $controllerBaseServices[$service] ?? 'cache($bin)',
+                ))
+                ->line($node->getLine())
+                ->build()
+            ];
+        }
+
+        return [];
+    }
+}

--- a/tests/fixtures/drupal/modules/phpstan_fixtures/src/Controller/UnnecessaryServiceInjectedController.php
+++ b/tests/fixtures/drupal/modules/phpstan_fixtures/src/Controller/UnnecessaryServiceInjectedController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\phpstan_fixtures\Controller;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class UnnecessaryServiceInjectedController extends ControllerBase
+{
+
+    /**
+     * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+     */
+    protected $entityTypeManager;
+
+    /**
+     * @var \Drupal\Core\Cache\CacheBackendInterface
+     */
+    protected $cache;
+
+    public function __construct(
+        EntityTypeManagerInterface $entity_type_manager,
+        CacheBackendInterface $cache_backend
+    ) {
+        $this->entityTypeManager = $entity_type_manager;
+        $this->cache = $cache_backend;
+    }
+
+    public static function create(ContainerInterface $container)
+    {
+        return new self(
+            $container->get('entity_type.manager'),
+            $container->get('cache.default')
+        );
+    }
+
+    public function handle()
+    {
+        return [];
+    }
+}

--- a/tests/src/Rules/UnnecessaryDependencyInjectionRuleTest.php
+++ b/tests/src/Rules/UnnecessaryDependencyInjectionRuleTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\UnnecessaryDependencyInjectionRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class UnnecessaryDependencyInjectionRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new UnnecessaryDependencyInjectionRule();
+    }
+
+    /**
+     * @dataProvider controllerData
+     */
+    public function testRule(string $path, array $errorMessages): void
+    {
+        // @phpstan-ignore-next-line
+        $this->analyse([$path], $errorMessages);
+    }
+
+    public function controllerData(): \Generator
+    {
+        yield [
+            __DIR__ . '/../../fixtures/drupal/modules/phpstan_fixtures/src/Controller/UnnecessaryServiceInjectedController.php',
+            [
+                [
+                    'The entity_type.manager service is already defined in Drupal\Core\Controller\ControllerBase. Use the parent method entityTypeManager() instead.',
+                    34
+                ],
+                [
+                    'The cache.default service is already defined in Drupal\Core\Controller\ControllerBase. Use the parent method cache($bin) instead.',
+                    35
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
**Motivation**
I often see unnecessary dependency injection in controllers that extend the controller base. With this new rule we can check whether a parent method call is sufficient. This idea could be extended to other use cases. For example when a class or a parent class uses a trait, e.g., `LoggerChannelTrait`, and still dependency injection is used for the corresponding service.

**Proposed changes**
Add new rule as proposed in pull request.

**Alternatives considered**
None so far.

**Testing steps**
Please see the attached test case.
