### PR TITLE
Fixing TypeError and deprecated message

### DIFF
--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -55,6 +55,9 @@ class ServiceMap
             );
             $deprecated = $serviceDefinition['deprecated'] ?? null;
             if ($deprecated) {
+                if (is_array($deprecated) && !empty($deprecated['message'])) {
+                    $deprecated = $deprecated['message'];
+                }
                 self::$services[$serviceId]->setDeprecated(true, $deprecated);
             }
         }

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -58,6 +58,10 @@ class ServiceMap
                 if (is_array($deprecated) && isset($deprecated['message'])) {
                     $deprecated = $deprecated['message'];
                 }
+                $deprecated = str_replace('%service_id%', $serviceId, $deprecated);
+                if (isset($serviceDefinition['alias'])) {
+                    $deprecated = str_replace('%alias_id%', $serviceDefinition['alias'], $deprecated);
+                }
                 self::$services[$serviceId]->setDeprecated(true, $deprecated);
             }
         }

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -55,7 +55,7 @@ class ServiceMap
             );
             $deprecated = $serviceDefinition['deprecated'] ?? null;
             if ($deprecated) {
-                if (is_array($deprecated) && !empty($deprecated['message'])) {
+                if (is_array($deprecated) && isset($deprecated['message'])) {
                     $deprecated = $deprecated['message'];
                 }
                 self::$services[$serviceId]->setDeprecated(true, $deprecated);


### PR DESCRIPTION
When running phpstan, I was getting
TypeError thrown in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/DrupalServiceDefinition.php on line 55 while loading bootstrap file /var/www/html/vendor/mglaman/phpstan-drupal/drupal-autoloader.php: mglaman\PHPStanDrupal\Drupal\DrupalServiceDefinition::setDeprecated(): Argument #2 ($template) must be of type ?string, array given, called in /var/www/html/vendor/mglaman/phpstan-drupal/src/Drupal/ServiceMap.php on line 63

Also, the deprecated message is not too helpful:
  "deprecated" => "The "%service_id%" service is deprecated in drupal:9.0.0 and is removed from drupal:20.0.0. This is a test."

This would be replaced by Symfony's dependecy-injection Definition class. As phpstan pulls them directly from the yaml file, we should do the replacement. 