### PR TITLE
Fully qualify all global function calls.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,7 @@
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/>
 	<rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
 	<rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
 </ruleset>

--- a/src/DeprecatedScope/DeprecationHelperScope.php
+++ b/src/DeprecatedScope/DeprecationHelperScope.php
@@ -8,6 +8,8 @@ use Drupal\Component\Utility\DeprecationHelper;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Deprecations\DeprecatedScopeResolver;
+use function class_exists;
+use function count;
 
 final class DeprecationHelperScope implements DeprecatedScopeResolver
 {

--- a/src/DeprecatedScope/GroupLegacyScope.php
+++ b/src/DeprecatedScope/GroupLegacyScope.php
@@ -6,6 +6,7 @@ namespace mglaman\PHPStanDrupal\DeprecatedScope;
 
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Deprecations\DeprecatedScopeResolver;
+use function strpos;
 
 final class GroupLegacyScope implements DeprecatedScopeResolver
 {

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -7,6 +7,24 @@ use DrupalFinder\DrupalFinder;
 use PHPStan\DependencyInjection\Container;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
+use function array_map;
+use function array_merge;
+use function array_walk;
+use function class_exists;
+use function dirname;
+use function file_exists;
+use function in_array;
+use function interface_exists;
+use function is_array;
+use function is_dir;
+use function is_string;
+use function realpath;
+use function str_replace;
+use function strpos;
+use function strtr;
+use function trigger_error;
+use function ucwords;
+use function usort;
 
 class DrupalAutoloader
 {

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -3,10 +3,16 @@
 namespace mglaman\PHPStanDrupal\Drupal;
 
 use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter;
 use DrupalFinder\DrupalFinder;
+use Drush\Drush;
 use PHPStan\DependencyInjection\Container;
+use PHPUnit\Framework\Test;
+use ReflectionClass;
+use RuntimeException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Yaml;
+use Throwable;
 use function array_map;
 use function array_merge;
 use function array_walk;
@@ -86,7 +92,7 @@ class DrupalAutoloader
         $drupalRoot = $finder->getDrupalRoot();
         $drupalVendorRoot = $finder->getVendorDir();
         if (! (bool) $drupalRoot || ! (bool) $drupalVendorRoot) {
-            throw new \RuntimeException("Unable to detect Drupal at {$drupalParams['drupal_root']}");
+            throw new RuntimeException("Unable to detect Drupal at {$drupalParams['drupal_root']}");
         }
 
         $this->drupalRoot = $drupalRoot;
@@ -160,11 +166,11 @@ class DrupalAutoloader
             }
         }
 
-        if (class_exists(\Drush\Drush::class)) {
-            $reflect = new \ReflectionClass(\Drush\Drush::class);
+        if (class_exists(Drush::class)) {
+            $reflect = new ReflectionClass(Drush::class);
             if ($reflect->getFileName() !== false) {
                 $levels = 2;
-                if (\Drush\Drush::getMajorVersion() < 9) {
+                if (Drush::getMajorVersion() < 9) {
                     $levels = 3;
                 }
                 $drushDir = dirname($reflect->getFileName(), $levels);
@@ -218,9 +224,9 @@ class DrupalAutoloader
         $service_map = $container->getByType(ServiceMap::class);
         $service_map->setDrupalServices($this->serviceMap);
 
-        if (interface_exists(\PHPUnit\Framework\Test::class)
+        if (interface_exists(Test::class)
             && class_exists('Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter')) {
-            \Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter::mutateTestBase($this->autoloader);
+            ClassWriter::mutateTestBase($this->autoloader);
         }
 
         $extension_map = $container->getByType(ExtensionMap::class);
@@ -325,7 +331,7 @@ class DrupalAutoloader
     {
         try {
             $extension->load();
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             // Something prevented the extension file from loading.
             // This can happen when drupal_get_path or drupal_get_filename are used outside of the scope of a function.
         }
@@ -339,7 +345,7 @@ class DrupalAutoloader
             $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
             // This can happen when drupal_get_path or drupal_get_filename are used outside the scope of a function.
             @trigger_error("$path invoked the Drupal container outside of the scope of a function or class method. It was not loaded.", E_USER_WARNING);
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
             // Something prevented the extension file from loading.
             @trigger_error("$path failed loading due to {$e->getMessage()}", E_USER_WARNING);

--- a/src/Drupal/DrupalServiceDefinition.php
+++ b/src/Drupal/DrupalServiceDefinition.php
@@ -6,6 +6,8 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use function count;
+use function str_replace;
 
 class DrupalServiceDefinition
 {

--- a/src/Drupal/Extension.php
+++ b/src/Drupal/Extension.php
@@ -2,7 +2,14 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use RuntimeException;
 use Symfony\Component\Yaml\Yaml;
+use function explode;
+use function file_get_contents;
+use function is_array;
+use function sprintf;
+use function strpos;
+use function trim;
 
 /**
  * Defines an extension (file) object.
@@ -190,7 +197,7 @@ class Extension
      */
     public function getDependencies(): array
     {
-        if (\is_array($this->dependencies)) {
+        if (is_array($this->dependencies)) {
             return $this->dependencies;
         }
 
@@ -205,12 +212,12 @@ class Extension
 
         // @see \Drupal\Core\Extension\Dependency::createFromString().
         foreach ($dependencies as $dependency) {
-            if (\strpos($dependency, ':') !== false) {
-                [, $dependency] = \explode(':', $dependency);
+            if (strpos($dependency, ':') !== false) {
+                [, $dependency] = explode(':', $dependency);
             }
 
-            $parts = \explode('(', $dependency, 2);
-            $this->dependencies[] = \trim($parts[0]);
+            $parts = explode('(', $dependency, 2);
+            $this->dependencies[] = trim($parts[0]);
         }
 
         return $this->dependencies;
@@ -218,13 +225,13 @@ class Extension
 
     private function parseInfo(): array
     {
-        if (\is_array($this->info)) {
+        if (is_array($this->info)) {
             return $this->info;
         }
 
-        $infoContent = \file_get_contents(\sprintf('%s/%s', $this->root, $this->getPathname()));
+        $infoContent = file_get_contents(sprintf('%s/%s', $this->root, $this->getPathname()));
         if (false === $infoContent) {
-            throw new \RuntimeException(\sprintf('Cannot read "%s', $this->getPathname()));
+            throw new RuntimeException(sprintf('Cannot read "%s', $this->getPathname()));
         }
 
         return $this->info = Yaml::parse($infoContent);

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -2,6 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use FilesystemIterator;
+use mglaman\PHPStanDrupal\Drupal\Extension;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use function array_filter;
 use function array_flip;
 use function array_multisort;
@@ -216,7 +220,7 @@ class ExtensionDiscovery
             return $all_files;
         }
 
-        return array_filter($all_files, function (\mglaman\PHPStanDrupal\Drupal\Extension $file) : bool {
+        return array_filter($all_files, function (Extension $file) : bool {
             if (strpos($file->subpath, 'profiles') !== 0) {
                 // This extension doesn't belong to a profile, ignore it.
                 return true;
@@ -341,11 +345,11 @@ class ExtensionDiscovery
         // symlinks (to allow extensions to be linked from elsewhere), and return
         // the RecursiveDirectoryIterator instance to have access to getSubPath(),
         // since SplFileInfo does not support relative paths.
-        $flags = \FilesystemIterator::UNIX_PATHS;
-        $flags |= \FilesystemIterator::SKIP_DOTS;
-        $flags |= \FilesystemIterator::FOLLOW_SYMLINKS;
-        $flags |= \FilesystemIterator::CURRENT_AS_SELF;
-        $directory_iterator = new \RecursiveDirectoryIterator($absolute_dir, $flags);
+        $flags = FilesystemIterator::UNIX_PATHS;
+        $flags |= FilesystemIterator::SKIP_DOTS;
+        $flags |= FilesystemIterator::FOLLOW_SYMLINKS;
+        $flags |= FilesystemIterator::CURRENT_AS_SELF;
+        $directory_iterator = new RecursiveDirectoryIterator($absolute_dir, $flags);
 
         // Allow directories specified in settings.php to be ignored. You can use
         // this to not check for files in common special-purpose directories. For
@@ -361,11 +365,11 @@ class ExtensionDiscovery
 
         // The actual recursive filesystem scan is only invoked by instantiating the
         // RecursiveIteratorIterator.
-        $iterator = new \RecursiveIteratorIterator(
+        $iterator = new RecursiveIteratorIterator(
             $filter,
-            \RecursiveIteratorIterator::LEAVES_ONLY,
+            RecursiveIteratorIterator::LEAVES_ONLY,
             // Suppress filesystem errors in case a directory cannot be accessed.
-            \RecursiveIteratorIterator::CATCH_GET_CHILD
+            RecursiveIteratorIterator::CATCH_GET_CHILD
         );
 
         foreach ($iterator as $key => $fileinfo) {

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -2,6 +2,15 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use function array_filter;
+use function array_flip;
+use function array_multisort;
+use function dirname;
+use function file_exists;
+use function is_dir;
+use function preg_match;
+use function strpos;
+
 class ExtensionDiscovery
 {
 

--- a/src/Drupal/ExtensionMap.php
+++ b/src/Drupal/ExtensionMap.php
@@ -2,6 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use function array_combine;
+use function array_map;
+use function is_array;
+
 final class ExtensionMap
 {
     /** @var array<string, Extension>  */

--- a/src/Drupal/RecursiveExtensionFilterIterator.php
+++ b/src/Drupal/RecursiveExtensionFilterIterator.php
@@ -2,6 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use function array_merge;
+use function in_array;
+use function substr;
+
 /**
  * Filters a RecursiveDirectoryIterator to discover extensions.
  *

--- a/src/Drupal/RecursiveExtensionFilterIterator.php
+++ b/src/Drupal/RecursiveExtensionFilterIterator.php
@@ -2,6 +2,8 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use RecursiveFilterIterator;
+use RecursiveIterator;
 use function array_merge;
 use function in_array;
 use function substr;
@@ -13,7 +15,7 @@ use function substr;
  *
  * @method bool isDir()
  */
-class RecursiveExtensionFilterIterator extends \RecursiveFilterIterator
+class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
 {
 
     /**
@@ -69,7 +71,7 @@ class RecursiveExtensionFilterIterator extends \RecursiveFilterIterator
      *   (optional) Add to the blacklist of directories that should be filtered
      *   out during the iteration.
      */
-    public function __construct(\RecursiveIterator $iterator, array $blacklist = [])
+    public function __construct(RecursiveIterator $iterator, array $blacklist = [])
     {
         parent::__construct($iterator);
         $this->blacklist = array_merge($this->blacklist, $blacklist);
@@ -78,7 +80,7 @@ class RecursiveExtensionFilterIterator extends \RecursiveFilterIterator
     /**
      * {@inheritdoc}
      */
-    public function getChildren(): \RecursiveFilterIterator
+    public function getChildren(): RecursiveFilterIterator
     {
         $filter = parent::getChildren();
         if ($filter instanceof self) {

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -2,6 +2,8 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use function class_exists;
+
 class ServiceMap
 {
     /** @var DrupalServiceDefinition[] */

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -6,6 +6,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\MethodsClassReflectionExtension;
 use PHPStan\Type\ObjectType;
+use function array_key_exists;
 
 /**
  * Allows some common methods on fields.

--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -4,6 +4,7 @@ namespace mglaman\PHPStanDrupal\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
@@ -116,13 +117,13 @@ class EntityFieldReflection implements PropertyReflection
         return null;
     }
 
-    public function isDeprecated(): \PHPStan\TrinaryLogic
+    public function isDeprecated(): TrinaryLogic
     {
-        return \PHPStan\TrinaryLogic::createNo();
+        return TrinaryLogic::createNo();
     }
 
-    public function isInternal(): \PHPStan\TrinaryLogic
+    public function isInternal(): TrinaryLogic
     {
-        return \PHPStan\TrinaryLogic::createNo();
+        return TrinaryLogic::createNo();
     }
 }

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
+use LogicException;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
@@ -59,7 +60,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
-        throw new \LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
+        throw new LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
     }
 
     public static function classObjectIsSuperOfInterface(string $name, ObjectType $interfaceObject) : TrinaryLogic

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -7,6 +7,7 @@ use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
+use function array_key_exists;
 
 /**
  * Allows field access via magic methods

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -4,6 +4,7 @@ namespace mglaman\PHPStanDrupal\Reflection;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
@@ -112,9 +113,9 @@ class FieldItemListPropertyReflection implements PropertyReflection
         return null;
     }
 
-    public function isDeprecated(): \PHPStan\TrinaryLogic
+    public function isDeprecated(): TrinaryLogic
     {
-        return \PHPStan\TrinaryLogic::createNo();
+        return TrinaryLogic::createNo();
     }
 
     public function getDeprecatedDescription(): ?string
@@ -122,8 +123,8 @@ class FieldItemListPropertyReflection implements PropertyReflection
         return null;
     }
 
-    public function isInternal(): \PHPStan\TrinaryLogic
+    public function isInternal(): TrinaryLogic
     {
-        return \PHPStan\TrinaryLogic::createNo();
+        return TrinaryLogic::createNo();
     }
 }

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -8,6 +8,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use function in_array;
 
 /**
  * Allows field access via magic methods

--- a/src/Rules/Classes/ClassExtendsInternalClassRule.php
+++ b/src/Rules/Classes/ClassExtendsInternalClassRule.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use function sprintf;
 
 class ClassExtendsInternalClassRule implements Rule
 {
@@ -70,9 +71,9 @@ class ClassExtendsInternalClassRule implements Rule
 
     private function buildError(?string $currentClassName, string $extendedClassName): RuleErrorBuilder
     {
-        return RuleErrorBuilder::message(\sprintf(
+        return RuleErrorBuilder::message(sprintf(
             '%s extends @internal class %s.',
-            $currentClassName !== null ? \sprintf('Class %s', $currentClassName) : 'Anonymous class',
+            $currentClassName !== null ? sprintf('Class %s', $currentClassName) : 'Anonymous class',
             $extendedClassName
         ));
     }

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -7,6 +7,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Type\ObjectType;
+use function sprintf;
 
 /**
  * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Class_>

--- a/src/Rules/Deprecations/AccessDeprecatedConstant.php
+++ b/src/Rules/Deprecations/AccessDeprecatedConstant.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Rules\Deprecations;
 
+use Drupal;
 use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
@@ -92,7 +93,7 @@ class AccessDeprecatedConstant implements Rule
             'USER_REGISTER_VISITORS' => 'Deprecated in drupal:8.3.0 and is removed from drupal:9.0.0. Use \Drupal\user\UserInterface::REGISTER_VISITORS instead.',
             'USER_REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL' => 'Deprecated in drupal:8.3.0 and is removed from drupal:9.0.0. Use \Drupal\user\UserInterface::REGISTER_VISITORS_ADMINISTRATIVE_APPROVAL instead.',
         ];
-        [$major, $minor] = explode('.', \Drupal::VERSION, 3);
+        [$major, $minor] = explode('.', Drupal::VERSION, 3);
         if ($major === '9') {
             if ((int) $minor >= 1) {
                 $deprecatedConstants = array_merge($deprecatedConstants, [

--- a/src/Rules/Deprecations/AccessDeprecatedConstant.php
+++ b/src/Rules/Deprecations/AccessDeprecatedConstant.php
@@ -6,8 +6,12 @@ use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use function array_merge;
+use function explode;
+use function sprintf;
 
-class AccessDeprecatedConstant implements \PHPStan\Rules\Rule
+class AccessDeprecatedConstant implements Rule
 {
     /** @var ReflectionProvider */
     private $reflectionProvider;

--- a/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
+++ b/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
@@ -10,6 +10,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\Constant\ConstantArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
+use function count;
 
 final class ConditionManagerCreateInstanceContextConfigurationRule implements Rule
 {

--- a/src/Rules/Deprecations/ConfigEntityConfigExportRule.php
+++ b/src/Rules/Deprecations/ConfigEntityConfigExportRule.php
@@ -8,6 +8,7 @@ use PHPStan\PhpDoc\ResolvedPhpDocBlock;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\ShouldNotHappenException;
+use function preg_match;
 
 final class ConfigEntityConfigExportRule extends DeprecatedAnnotationsRuleBase
 {

--- a/src/Rules/Deprecations/DeprecatedHookImplementation.php
+++ b/src/Rules/Deprecations/DeprecatedHookImplementation.php
@@ -9,6 +9,10 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use function basename;
+use function explode;
+use function strlen;
+use function substr_replace;
 
 class DeprecatedHookImplementation implements Rule
 {

--- a/src/Rules/Deprecations/PluginAnnotationContextDefinitionsRule.php
+++ b/src/Rules/Deprecations/PluginAnnotationContextDefinitionsRule.php
@@ -6,6 +6,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\ShouldNotHappenException;
+use function preg_match;
 
 final class PluginAnnotationContextDefinitionsRule extends DeprecatedAnnotationsRuleBase
 {

--- a/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Rules\Deprecations;
 
+use Drupal;
 use Drupal\Core\Routing\RouteObjectInterface;
 use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
@@ -9,7 +10,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
-use function explode;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface as SymfonyRouteObjectInterface;
 use function sprintf;
 
 final class SymfonyCmfRouteObjectInterfaceConstantsRule implements Rule
@@ -38,11 +39,11 @@ final class SymfonyCmfRouteObjectInterfaceConstantsRule implements Rule
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }
-        [$major, $minor] = explode('.', \Drupal::VERSION, 3);
+        [$major, $minor] = explode('.', Drupal::VERSION, 3);
         if ($major !== '9' && (int) $minor > 1) {
             return [];
         }
-        $cmfRouteObjectInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteObjectInterface::class);
+        $cmfRouteObjectInterfaceType = new ObjectType(SymfonyRouteObjectInterface::class);
         if (!$classType->isSuperTypeOf($cmfRouteObjectInterfaceType)->yes()) {
             return [];
         }

--- a/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
@@ -9,6 +9,8 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use function explode;
+use function sprintf;
 
 final class SymfonyCmfRouteObjectInterfaceConstantsRule implements Rule
 {

--- a/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
@@ -10,6 +10,8 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use function explode;
+use function sprintf;
 
 final class SymfonyCmfRoutingInClassMethodSignatureRule implements Rule
 {

--- a/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Rules\Deprecations;
 
+use Drupal;
 use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
@@ -10,6 +11,9 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use Symfony\Cmf\Component\Routing\LazyRouteCollection;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use function explode;
 use function sprintf;
 
@@ -27,15 +31,15 @@ final class SymfonyCmfRoutingInClassMethodSignatureRule implements Rule
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }
-        [$major, $minor] = explode('.', \Drupal::VERSION, 3);
+        [$major, $minor] = explode('.', Drupal::VERSION, 3);
         if ($major !== '9' || (int) $minor < 1) {
             return [];
         }
         $method = $node->getMethodReflection();
 
-        $cmfRouteObjectInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteObjectInterface::class);
-        $cmfRouteProviderInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteProviderInterface::class);
-        $cmfLazyRouteCollectionType = new ObjectType(\Symfony\Cmf\Component\Routing\LazyRouteCollection::class);
+        $cmfRouteObjectInterfaceType = new ObjectType(RouteObjectInterface::class);
+        $cmfRouteProviderInterfaceType = new ObjectType(RouteProviderInterface::class);
+        $cmfLazyRouteCollectionType = new ObjectType(LazyRouteCollection::class);
 
         $methodSignature = ParametersAcceptorSelector::selectSingle($method->getVariants());
 

--- a/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
+++ b/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
@@ -6,6 +6,9 @@ use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use function in_array;
+use function sprintf;
+use function strtolower;
 
 /**
  * Based on Drupal_Sniffs_Functions_DiscouragedFunctionsSniff.

--- a/src/Rules/Drupal/LoadIncludeBase.php
+++ b/src/Rules/Drupal/LoadIncludeBase.php
@@ -6,6 +6,7 @@ use mglaman\PHPStanDrupal\Drupal\ExtensionMap;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
+use function count;
 
 abstract class LoadIncludeBase implements Rule
 {

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -7,6 +7,9 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use function count;
+use function is_file;
+use function sprintf;
 
 class LoadIncludes extends LoadIncludeBase
 {
@@ -27,7 +30,7 @@ class LoadIncludes extends LoadIncludeBase
             return [];
         }
         $args = $node->getArgs();
-        if (\count($args) < 2) {
+        if (count($args) < 2) {
             return [];
         }
         $type = $scope->getType($node->var);

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -7,6 +7,7 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use Throwable;
 use function count;
 use function is_file;
 use function sprintf;
@@ -75,7 +76,7 @@ class LoadIncludes extends LoadIncludeBase
                     ->line($node->getStartLine())
                     ->build()
             ];
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return [
                 RuleErrorBuilder::message(sprintf(
                     'A file could not be loaded from %s::loadInclude',

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -5,6 +5,9 @@ namespace mglaman\PHPStanDrupal\Rules\Drupal;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
+use function count;
+use function is_file;
+use function sprintf;
 
 /**
  * Handles module_load_include dynamic file loading.
@@ -31,7 +34,7 @@ class ModuleLoadInclude extends LoadIncludeBase
             return [];
         }
         $args = $node->getArgs();
-        if (\count($args) < 2) {
+        if (count($args) < 2) {
             return [];
         }
 

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -3,8 +3,10 @@
 namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
 use PhpParser\Node;
+use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
+use Throwable;
 use function count;
 use function is_file;
 use function sprintf;
@@ -26,7 +28,7 @@ class ModuleLoadInclude extends LoadIncludeBase
     public function processNode(Node $node, Scope $scope): array
     {
         assert($node instanceof Node\Expr\FuncCall);
-        if (!$node->name instanceof \PhpParser\Node\Name) {
+        if (!$node->name instanceof Name) {
             return [];
         }
         $name = (string) $node->name;
@@ -66,7 +68,7 @@ class ModuleLoadInclude extends LoadIncludeBase
                     ->line($node->getStartLine())
                     ->build()
             ];
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             return [
                 RuleErrorBuilder::message('A file could not be loaded from module_load_include')
                     ->line($node->getStartLine())

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -5,6 +5,7 @@ namespace mglaman\PHPStanDrupal\Rules\Drupal\PluginManager;
 use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\Type;
 use function array_map;
 use function count;
@@ -29,7 +30,7 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
         assert($node instanceof Node\Stmt\ClassMethod);
 
         if (!$scope->isInClass()) {
-            throw new \PHPStan\ShouldNotHappenException();
+            throw new ShouldNotHappenException();
         }
 
         if ($scope->isInTrait()) {

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -6,6 +6,10 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\Type;
+use function array_map;
+use function count;
+use function sprintf;
+use function strpos;
 
 class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
 {

--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -27,6 +27,14 @@ use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use PHPStan\Type\VerbosityLevel;
+use function array_map;
+use function array_merge;
+use function class_exists;
+use function count;
+use function explode;
+use function preg_match;
+use function sprintf;
+use function substr_count;
 
 final class RenderCallbackRule implements Rule
 {

--- a/src/Rules/Drupal/RequestStackGetMainRequestRule.php
+++ b/src/Rules/Drupal/RequestStackGetMainRequestRule.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
+use Drupal;
 use Drupal\Core\Http\RequestStack as DrupalRequestStack;
 use mglaman\PHPStanDrupal\Internal\DeprecatedScopeCheck;
 use PhpParser\Node;
@@ -27,7 +28,7 @@ final class RequestStackGetMainRequestRule implements Rule
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }
-        [$major, $minor] = explode('.', \Drupal::VERSION, 3);
+        [$major, $minor] = explode('.', Drupal::VERSION, 3);
         // Only valid for 9.3 -> 9.5. Deprecated in Drupal 10.
         if ($major !== '9' || (int) $minor < 3) {
             return [];

--- a/src/Rules/Drupal/RequestStackGetMainRequestRule.php
+++ b/src/Rules/Drupal/RequestStackGetMainRequestRule.php
@@ -10,6 +10,8 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use Symfony\Component\HttpFoundation\RequestStack as SymfonyRequestStack;
+use function explode;
+use function sprintf;
 
 final class RequestStackGetMainRequestRule implements Rule
 {

--- a/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
+++ b/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
@@ -10,6 +10,8 @@ use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPUnit\Framework\TestCase;
+use function in_array;
+use function sprintf;
 
 class TestClassesProtectedPropertyModulesRule implements Rule
 {

--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -8,6 +8,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
+use PHPUnit\Framework\Test;
 use function count;
 use function in_array;
 use function interface_exists;
@@ -24,7 +25,7 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!interface_exists(\PHPUnit\Framework\Test::class)) {
+        if (!interface_exists(Test::class)) {
             return [];
         }
         assert($node instanceof Node\Stmt\Class_);

--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -8,6 +8,11 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeCombinator;
+use function count;
+use function in_array;
+use function interface_exists;
+use function method_exists;
+use function substr_compare;
 
 final class BrowserTestBaseDefaultThemeRule implements Rule
 {

--- a/src/Type/ContainerDynamicReturnTypeExtension.php
+++ b/src/Type/ContainerDynamicReturnTypeExtension.php
@@ -13,6 +13,8 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use function count;
+use function in_array;
 
 class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/DrupalClassResolverDynamicReturnTypeExtension.php
+++ b/src/Type/DrupalClassResolverDynamicReturnTypeExtension.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use function count;
 
 class DrupalClassResolverDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -38,7 +39,7 @@ class DrupalClassResolverDynamicReturnTypeExtension implements DynamicMethodRetu
         MethodCall $methodCall,
         Scope $scope
     ): Type {
-        if (0 === \count($methodCall->getArgs())) {
+        if (0 === count($methodCall->getArgs())) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
 

--- a/src/Type/DrupalClassResolverDynamicStaticReturnTypeExtension.php
+++ b/src/Type/DrupalClassResolverDynamicStaticReturnTypeExtension.php
@@ -10,6 +10,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use function count;
 
 class DrupalClassResolverDynamicStaticReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
@@ -38,7 +39,7 @@ class DrupalClassResolverDynamicStaticReturnTypeExtension implements DynamicStat
         StaticCall $methodCall,
         Scope $scope
     ): Type {
-        if (0 === \count($methodCall->getArgs())) {
+        if (0 === count($methodCall->getArgs())) {
             return new ObjectType(ClassResolverInterface::class);
         }
 

--- a/src/Type/DrupalClassResolverDynamicStaticReturnTypeExtension.php
+++ b/src/Type/DrupalClassResolverDynamicStaticReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Type;
 
+use Drupal;
 use Drupal\Core\DependencyInjection\ClassResolverInterface;
 use mglaman\PHPStanDrupal\Drupal\ServiceMap;
 use PhpParser\Node\Expr\StaticCall;
@@ -26,7 +27,7 @@ class DrupalClassResolverDynamicStaticReturnTypeExtension implements DynamicStat
 
     public function getClass(): string
     {
-        return \Drupal::class;
+        return Drupal::class;
     }
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/DrupalClassResolverReturnType.php
+++ b/src/Type/DrupalClassResolverReturnType.php
@@ -12,6 +12,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use function count;
 
 final class DrupalClassResolverReturnType
 {

--- a/src/Type/DrupalStaticEntityQueryDynamicReturnTypeExtension.php
+++ b/src/Type/DrupalStaticEntityQueryDynamicReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Type;
 
+use Drupal;
 use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
 use Drupal\Core\Entity\ContentEntityStorageInterface;
 use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
@@ -31,7 +32,7 @@ class DrupalStaticEntityQueryDynamicReturnTypeExtension implements DynamicStatic
 
     public function getClass(): string
     {
-        return \Drupal::class;
+        return Drupal::class;
     }
 
     public function isStaticMethodSupported(MethodReflection $methodReflection): bool

--- a/src/Type/EntityAccessControlHandlerReturnTypeExtension.php
+++ b/src/Type/EntityAccessControlHandlerReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use function in_array;
 
 final class EntityAccessControlHandlerReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/EntityAccessControlHandlerReturnTypeExtension.php
+++ b/src/Type/EntityAccessControlHandlerReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Type\BooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use function count;
 use function in_array;
 
 final class EntityAccessControlHandlerReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -32,13 +33,13 @@ final class EntityAccessControlHandlerReturnTypeExtension implements DynamicMeth
 
         $args = $methodCall->getArgs();
         $arg = null;
-        if ($methodReflection->getName() === 'access' && \count($args) === 4) {
+        if ($methodReflection->getName() === 'access' && count($args) === 4) {
             $arg = $args[3];
         }
-        if ($methodReflection->getName() === 'createAccess' && \count($args) === 4) {
+        if ($methodReflection->getName() === 'createAccess' && count($args) === 4) {
             $arg = $args[3];
         }
-        if ($methodReflection->getName() === 'fieldAccess' && \count($args) === 5) {
+        if ($methodReflection->getName() === 'fieldAccess' && count($args) === 5) {
             $arg = $args[4];
         }
 

--- a/src/Type/EntityQuery/EntityQueryDynamicReturnTypeExtension.php
+++ b/src/Type/EntityQuery/EntityQueryDynamicReturnTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use function in_array;
 
 class EntityQueryDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/EntityQuery/EntityQueryType.php
+++ b/src/Type/EntityQuery/EntityQueryType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace mglaman\PHPStanDrupal\Type\EntityQuery;
 
 use PHPStan\Type\ObjectType;
+use function implode;
 
 class EntityQueryType extends ObjectType
 {

--- a/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
@@ -15,6 +15,7 @@ use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
+use function in_array;
 
 class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -36,7 +37,7 @@ class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return \in_array(
+        return in_array(
             $methodReflection->getName(),
             [
                 'create',
@@ -72,11 +73,11 @@ class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
         if ($type === null) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         }
-        if (\in_array($methodReflection->getName(), ['load', 'loadUnchanged'], true)) {
+        if (in_array($methodReflection->getName(), ['load', 'loadUnchanged'], true)) {
             return TypeCombinator::addNull($type);
         }
 
-        if (\in_array($methodReflection->getName(), ['loadMultiple', 'loadByProperties'], true)) {
+        if (in_array($methodReflection->getName(), ['loadMultiple', 'loadByProperties'], true)) {
             if ((new ObjectType(ConfigEntityStorageInterface::class))->isSuperTypeOf($callerType)->yes()) {
                 return new ArrayType(new StringType(), $type);
             }

--- a/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function in_array;
 
@@ -54,7 +55,7 @@ class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): \PHPStan\Type\Type {
+    ): Type {
         $callerType = $scope->getType($methodCall->var);
         if (!$callerType instanceof ObjectType) {
             return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();

--- a/src/Type/EntityStorage/GetQueryReturnTypeExtension.php
+++ b/src/Type/EntityStorage/GetQueryReturnTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use function in_array;
 
 final class GetQueryReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {

--- a/src/Type/EntityStorage/GetQueryReturnTypeExtension.php
+++ b/src/Type/EntityStorage/GetQueryReturnTypeExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 use function in_array;
 
 final class GetQueryReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -36,7 +37,7 @@ final class GetQueryReturnTypeExtension implements DynamicMethodReturnTypeExtens
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): \PHPStan\Type\Type {
+    ): Type {
         $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         if (!$returnType instanceof ObjectType) {
             return $returnType;

--- a/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
 
 class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -46,7 +47,7 @@ class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMe
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): \PHPStan\Type\Type {
+    ): Type {
         $returnType = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
         if (!isset($methodCall->args[0])) {
             // Parameter is required.


### PR DESCRIPTION
Modern php has several optimizations it can apply to global functions at compile-time, but only when they are fully-qualified.

For example it can [translate](https://php.watch/articles/php-zend-engine-special-inlined-functions) several functions into specific opcodes which are faster than their function equivalent.

It can also do [compile-time evaluation](https://github.com/php/php-src/blob/43b62b7007adcf194abe549ccb64a6977bfd5c4e/ext/standard/basic_functions.stub.php#L1596-L1597) of constant operands for several functions.

Additionally, fully-qualifying global functions avoids a local namespace lookup and as such makes calls faster in general. The improvement will be pretty minor but every little helps, especially in situations where these functions may be called thousands of times in a single analysis.

