### PR TITLE
Add implements generics to all Rule implementations and remove associated assert() calls.

### DIFF
--- a/src/Rules/Classes/ClassExtendsInternalClassRule.php
+++ b/src/Rules/Classes/ClassExtendsInternalClassRule.php
@@ -11,6 +11,9 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function sprintf;
 
+/**
+ * @implements Rule<Class_>
+ */
 class ClassExtendsInternalClassRule implements Rule
 {
     /**
@@ -30,7 +33,6 @@ class ClassExtendsInternalClassRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        /** @var Class_ $node */
         if (!isset($node->extends)) {
             return [];
         }

--- a/src/Rules/Deprecations/AccessDeprecatedConstant.php
+++ b/src/Rules/Deprecations/AccessDeprecatedConstant.php
@@ -12,6 +12,9 @@ use function array_merge;
 use function explode;
 use function sprintf;
 
+/**
+ * @implements Rule<Node\Expr\ConstFetch>
+ */
 class AccessDeprecatedConstant implements Rule
 {
     /** @var ReflectionProvider */
@@ -28,7 +31,6 @@ class AccessDeprecatedConstant implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\ConstFetch);
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }

--- a/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
+++ b/src/Rules/Deprecations/ConditionManagerCreateInstanceContextConfigurationRule.php
@@ -12,6 +12,9 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\ObjectType;
 use function count;
 
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
 final class ConditionManagerCreateInstanceContextConfigurationRule implements Rule
 {
     public function getNodeType(): string
@@ -21,7 +24,6 @@ final class ConditionManagerCreateInstanceContextConfigurationRule implements Ru
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\MethodCall);
         if (!$node->name instanceof Node\Identifier) {
             return [];
         }

--- a/src/Rules/Deprecations/DeprecatedAnnotationsRuleBase.php
+++ b/src/Rules/Deprecations/DeprecatedAnnotationsRuleBase.php
@@ -8,6 +8,9 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 
+/**
+ * @implements Rule<Node\Stmt\Class_>
+ */
 abstract class DeprecatedAnnotationsRuleBase implements Rule
 {
 
@@ -36,7 +39,6 @@ abstract class DeprecatedAnnotationsRuleBase implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Stmt\Class_);
         if ($node->extends === null) {
             return [];
         }

--- a/src/Rules/Deprecations/DeprecatedHookImplementation.php
+++ b/src/Rules/Deprecations/DeprecatedHookImplementation.php
@@ -14,6 +14,9 @@ use function explode;
 use function strlen;
 use function substr_replace;
 
