### PR TITLE
Check also for Node\Scalar\Encapsed

### DIFF
--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -59,7 +59,7 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                     throw new ShouldNotHappenException();
                 }
                 $cacheKey = $setCacheBackendArgs[1]->value;
-                if (!$cacheKey instanceof Node\Scalar\String_ && !$cacheKey instanceof Node\Scalar\Encapsed) {
+                if (!$cacheKey instanceof Node\Scalar\String_) {
                     continue;
                 }
                 $hasCacheBackendSet = true;

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -5,7 +5,6 @@ namespace mglaman\PHPStanDrupal\Rules\Drupal\PluginManager;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Type;
 
 class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -59,7 +59,7 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                     throw new ShouldNotHappenException();
                 }
                 $cacheKey = $setCacheBackendArgs[1]->value;
-                if (!$cacheKey instanceof Node\Scalar\String_) {
+                if (!$cacheKey instanceof Node\Scalar\String_ && !$cacheKey instanceof Node\Scalar\Encapsed) {
                     continue;
                 }
                 $hasCacheBackendSet = true;

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\Type;
 
 class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
 {
@@ -53,29 +54,30 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                 ($statement->name instanceof Node\Identifier) &&
                 $statement->name->name === 'setCacheBackend') {
                 // setCacheBackend accepts a cache backend, the cache key, and optional (but suggested) cache tags.
-                $setCacheBackendArgs = $statement->args;
-
-                if ($setCacheBackendArgs[1] instanceof Node\VariadicPlaceholder) {
-                    throw new ShouldNotHappenException();
-                }
-                $cacheKey = $setCacheBackendArgs[1]->value;
-                if (!$cacheKey instanceof Node\Scalar\String_) {
+                $setCacheBackendArgs = $statement->getArgs();
+                if (count($setCacheBackendArgs) < 2) {
                     continue;
                 }
                 $hasCacheBackendSet = true;
 
+                $cacheKey = array_map(
+                    static fn (Type $type) => $type->getValue(),
+                    $scope->getType($setCacheBackendArgs[1]->value)->getConstantStrings()
+                );
+                if (count($cacheKey) === 0) {
+                    continue;
+                }
+
                 if (isset($setCacheBackendArgs[2])) {
-                    if ($setCacheBackendArgs[2] instanceof Node\VariadicPlaceholder) {
-                        throw new ShouldNotHappenException();
-                    }
-                    /** @var \PhpParser\Node\Expr\Array_ $cacheTags */
-                    $cacheTags = $setCacheBackendArgs[2]->value;
-                    if (count($cacheTags->items) > 0) {
-                        /** @var \PhpParser\Node\Expr\ArrayItem $item */
-                        foreach ($cacheTags->items as $item) {
-                            if (($item->value instanceof Node\Scalar\String_) &&
-                                strpos($item->value->value, $cacheKey->value) === false) {
-                                $misnamedCacheTagWarnings[] = $item->value->value;
+                    $cacheTagsType = $scope->getType($setCacheBackendArgs[2]->value);
+                    foreach ($cacheTagsType->getConstantArrays() as $constantArray) {
+                        foreach ($constantArray->getValueTypes() as $valueType) {
+                            foreach ($valueType->getConstantStrings() as $cacheTagConstantString) {
+                                foreach ($cacheKey as $cacheKeyValue) {
+                                    if (strpos($cacheTagConstantString->getValue(), $cacheKeyValue) === false) {
+                                        $misnamedCacheTagWarnings[] = $cacheTagConstantString->getValue();
+                                    }
+                                }
                             }
                         }
                     }

--- a/tests/src/Rules/PluginManagerSetsCacheBackendRuleTest.php
+++ b/tests/src/Rules/PluginManagerSetsCacheBackendRuleTest.php
@@ -32,6 +32,10 @@ final class PluginManagerSetsCacheBackendRuleTest extends DrupalRuleTestCase
                 [
                     'Missing cache backend declaration for performance.',
                     12
+                ],
+                [
+                    'plugins cache tag might be unclear and does not contain the cache key in it.',
+                    112,
                 ]
             ]
         ];

--- a/tests/src/Rules/PluginManagerSetsCacheBackendRuleTest.php
+++ b/tests/src/Rules/PluginManagerSetsCacheBackendRuleTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class PluginManagerSetsCacheBackendRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new PluginManagerSetsCacheBackendRule();
+    }
+
+    /**
+     * @dataProvider ruleData
+     */
+    public function testRule(string $path, array $errorMessages): void
+    {
+        $this->analyse([$path], $errorMessages);
+    }
+
+    public static function ruleData(): \Generator
+    {
+        yield [
+            __DIR__ . '/data/plugin-manager-cache-backend.php',
+            [
+                [
+                    'Missing cache backend declaration for performance.',
+                    12
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/src/Rules/data/plugin-manager-cache-backend.php
+++ b/tests/src/Rules/data/plugin-manager-cache-backend.php
@@ -85,3 +85,43 @@ class Qux extends DefaultPluginManager
     }
 
 }
+
+class BarTags extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+        CacheBackendInterface $cache_backend
+    ) {
+        parent::__construct(
+            'Plugin/Bar',
+            $namespaces,
+            $module_handler,
+            'BarInterface',
+            'BarAnnotation',
+        );
+        $this->setCacheBackend($cache_backend, 'bar_plugins', ['bar_plugins']);
+    }
+
+}
+
+class BarTagsNotClear extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+        CacheBackendInterface $cache_backend
+    ) {
+        parent::__construct(
+            'Plugin/Bar',
+            $namespaces,
+            $module_handler,
+            'BarInterface',
+            'BarAnnotation',
+        );
+        $this->setCacheBackend($cache_backend, 'bar_plugins', ['plugins']);
+    }
+
+}

--- a/tests/src/Rules/data/plugin-manager-cache-backend.php
+++ b/tests/src/Rules/data/plugin-manager-cache-backend.php
@@ -43,3 +43,45 @@ class Bar extends DefaultPluginManager
     }
 
 }
