### PR TITLE
Improve RevisionableStorageInterface stub

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
 		- drupal-autoloader.php
 		- tests/src
 	excludePaths:
+		-  tests/src/data/*.php
 		-  tests/src/Type/data/*.php
 		-  tests/src/Rules/data/*.php
 	dynamicConstantNames:

--- a/stubs/Drupal/Core/Entity/BundleEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/BundleEntityStorageInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface BundleEntityStorageInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/ContentEntityStorageBase.stub
+++ b/stubs/Drupal/Core/Entity/ContentEntityStorageBase.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface, BundleEntityStorageInterface {
+
+    /**
+     * @param int|numeric-string $revision_id
+     * @return \Drupal\Core\Entity\RevisionableInterface|null
+     * @not-deprecated
+     */
+    public function loadRevision(int|string $revision_id): \Drupal\Core\Entity\RevisionableInterface|null
+    {
+    }
+
+}

--- a/stubs/Drupal/Core/Entity/ContentEntityStorageBase.stub
+++ b/stubs/Drupal/Core/Entity/ContentEntityStorageBase.stub
@@ -4,13 +4,4 @@ namespace Drupal\Core\Entity;
 
 abstract class ContentEntityStorageBase extends EntityStorageBase implements ContentEntityStorageInterface, DynamicallyFieldableEntityStorageInterface, BundleEntityStorageInterface {
 
-    /**
-     * @param int|numeric-string $revision_id
-     * @return \Drupal\Core\Entity\RevisionableInterface|null
-     * @not-deprecated
-     */
-    public function loadRevision(int|string $revision_id): \Drupal\Core\Entity\RevisionableInterface|null
-    {
-    }
-
 }

--- a/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
@@ -2,6 +2,8 @@
 
 namespace Drupal\Core\Entity;
 
+// Remove extension of `EntityStorageInterface` so that `TranslatableRevisionableStorageInterface`
+// is properly processed.
 interface ContentEntityStorageInterface extends TranslatableRevisionableStorageInterface {
 
 }

--- a/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
@@ -2,6 +2,6 @@
 
 namespace Drupal\Core\Entity;
 
