### PR TITLE
Simplify access to reflections in SymfonyCmfRoutingInClassMethodSignatureRule and TestClassesProtectedPropertyModulesRule.

### DIFF
--- a/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
@@ -6,7 +6,6 @@ use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassMethodNode;
-use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -30,10 +29,7 @@ final class SymfonyCmfRoutingInClassMethodSignatureRule implements Rule
         if ($major !== '9' || (int) $minor < 1) {
             return [];
         }
-        $method = $scope->getFunction();
-        if (!$method instanceof MethodReflection) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
+        $method = $node->getMethodReflection();
 
         $cmfRouteObjectInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteObjectInterface::class);
         $cmfRouteProviderInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteProviderInterface::class);

--- a/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
+++ b/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
@@ -9,7 +9,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
 use PHPUnit\Framework\TestCase;
 
 class TestClassesProtectedPropertyModulesRule implements Rule
@@ -27,15 +26,11 @@ class TestClassesProtectedPropertyModulesRule implements Rule
     {
         assert($node instanceof ClassPropertyNode);
 
-        if (!$scope->isInClass()) {
-            throw new ShouldNotHappenException();
-        }
-
         if ($node->getName() !== 'modules') {
             return [];
         }
 
-        $scopeClassReflection = $scope->getClassReflection();
+        $scopeClassReflection = $node->getClassReflection();
         if ($scopeClassReflection->isAnonymous()) {
             return [];
         }


### PR DESCRIPTION
PHPStan added the ability to access reflection objects from many of it's virtual nodes which guarantees they will be there, avoiding the need to do these checks.