+/**
+ * @implements Rule<Function_>
+ */
 class DeprecatedHookImplementation implements Rule
 {
 
@@ -31,7 +34,6 @@ class DeprecatedHookImplementation implements Rule
 
     public function processNode(Node $node, Scope $scope) : array
     {
-        assert($node instanceof Function_);
         if (!str_ends_with($scope->getFile(), ".module") && !str_ends_with($scope->getFile(), ".inc")) {
             return [];
         }

--- a/src/Rules/Deprecations/GetDeprecatedServiceRule.php
+++ b/src/Rules/Deprecations/GetDeprecatedServiceRule.php
@@ -8,6 +8,9 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
 final class GetDeprecatedServiceRule implements Rule
 {
 
@@ -28,7 +31,6 @@ final class GetDeprecatedServiceRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\MethodCall);
         if (!$node->name instanceof Node\Identifier) {
             return [];
         }

--- a/src/Rules/Deprecations/StaticServiceDeprecatedServiceRule.php
+++ b/src/Rules/Deprecations/StaticServiceDeprecatedServiceRule.php
@@ -8,6 +8,9 @@ use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 
+/**
+ * @implements Rule<Node\Expr\StaticCall>
+ */
 final class StaticServiceDeprecatedServiceRule implements Rule
 {
 
@@ -28,7 +31,6 @@ final class StaticServiceDeprecatedServiceRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\StaticCall);
         if (!$node->name instanceof Node\Identifier) {
             return [];
         }

--- a/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRouteObjectInterfaceConstantsRule.php
@@ -13,6 +13,9 @@ use PHPStan\Type\ObjectType;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface as SymfonyRouteObjectInterface;
 use function sprintf;
 
+/**
+ * @implements Rule<Node\Expr\ClassConstFetch>
+ */
 final class SymfonyCmfRouteObjectInterfaceConstantsRule implements Rule
 {
 
@@ -23,7 +26,6 @@ final class SymfonyCmfRouteObjectInterfaceConstantsRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\ClassConstFetch);
         if (!$node->name instanceof Node\Identifier) {
             return [];
         }

--- a/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
+++ b/src/Rules/Deprecations/SymfonyCmfRoutingInClassMethodSignatureRule.php
@@ -17,6 +17,9 @@ use Symfony\Cmf\Component\Routing\RouteProviderInterface;
 use function explode;
 use function sprintf;
 
+/**
+ * @implements Rule<InClassMethodNode>
+ */
 final class SymfonyCmfRoutingInClassMethodSignatureRule implements Rule
 {
 
@@ -27,7 +30,6 @@ final class SymfonyCmfRoutingInClassMethodSignatureRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof InClassMethodNode);
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }

--- a/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
+++ b/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
@@ -12,6 +12,8 @@ use function strtolower;
 
 /**
  * Based on Drupal_Sniffs_Functions_DiscouragedFunctionsSniff.
+ *
+ * @implements Rule<FuncCall>
  */
 class DiscouragedFunctionsRule implements Rule
 {
@@ -22,8 +24,6 @@ class DiscouragedFunctionsRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof FuncCall);
-
         if (!($node->name instanceof Node\Name)) {
             return [];
         }

--- a/src/Rules/Drupal/EntityQuery/EntityQueryHasAccessCheckRule.php
+++ b/src/Rules/Drupal/EntityQuery/EntityQueryHasAccessCheckRule.php
@@ -12,6 +12,9 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
 final class EntityQueryHasAccessCheckRule implements Rule
 {
     public function getNodeType(): string
@@ -21,10 +24,6 @@ final class EntityQueryHasAccessCheckRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node instanceof Node\Expr\MethodCall) {
-            return [];
-        }
-
         $name = $node->name;
         if (!$name instanceof Node\Identifier) {
             return [];

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -7,6 +7,9 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Rules\Rule;
 
+/**
+ * @implements Rule<Node\Expr\StaticCall>
+ */
 class GlobalDrupalDependencyInjectionRule implements Rule
 {
     public function getNodeType(): string
@@ -16,8 +19,6 @@ class GlobalDrupalDependencyInjectionRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\StaticCall);
-
         // Only check static calls to \Drupal
         if (!($node->class instanceof Node\Name\FullyQualified) || (string) $node->class !== 'Drupal') {
             return [];

--- a/src/Rules/Drupal/LoadIncludeBase.php
+++ b/src/Rules/Drupal/LoadIncludeBase.php
@@ -8,6 +8,10 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use function count;
 
+/**
+ * @template TNodeType of Node
+ * @implements Rule<TNodeType>
+ */
 abstract class LoadIncludeBase implements Rule
 {
 

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -12,6 +12,9 @@ use function count;
 use function is_file;
 use function sprintf;
 
+/**
+ * @extends LoadIncludeBase<Node\Expr\MethodCall>
+ */
 class LoadIncludes extends LoadIncludeBase
 {
 
@@ -22,7 +25,6 @@ class LoadIncludes extends LoadIncludeBase
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\MethodCall);
         if (!$node->name instanceof Node\Identifier) {
             return [];
         }

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -16,6 +16,8 @@ use function sprintf;
  *
  * @note may become deprecated and removed in D10
  * @see https://www.drupal.org/project/drupal/issues/697946
+ *
+ * @extends LoadIncludeBase<Node\Expr\FuncCall>
  */
 class ModuleLoadInclude extends LoadIncludeBase
 {
@@ -27,7 +29,6 @@ class ModuleLoadInclude extends LoadIncludeBase
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\FuncCall);
         if (!$node->name instanceof Name) {
             return [];
         }

--- a/src/Rules/Drupal/PluginManager/AbstractPluginManagerRule.php
+++ b/src/Rules/Drupal/PluginManager/AbstractPluginManagerRule.php
@@ -6,7 +6,8 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 
 /**
- * @phpstan-template TNodeType of \PhpParser\Node
+ * @template TNodeType of \PhpParser\Node
+ * @implements Rule<TNodeType>
  */
 abstract class AbstractPluginManagerRule implements Rule
 {

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -12,6 +12,9 @@ use function count;
 use function sprintf;
 use function strpos;
 
+/**
+ * @extends AbstractPluginManagerRule<ClassMethod>
+ */
 class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
 {
     public function getNodeType(): string
@@ -19,16 +22,8 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
         return ClassMethod::class;
     }
 
-    /**
-     * @param Node $node
-     * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
-     * @throws \PHPStan\ShouldNotHappenException
-     */
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Stmt\ClassMethod);
-
         if (!$scope->isInClass()) {
             throw new ShouldNotHappenException();
         }

--- a/src/Rules/Drupal/RenderCallbackRule.php
+++ b/src/Rules/Drupal/RenderCallbackRule.php
@@ -36,6 +36,9 @@ use function preg_match;
 use function sprintf;
 use function substr_count;
 
+/**
+ * @implements Rule<Node\Expr\ArrayItem>
+ */
 final class RenderCallbackRule implements Rule
 {
 
@@ -65,7 +68,6 @@ final class RenderCallbackRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\ArrayItem);
         $key = $node->key;
         if (!$key instanceof Node\Scalar\String_) {
             return [];

--- a/src/Rules/Drupal/RequestStackGetMainRequestRule.php
+++ b/src/Rules/Drupal/RequestStackGetMainRequestRule.php
@@ -14,6 +14,9 @@ use Symfony\Component\HttpFoundation\RequestStack as SymfonyRequestStack;
 use function explode;
 use function sprintf;
 
+/**
+ * @implements Rule<Node\Expr\MethodCall>
+ */
 final class RequestStackGetMainRequestRule implements Rule
 {
 
@@ -24,7 +27,6 @@ final class RequestStackGetMainRequestRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof Node\Expr\MethodCall);
         if (DeprecatedScopeCheck::inDeprecatedScope($scope)) {
             return [];
         }

--- a/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
+++ b/src/Rules/Drupal/TestClassesProtectedPropertyModulesRule.php
@@ -13,6 +13,9 @@ use PHPUnit\Framework\TestCase;
 use function in_array;
 use function sprintf;
 
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
 class TestClassesProtectedPropertyModulesRule implements Rule
 {
 
@@ -26,8 +29,6 @@ class TestClassesProtectedPropertyModulesRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof ClassPropertyNode);
-
         if ($node->getName() !== 'modules') {
             return [];
         }

--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -15,6 +15,9 @@ use function interface_exists;
 use function method_exists;
 use function substr_compare;
 
+/**
+ * @implements Rule<Node\Stmt\Class_>
+ */
 final class BrowserTestBaseDefaultThemeRule implements Rule
 {
 
@@ -28,7 +31,6 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
         if (!interface_exists(Test::class)) {
             return [];
         }
-        assert($node instanceof Node\Stmt\Class_);
         if ($node->extends === null) {
             return [];
         }


### PR DESCRIPTION
This change allows phpstan to statically verify that the rules work correctly without having to get `assert()` involved, as `assert()` is a finicky beast whose implications can change based on the php configuration of the system it is run on. 