### PR TITLE
Allow services.yml to contain custom tags

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -182,7 +182,7 @@ class DrupalAutoloader
         }
 
         foreach ($this->serviceYamls as $extension => $serviceYaml) {
-            $yaml = Yaml::parseFile($serviceYaml);
+            $yaml = Yaml::parseFile($serviceYaml, Yaml::PARSE_CUSTOM_TAGS);
             // Weed out service files which only provide parameters.
             if (!isset($yaml['services']) || !is_array($yaml['services'])) {
                 continue;


### PR DESCRIPTION
Drupal now allows services.yml to contain YAML tags such as `!tagged_iterator`:

https://www.drupal.org/project/drupal/issues/3414208
https://www.drupal.org/node/3436859

This however crashes the DrupalAutoloader code:

https://git.drupalcode.org/project/drupal/-/jobs/1217562

`Symfony\Component\Yaml\Exception\ParseException thrown in /builds/project/drupal/vendor/symfony/yaml/Inline.php on line 775 while loading bootstrap file /builds/project/drupal/vendor/mglaman/phpstan-drupal/drupal-autoloader.php: Tags support is not enabled. Enable the "Yaml::PARSE_CUSTOM_TAGS" flag to use "!tagged_iterator" at line 635 (near "arguments: [!tagged_iterator module_install.uninstall_validator]").`
