### PR TITLE
Seperate core and contrib api files

### DIFF
--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -1,7 +1,7 @@
 parameters:
 	drupal:
 		bleedingEdge:
-			checkDeprecatedHooksInApiFiles: true
+			checkDeprecatedHooksInApiFiles: false
 			checkCoreDeprecatedHooksInApiFiles: true
 			checkContribDeprecatedHooksInApiFiles: true
 		rules:

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -2,7 +2,7 @@ parameters:
 	drupal:
 		bleedingEdge:
 			checkDeprecatedHooksInApiFiles: true
-			checkCoreDeprecatedHooksInApiFiles: false
+			checkCoreDeprecatedHooksInApiFiles: true
 			checkContribDeprecatedHooksInApiFiles: false
 		rules:
 			testClassSuffixNameRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -2,7 +2,7 @@ parameters:
 	drupal:
 		bleedingEdge:
 			checkDeprecatedHooksInApiFiles: true
-			checkCoreDeprecatedHooksInApiFiles: true
+			checkCoreDeprecatedHooksInApiFiles: false
 			checkContribDeprecatedHooksInApiFiles: false
 		rules:
 			testClassSuffixNameRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -2,6 +2,8 @@ parameters:
 	drupal:
 		bleedingEdge:
 			checkDeprecatedHooksInApiFiles: true
+			checkCoreDeprecatedHooksInApiFiles: false
+			checkContribDeprecatedHooksInApiFiles: false
 		rules:
 			testClassSuffixNameRule: true
 			dependencySerializationTraitPropertyRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -2,8 +2,8 @@ parameters:
 	drupal:
 		bleedingEdge:
 			checkDeprecatedHooksInApiFiles: true
-			checkCoreDeprecatedHooksInApiFiles: false
-			checkContribDeprecatedHooksInApiFiles: false
+			checkCoreDeprecatedHooksInApiFiles: true
+			checkContribDeprecatedHooksInApiFiles: true
 		rules:
 			testClassSuffixNameRule: true
 			dependencySerializationTraitPropertyRule: true

--- a/extension.neon
+++ b/extension.neon
@@ -19,6 +19,8 @@ parameters:
 		drupal_root: '%currentWorkingDirectory%'
 		bleedingEdge:
 			checkDeprecatedHooksInApiFiles: false
+			checkCoreDeprecatedHooksInApiFiles: false
+			checkContribDeprecatedHooksInApiFiles: false
 		rules:
 			testClassSuffixNameRule: false
 			dependencySerializationTraitPropertyRule: false

--- a/extension.neon
+++ b/extension.neon
@@ -242,6 +242,8 @@ parametersSchema:
 		drupal_root: string()
 		bleedingEdge: structure([
 			checkDeprecatedHooksInApiFiles: boolean()
+			checkCoreDeprecatedHooksInApiFiles: boolean()
+			checkContribDeprecatedHooksInApiFiles: boolean()
 		])
 		rules: structure([
 			testClassSuffixNameRule: boolean()

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -84,7 +84,7 @@ class DrupalAutoloader
     public function register(Container $container): void
     {
         /**
-         * @var array{drupal_root: string, bleedingEdge: array{checkDeprecatedHooksInApiFiles: bool}} $drupalParams
+         * @var array{drupal_root: string, bleedingEdge: array{checkDeprecatedHooksInApiFiles: bool, checkCoreDeprecatedHooksInApiFiles: bool, checkContribDeprecatedHooksInApiFiles: bool}} $drupalParams
          */
         $drupalParams = $container->getParameter('drupal');
         $drupalRoot = realpath($drupalParams['drupal_root']);

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -127,7 +127,14 @@ class DrupalAutoloader
         $this->addThemeNamespaces();
         $this->registerPs4Namespaces($this->namespaces);
         $this->loadLegacyIncludes();
-        $checkDeprecatedHooksInApiFiles =  $drupalParams['bleedingEdge']['checkDeprecatedHooksInApiFiles'];
+
+        // Trigger deprecation error if checkDeprecatedHooksInApiFiles is enabled.
+        if ($drupalParams['bleedingEdge']['checkDeprecatedHooksInApiFiles']) {
+            trigger_error('The bleedingEdge.checkDeprecatedHooksInApiFiles parameter is deprecated and will be removed in a future release.', E_USER_DEPRECATED);
+        }
+        $checkDeprecatedHooksInApiFiles = $drupalParams['bleedingEdge']['checkDeprecatedHooksInApiFiles'];
+        $checkCoreDeprecatedHooksInApiFiles = $drupalParams['bleedingEdge']['checkCoreDeprecatedHooksInApiFiles'] || $checkDeprecatedHooksInApiFiles;
+        $checkContribDeprecatedHooksInApiFiles = $drupalParams['bleedingEdge']['checkContribDeprecatedHooksInApiFiles'] || $checkDeprecatedHooksInApiFiles;
 
         foreach ($this->moduleData as $extension) {
             $this->loadExtension($extension);

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -152,8 +152,13 @@ class DrupalAutoloader
             if (file_exists($module_dir . '/' . $module_name . '.post_update.php')) {
                 $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.post_update.php');
             }
-            // Add .api.php
-            if ($checkDeprecatedHooksInApiFiles && file_exists($module_dir . '/' . $module_name . '.api.php')) {
+
+            // Add .api.php for core modules
+            if ($checkCoreDeprecatedHooksInApiFiles && str_starts_with($extension->getPath(), 'core/') && file_exists($module_dir . '/' . $module_name . '.api.php')) {
+                $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.api.php');
+            }
+            // Add .api.php for contrib modules
+            if ($checkContribDeprecatedHooksInApiFiles && str_starts_with($extension->getPath(), 'core/') === false && file_exists($module_dir . '/' . $module_name . '.api.php')) {
                 $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.api.php');
             }
             // Add misc .inc that are magically allowed via hook_hook_info.

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -154,11 +154,11 @@ class DrupalAutoloader
             }
 
             // Add .api.php for core modules
-            if ($checkCoreDeprecatedHooksInApiFiles && str_starts_with($extension->getPath(), 'core/') && file_exists($module_dir . '/' . $module_name . '.api.php')) {
+            if ($checkCoreDeprecatedHooksInApiFiles && $extension->origin === 'core' && file_exists($module_dir . '/' . $module_name . '.api.php')) {
                 $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.api.php');
             }
             // Add .api.php for contrib modules
-            if ($checkContribDeprecatedHooksInApiFiles && str_starts_with($extension->getPath(), 'core/') === false && file_exists($module_dir . '/' . $module_name . '.api.php')) {
+            if ($checkContribDeprecatedHooksInApiFiles && $extension->origin !== 'core' && file_exists($module_dir . '/' . $module_name . '.api.php')) {
                 $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.api.php');
             }
             // Add misc .inc that are magically allowed via hook_hook_info.


### PR DESCRIPTION
Fixes #770

1. Added new options to bleeding edge. Current behaviour is the same.
2. Trigger deprecation notice when using old parameter, did not add a version since i dont know when it will be removed
3. Added defaults as per related issue. Behaviour is the same, but can be specified.
4. Wanted to add a test for a core module, but not sure how so i didnt.