### PR TITLE
Fixed TypeError.

### DIFF
--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -55,6 +55,9 @@ class ServiceMap
             );
             $deprecated = $serviceDefinition['deprecated'] ?? null;
             if ($deprecated) {
+                if (is_array($deprecated) && !empty($deprecated['message'])) {
+                    $deprecated = $deprecated['message'];
+                }
                 self::$services[$serviceId]->setDeprecated(true, $deprecated);
             }
         }


### PR DESCRIPTION
When running phpstan, I was getting 
`TypeError thrown in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalServiceDefinition.php on line 55 while loading bootstrap file /var/www/html/vendor/mglaman/phpstan-drupal/drupal-autoloader.php: mglaman\PHPStanDrupal\Drupal\DrupalServiceDefinition::setDeprecated(): Argument #2 ($template) must be of type ?string, array given, called in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/ServiceMap.php on line 63`
