### PR TITLE
Add null to the container get method return type when ContainerInterace::NULL_ON_INVALID_REFERENCE is passed as the second argument.

### DIFF
--- a/src/Type/ContainerDynamicReturnTypeExtension.php
+++ b/src/Type/ContainerDynamicReturnTypeExtension.php
@@ -9,9 +9,10 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -41,24 +42,54 @@ class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
         Scope $scope
     ): Type {
         $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
-        $args = $methodCall->getArgs();
-        if (count($args) !== 1) {
-            return $returnType;
-        }
-
         $methodName = $methodReflection->getName();
-        $types = [];
-        $argType = $scope->getType($args[0]->value);
 
-        foreach ($argType->getConstantStrings() as $constantStringType) {
-            $serviceId = $constantStringType->getValue();
-            $service = $this->serviceMap->getService($serviceId);
-            if ($methodName === 'get') {
-                $types[] = $service !== null ? $service->getType() : $returnType;
-            } elseif ($methodName === 'has') {
+        if ($methodName === 'has') {
+            $args = $methodCall->getArgs();
+            if (count($args) !== 1) {
+                return $returnType;
+            }
+
+            $types = [];
+            $argType = $scope->getType($args[0]->value);
+
+            foreach ($argType->getConstantStrings() as $constantStringType) {
+                $serviceId = $constantStringType->getValue();
+                $service = $this->serviceMap->getService($serviceId);
                 $types[] = new ConstantBooleanType($service !== null);
             }
+
+            return TypeCombinator::union(...$types);
+        } elseif ($methodName === 'get') {
+            $args = $methodCall->getArgs();
+            if (count($args) === 0) {
+                return $returnType;
+            }
+
+            $types = [];
+
+            if (isset($args[1])) {
+                $invalidBehaviour = $scope->getType($args[1]->value);
+
+                foreach ($invalidBehaviour->getConstantScalarValues() as $value) {
+                    if ($value === ContainerInterface::NULL_ON_INVALID_REFERENCE) {
+                        $types[] = new NullType();
+                        break;
+                    }
+                }
+            }
+
+            $argType = $scope->getType($args[0]->value);
+
+            foreach ($argType->getConstantStrings() as $constantStringType) {
+                $serviceId = $constantStringType->getValue();
+                $service = $this->serviceMap->getService($serviceId);
+                $types[] = $service !== null ? $service->getType() : $returnType;
+            }
+
+            return TypeCombinator::union(...$types);
         }
-        return TypeCombinator::union(...$types);
+
+        return $returnType;
     }
 }

--- a/tests/src/Type/DrupalContainerDynamicReturnTypeTest.php
+++ b/tests/src/Type/DrupalContainerDynamicReturnTypeTest.php
@@ -17,6 +17,7 @@ final class DrupalContainerDynamicReturnTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/drupal-service-static.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/drupal-class-resolver.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-563.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/container-optional.php');
     }
 
     /**

--- a/tests/src/Type/data/container-optional.php
+++ b/tests/src/Type/data/container-optional.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace DrupalContainerOptional;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\service_map\MyService;
+use function PHPStan\Testing\assertType;
+
+function test(): void {
+    $container = \Drupal::getContainer();
+
+    assertType(
+        'object|null',
+        $container->get('unknown_service', ContainerInterface::NULL_ON_INVALID_REFERENCE)
+    );
+
+    assertType(
+        MyService::class . '|null',
+        $container->get('service_map.my_service', ContainerInterface::NULL_ON_INVALID_REFERENCE)
+    );
+
+    assertType(
+        MyService::class,
+        $container->get('service_map.my_service', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
+    );
+
+    assertType(
+        MyService::class,
+        $container->get('service_map.my_service', ContainerInterface::RUNTIME_EXCEPTION_ON_INVALID_REFERENCE)
+    );
+
+    assertType(
+        MyService::class,
+        $container->get('service_map.my_service', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)
+    );
+
+    assertType(
+        MyService::class,
+        $container->get('service_map.my_service', ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE)
+    );
+}


### PR DESCRIPTION
When developing modules that interact with optional modules it is useful to pass the `ContainerInterface::NULL_ON_INVALID_REFERENCE` second arg and do a null check rather than cumbersome exception handling 

This change adds `null` to the return type of any `$container->get` method calls that explicitly state it may return null

This also improves handling of `$container->get` with any second arg in general, as the second arg would disable the return type extension, causing it to fallback to the `object|null` return type on the ContainerInterface even though the module is likely available due to `require-dev` and this extension could provide a better type.

Looking at the [drupal source](https://github.com/drupal/drupal/blob/1325be71ae78c43818dd84dd2e542b21559435af/core/lib/Drupal/Component/DependencyInjection/Container.php#L131) it only respects 2 out of 5 of the constants provided by symfony but i added tests for all 5 to be sure 