+
+class Baz extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+        CacheBackendInterface $cache_backend,
+        string $type,
+    ) {
+        parent::__construct(
+            'Plugin/Bar',
+            $namespaces,
+            $module_handler,
+            'BarInterface',
+            'BarAnnotation',
+        );
+        $this->setCacheBackend($cache_backend, 'bar_' . $type . '_plugins');
+    }
+
+}
+
+class Qux extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+        CacheBackendInterface $cache_backend,
+        string $type,
+    ) {
+        parent::__construct(
+            'Plugin/Bar',
+            $namespaces,
+            $module_handler,
+            'BarInterface',
+            'BarAnnotation',
+        );
+        $this->setCacheBackend($cache_backend, "bar_{$type}_plugins");
+    }
+
+}

--- a/tests/src/Rules/data/plugin-manager-cache-backend.php
+++ b/tests/src/Rules/data/plugin-manager-cache-backend.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PluginManagerCacheBackend;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+
+class Foo extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+    ) {
+        parent::__construct(
+            'Plugin/Foo',
+            $namespaces,
+            $module_handler,
+            'FooInterface',
+            'FooAnnotation',
+        );
+    }
+
+}
+
+class Bar extends DefaultPluginManager
+{
+
+    public function __construct(
+        \Traversable $namespaces,
+        ModuleHandlerInterface $module_handler,
+        CacheBackendInterface $cache_backend
+    ) {
+        parent::__construct(
+            'Plugin/Bar',
+            $namespaces,
+            $module_handler,
+            'BarInterface',
+            'BarAnnotation',
+        );
+        $this->setCacheBackend($cache_backend, 'bar_plugins');
+    }
+
+}


### PR DESCRIPTION
**Motivation**

In my project I'm getting:

> Missing cache backend declaration for performance.

with a plugin manager having the cache backend line in the constructor:

```php
$this->setCacheBackend($cache_backend, "mymodule_{$type}_plugins");
```

where `$type` is passed in constructor's signature, same as in Views plugin manager.

**Proposed changes**

This PR

**Alternatives considered**

None.

**Testing steps**

Unfortunately, for some mysterious reasons, I can't replicate this in the test from phpstan-drupal. I'm missing something. But applying the PR as patch to my project solves the issue.

I'm using

* PHPStan 1.10.25
* mglaman/phpstan-drupal 1.1.36