### PR TITLE
Introduce identifier error formatter

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -264,6 +264,8 @@ parametersSchema:
 		))
 	])
 services:
+	errorFormatter.identifier_baseline:
+		class: mglaman\PHPStanDrupal\Command\ErrorFormatter\IdentifierIgnoreErrorFormatter
 	-
 		class: mglaman\PHPStanDrupal\Drupal\ServiceMap
 	-

--- a/src/Command/ErrorFormatter/IdentifierIgnoreErrorFormatter.php
+++ b/src/Command/ErrorFormatter/IdentifierIgnoreErrorFormatter.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Command\ErrorFormatter;
+
+use PHPStan\Command\AnalysisResult;
+use PHPStan\Command\Output;
+use PHPStan\File\RelativePathHelper;
+
+/**
+ * A PHP baseline error formatter that ignores by identifier instead of message.
+ */
+final class IdentifierIgnoreErrorFormatter {
+
+    public function __construct(private RelativePathHelper $relativePathHelper) {}
+
+    public function formatErrors(
+        AnalysisResult $analysisResult,
+        Output $output,
+    ): int {
+        if (!$analysisResult->hasErrors()) {
+            $php = '<?php declare(strict_types = 1);';
+            $php .= "\n\n";
+            $php .= 'return [];';
+            $php .= "\n";
+            $output->writeRaw($php);
+            return 0;
+        }
+
+        $fileErrors = [];
+        foreach ($analysisResult->getFileSpecificErrors() as $fileSpecificError) {
+            if (!$fileSpecificError->canBeIgnored()) {
+                continue;
+            }
+            $fileErrors['/' . $this->relativePathHelper->getRelativePath($fileSpecificError->getFilePath())][] = $fileSpecificError;
+        }
+        ksort($fileErrors, SORT_STRING);
+
+        $php = '<?php declare(strict_types = 1);';
+        $php .= "\n\n";
+        $php .= '$ignoreErrors = [];';
+        $php .= "\n";
+        foreach ($fileErrors as $file => $errors) {
+            $fileErrorsByString = [];
+            foreach ($errors as $error) {
+                $string = $error->getIdentifier();
+                $type = 'identifier';
+                if ($string === NULL) {
+                    $string = $error->getMessage();
+                    $type = 'message';
+                }
+
+                if (!isset($fileErrorsByString[$string])) {
+                    $fileErrorsByString[$string] = [1, $type];
+                    continue;
+                }
+
+                $fileErrorsByString[$string][0]++;
+              }
+              ksort($fileErrorsByString, SORT_STRING);
+
+              foreach ($fileErrorsByString as $string => [$count, $type]) {
+                  if ($type === "identifier") {
+                      $php .= sprintf(
+                          "\$ignoreErrors[] = [\n\t'identifier' => %s,\n\t'count' => %d,\n\t'path' => __DIR__ . %s,\n];\n",
+                          var_export($string, TRUE),
+                          var_export($count, TRUE),
+                          var_export($file, TRUE),
+                      );
+                  }
+                  else {
+                      $php .= sprintf(
+                          "\$ignoreErrors[] = [\n\t'message' => %s,\n\t'count' => %d,\n\t'path' => __DIR__ . %s,\n];\n",
+                          var_export('#^' . preg_quote($string, '#') . '$#', TRUE),
+                          var_export($count, TRUE),
+                          var_export($file, TRUE),
+                      );
+                  }
+            }
+        }
+
+        $php .= "\n";
+        $php .= 'return [\'parameters\' => [\'ignoreErrors\' => $ignoreErrors]];';
+        $php .= "\n";
+
+        $output->writeRaw($php);
+
+        return 1;
+    }
+
+}


### PR DESCRIPTION
PHPStan allows us to ignore by identifier rather than message (as of 1.11). This is slightly less specific than the message is, but has the benefit of being a lot fewer bytes and a lot easier to deduplicate. This significantly reduces the size of the PHP baseline when used for Drupal Core.

Use the new formatter by passing `--error-format=identifier_baseline` to the `phpstan analyze` command. Note that you can unfortunately **not** pipe to the baseline because this clears out the file before PHPStan is started. 

⚠️ The baseline file must be empty since the error formatter would otherwise not get any errors to display (as they are all ignored). You can add a `return [];` at the top of the baseline to easily do this.

In case no identifier is available the formatter falls back to using the message in the same way PHPStan's `BaselinePhpErrorFormatter` would do.

There's one important difference vs the `BaselinePhpErrorFormatter` because `$message` and `$file` are not escaped using `Helpers::escape` as is done [in PHPStan](https://github.com/phpstan/phpstan-src/blob/2.0.x/src/Command/ErrorFormatter/BaselinePhpErrorFormatter.php#L89). `Helpers` is a class from the [nette/di](https://github.com/nette/di) package that's marked as internal. To add that code back we'd need to add `nette/di` as a dependency to `phpstan-drupal` or fork the helper.