### PR TITLE
Add new class to exclusion [#780]

### DIFF
--- a/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
+++ b/src/Rules/Drupal/Tests/BrowserTestBaseDefaultThemeRule.php
@@ -71,6 +71,7 @@ final class BrowserTestBaseDefaultThemeRule implements Rule
 
         $excludedTestTypes = TypeCombinator::union(
             new ObjectType('Drupal\\FunctionalTests\\Update\\UpdatePathTestBase'),
+            new ObjectType('Drupal\\FunctionalTests\\Installer\\InstallerConfigDirectoryTestBase'),
             new ObjectType('Drupal\\FunctionalTests\\Installer\\InstallerExistingConfigTestBase')
         );
         if ($excludedTestTypes->isSuperTypeOf($classType)->yes()) {


### PR DESCRIPTION
This should include the exclusion for the new class to match the now deprecated InstallerExistingConfigTestBase.

- fixes #780