### PR TITLE
Add DependencySerializationTraitPropertyRule

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -21,6 +21,7 @@ parameters:
 			checkDeprecatedHooksInApiFiles: false
 		rules:
 			testClassSuffixNameRule: false
+			dependencySerializationTraitPropertyRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -242,6 +243,7 @@ parametersSchema:
 		])
 		rules: structure([
 			testClassSuffixNameRule: boolean()
+			dependencySerializationTraitPropertyRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/rules.neon
+++ b/rules.neon
@@ -23,7 +23,11 @@ rules:
 conditionalTags:
 	mglaman\PHPStanDrupal\Rules\Drupal\Tests\TestClassSuffixNameRule:
 		phpstan.rules.rule: %drupal.rules.testClassSuffixNameRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule:
+		phpstan.rules.rule: %drupal.rules.dependencySerializationTraitPropertyRule%
 
 services:
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\Tests\TestClassSuffixNameRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule

--- a/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
+++ b/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal\Coder;
+
+use Drupal\Core\Form\FormInterface;
+use PhpParser\Node;
+use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+final class FormNoPrivatePropertiesRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return ClassPropertyNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node instanceof ClassPropertyNode
+            || !$node->getClassReflection()->implementsInterface(FormInterface::class)) {
+            return [];
+        }
+
+        if ($node->isPrivate()) {
+            return [
+                RuleErrorBuilder::message(
+                    'Private properties are note allowed on FormInterface classes due to seralisation.'
+                )->tip('See https://www.drupal.org/node/3110266')->build(),
+            ];
+        }
+        if ($node->isReadOnly()) {
+            return [
+                RuleErrorBuilder::message(
+                    'Private properties are note allowed on FormInterface classes due to seralisation.'
+                )->tip('See https://www.drupal.org/node/3110266')->build(),
+            ];
+        }
+
+        return [];
+    }
+
+}

--- a/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
+++ b/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Rules\Drupal\Coder;
 
@@ -9,6 +11,9 @@ use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
+/**
+ * @implements Rule<ClassPropertyNode>
+ */
 final class FormNoPrivatePropertiesRule implements Rule
 {
 
@@ -19,26 +24,21 @@ final class FormNoPrivatePropertiesRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node instanceof ClassPropertyNode
-            || !$node->getClassReflection()->implementsInterface(FormInterface::class)) {
+        if (!$node->getClassReflection()->implementsInterface(FormInterface::class)) {
             return [];
         }
 
+        $errors = [];
         if ($node->isPrivate()) {
-            return [
-                RuleErrorBuilder::message(
-                    'Private properties are note allowed on FormInterface classes due to seralisation.'
-                )->tip('See https://www.drupal.org/node/3110266')->build(),
-            ];
+            $errors[] = RuleErrorBuilder::message(
+                'Private properties are not allowed on FormInterface classes due to serialisation.'
+            )->tip('See https://www.drupal.org/node/3110266')->build();
         }
         if ($node->isReadOnly()) {
-            return [
-                RuleErrorBuilder::message(
-                    'Private properties are note allowed on FormInterface classes due to seralisation.'
-                )->tip('See https://www.drupal.org/node/3110266')->build(),
-            ];
+            $errors[] = RuleErrorBuilder::message(
+                'Read only properties are not allowed on FormInterface classes due to serialisation.'
+            )->tip('See https://www.drupal.org/node/3110266')->build();
         }
-
-        return [];
+        return $errors;
     }
 }

--- a/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
+++ b/src/Rules/Drupal/Coder/FormNoPrivatePropertiesRule.php
@@ -4,8 +4,8 @@ namespace mglaman\PHPStanDrupal\Rules\Drupal\Coder;
 
 use Drupal\Core\Form\FormInterface;
 use PhpParser\Node;
-use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassPropertyNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -41,5 +41,4 @@ final class FormNoPrivatePropertiesRule implements Rule
 
         return [];
     }
