### PR TITLE
Add missing return in ClassExtendsInternalClassRule.

### DIFF
--- a/src/Rules/Classes/ClassExtendsInternalClassRule.php
+++ b/src/Rules/Classes/ClassExtendsInternalClassRule.php
@@ -52,7 +52,7 @@ class ClassExtendsInternalClassRule implements Rule
         $currentClassName = $node->namespacedName->toString();
 
         if (!NamespaceCheck::isDrupalNamespace($node)) {
-            [$this->buildError($currentClassName, $extendedClassName)->build()];
+            return [$this->buildError($currentClassName, $extendedClassName)->build()];
         }
 
         if (NamespaceCheck::isSharedNamespace($node)) {


### PR DESCRIPTION
Whilst having a poke around in the code for the sake of curiosity, i noticed this expression that is missing a return and as such does nothing.

If i look at the commit that introduced the issue, it appears as though the `->tip` calls were added in the same commit, so i'm not sure if the `return` is intended to be there, or if the entire conditional is now redundant and not necessary. Interestingly the tests don't change with or without the `return` so it's hard to say whether or not it should be there?

Perhaps given that it's been like this for ~3 years the correct fix is to remove the conditional altogether? If that is preferred let me know and i can update the pull request.