-interface ContentEntityStorageInterface extends EntityStorageInterface, TranslatableRevisionableStorageInterface {
+interface ContentEntityStorageInterface extends TranslatableRevisionableStorageInterface {
 
 }

--- a/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/ContentEntityStorageInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface ContentEntityStorageInterface extends EntityStorageInterface, TranslatableRevisionableStorageInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/DynamicallyFieldableEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/DynamicallyFieldableEntityStorageInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface DynamicallyFieldableEntityStorageInterface extends FieldableEntityStorageInterface, FieldStorageDefinitionListenerInterface, FieldDefinitionListenerInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/EntityHandlerBase.stub
+++ b/stubs/Drupal/Core/Entity/EntityHandlerBase.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+abstract class EntityHandlerBase {
+
+}

--- a/stubs/Drupal/Core/Entity/EntityHandlerInterface.stub
+++ b/stubs/Drupal/Core/Entity/EntityHandlerInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface EntityHandlerInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/EntityStorageBase.stub
+++ b/stubs/Drupal/Core/Entity/EntityStorageBase.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+abstract class EntityStorageBase extends EntityHandlerBase implements EntityStorageInterface, EntityHandlerInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/FieldableEntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/FieldableEntityStorageInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+
+interface FieldableEntityStorageInterface extends EntityStorageInterface {
+}

--- a/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
@@ -7,13 +7,11 @@ interface RevisionableStorageInterface extends EntityStorageInterface {
   /**
    * @param int|numeric-string $revision_id
    * @return \Drupal\Core\Entity\RevisionableInterface|null
-   * @not-deprecated
    */
-  public function loadRevision($revision_id);
+  public function loadRevision(int|string $revision_id);
 
   /**
    * @param int|numeric-string $revision_id
-   * @not-deprecated
    */
   public function deleteRevision($revision_id): void;
 

--- a/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
@@ -8,7 +8,7 @@ interface RevisionableStorageInterface extends EntityStorageInterface {
    * @param int|numeric-string $revision_id
    * @return \Drupal\Core\Entity\RevisionableInterface|null
    */
-  public function loadRevision(int|string $revision_id);
+  public function loadRevision($revision_id);
 
   /**
    * @param int|numeric-string $revision_id

--- a/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface TranslatableRevisionableStorageInterface extends TranslatableStorageInterface, RevisionableStorageInterface {
+
+}

--- a/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
@@ -2,6 +2,11 @@
 
 namespace Drupal\Core\Entity;
 
+// RevisionableStorageInterface before TranslatableStorageInterface so that its definition of
+// `loadRevision` is cached by PHPStan's reflection first. Otherwise PHPStan's reflection caches
+// the PhpDoc from `EntityStorageInterface::loadRevision`.
+//
+// This is fragile and relies on `ContentEntityStorageInterface` only implementing this interface.
 interface TranslatableRevisionableStorageInterface extends RevisionableStorageInterface, TranslatableStorageInterface {
 
 }

--- a/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/TranslatableRevisionableStorageInterface.stub
@@ -2,6 +2,6 @@
 
 namespace Drupal\Core\Entity;
 
-interface TranslatableRevisionableStorageInterface extends TranslatableStorageInterface, RevisionableStorageInterface {
+interface TranslatableRevisionableStorageInterface extends RevisionableStorageInterface, TranslatableStorageInterface {
 
 }

--- a/stubs/Drupal/Core/Entity/TranslatableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/TranslatableStorageInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\Entity;
+
+interface TranslatableStorageInterface extends EntityStorageInterface {
+}

--- a/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
+++ b/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
@@ -23,16 +23,18 @@ final class RevisionableStorageInterfaceStubTest extends DrupalRuleTestCase
 
     public function testRule(): void
     {
-        $this->analyse(
-            [__DIR__ . '/data/bug-586.php'],
-            [
-                [
-                    'Call to deprecated method loadRevision() of class Drupal\Core\Entity\EntityStorageInterface:
+        $errors = [];
+        if (version_compare(\Drupal::VERSION, '10.1', '>=')) {
+            $errors[] = [
+                'Call to deprecated method loadRevision() of class Drupal\Core\Entity\EntityStorageInterface:
 in drupal:10.1.0 and is removed from drupal:11.0.0. Use
 \Drupal\Core\Entity\RevisionableStorageInterface::loadRevision instead.',
-                    12
-                ]
-            ]
+                12
+            ];
+        }
+        $this->analyse(
+            [__DIR__ . '/data/bug-586.php'],
+            $errors
         );
     }
 

--- a/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
+++ b/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
@@ -25,7 +25,14 @@ final class RevisionableStorageInterfaceStubTest extends DrupalRuleTestCase
     {
         $this->analyse(
             [__DIR__ . '/data/bug-586.php'],
-            []
+            [
+                [
+                    'Call to deprecated method loadRevision() of class Drupal\Core\Entity\EntityStorageInterface:
+in drupal:10.1.0 and is removed from drupal:11.0.0. Use
+\Drupal\Core\Entity\RevisionableStorageInterface::loadRevision instead.',
+                    12
+                ]
+            ]
         );
     }
 

--- a/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
+++ b/tests/src/Rules/RevisionableStorageInterfaceStubTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Deprecations\CallToDeprecatedMethodRule;
+use PHPStan\Rules\Deprecations\DeprecatedScopeHelper;
+use PHPStan\Rules\Rule;
+
+final class RevisionableStorageInterfaceStubTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        // @phpstan-ignore-next-line
+        return new CallToDeprecatedMethodRule(
+            self::createReflectionProvider(),
+            self::getContainer()->getByType(DeprecatedScopeHelper::class)
+        );
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/bug-586.php'],
+            []
+        );
+    }
+
+}

--- a/tests/src/Rules/data/bug-586.php
+++ b/tests/src/Rules/data/bug-586.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Bug586;
+
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+
+$nodeStorage = \Drupal::entityTypeManager()->getStorage('node');
+$nodeStorage->loadRevision(1);
+
+$genericContentEntityStorage = \Drupal::entityTypeManager()->getStorage('foo');
+assert($genericContentEntityStorage instanceof ContentEntityStorageInterface);
+$genericContentEntityStorage->loadRevision(1);


### PR DESCRIPTION
fixes #586

```
// RevisionableStorageInterface before TranslatableStorageInterface so that its definition of
// `loadRevision` is cached by PHPStan's reflection first. Otherwise PHPStan's reflection caches
// the PhpDoc from `EntityStorageInterface::loadRevision`.
//
// This is fragile and relies on `ContentEntityStorageInterface` only implementing this interface.
interface TranslatableRevisionableStorageInterface extends RevisionableStorageInterface, TranslatableStorageInterface {

}

// Remove extension of `EntityStorageInterface` so that `TranslatableRevisionableStorageInterface`
// is properly processed.
interface ContentEntityStorageInterface extends TranslatableRevisionableStorageInterface {

}
```

This can't be fixed until Drupal core fixes its interface declarations.

https://www.drupal.org/project/drupal/issues/3383215