-
 }

--- a/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
+++ b/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
@@ -32,7 +32,7 @@ final class DependencySerializationTraitPropertyRule implements Rule
         if ($node->isPrivate()) {
             $errors[] = RuleErrorBuilder::message(
                 sprintf(
-                    'Private properties cannot be serialized with %s.',
+                    '%s does not support private properties.',
                     DependencySerializationTrait::class
                 )
             )->tip('See https://www.drupal.org/node/3110266')->build();
@@ -40,7 +40,7 @@ final class DependencySerializationTraitPropertyRule implements Rule
         if ($node->isReadOnly()) {
             $errors[] = RuleErrorBuilder::message(
                 sprintf(
-                    'Read only properties cannot be serialized with %s.',
+                    'Read-only properties are incompatible with %s.',
                     DependencySerializationTrait::class
                 )
             )->tip('See https://www.drupal.org/node/3110266')->build();

--- a/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
+++ b/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace mglaman\PHPStanDrupal\Rules\Drupal\Coder;
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
-use Drupal\Core\Form\FormInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertyNode;
@@ -14,7 +14,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<ClassPropertyNode>
  */
-final class FormNoPrivatePropertiesRule implements Rule
+final class DependencySerializationTraitPropertyRule implements Rule
 {
 
     public function getNodeType(): string
@@ -24,19 +24,25 @@ final class FormNoPrivatePropertiesRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->getClassReflection()->implementsInterface(FormInterface::class)) {
+        if (!$node->getClassReflection()->hasTraitUse(DependencySerializationTrait::class)) {
             return [];
         }
 
         $errors = [];
         if ($node->isPrivate()) {
             $errors[] = RuleErrorBuilder::message(
-                'Private properties are not allowed on FormInterface classes due to serialisation.'
+                sprintf(
+                    'Private properties cannot be serialized with %s.',
+                    DependencySerializationTrait::class
+                )
             )->tip('See https://www.drupal.org/node/3110266')->build();
         }
         if ($node->isReadOnly()) {
             $errors[] = RuleErrorBuilder::message(
-                'Read only properties are not allowed on FormInterface classes due to serialisation.'
+                sprintf(
+                    'Read only properties cannot be serialized with %s.',
+                    DependencySerializationTrait::class
+                )
             )->tip('See https://www.drupal.org/node/3110266')->build();
         }
         return $errors;

--- a/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
+++ b/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
@@ -20,27 +20,27 @@ final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestC
             [__DIR__.'/data/dependency-serialization-trait.php'],
             [
                 [
-                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
                     16,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
                     22,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read only properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
                     22,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read only properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
                     28,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
                     32,
                     'See https://www.drupal.org/node/3110266',
                 ],

--- a/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
+++ b/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new DependencySerializationTraitPropertyRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__.'/data/dependency-serialization-trait.php'],
+            [
+                [
+                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    16,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    22,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Read only properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    22,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Read only properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    28,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Private properties cannot be serialized with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
+                    32,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/src/Rules/data/dependency-serialization-trait.php
+++ b/tests/src/Rules/data/dependency-serialization-trait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DependencySerialization;
+
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBase;
+
+class Foo {
+    private EntityTypeManagerInterface $entityTypeManager;
+}
+
+class Bar {
+    use DependencySerializationTrait;
+
+    private EntityTypeManagerInterface $entityTypeManager;
+}
+
+class Baz {
+    use DependencySerializationTrait;
+
+    private readonly EntityTypeManagerInterface $entityTypeManager;
+}
+
+class Qux {
+    use DependencySerializationTrait;
+
+    protected readonly EntityTypeManagerInterface $entityTypeManager;
+}
+
+class FooForm extends FormBase {
+    private EntityTypeManagerInterface $entityTypeManager;
+}


### PR DESCRIPTION
Adds a check for all FormInterface implementing classes that private variables are no longer allowed
See #730 for context and discussion 

Fixes #730 