### PR TITLE
Add stub for \Drupal\Core\Field\FormatterInterface

### DIFF
--- a/stubs/Drupal/Core/Field/FormatterInterface.stub
+++ b/stubs/Drupal/Core/Field/FormatterInterface.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Core\Field;
+
+interface FormatterInterface {
+
+  /**
+   * @param \Drupal\Core\Field\FieldItemListInterface<\Drupal\Core\Field\FieldItemInterface> $items
+   * @param string $langcode
+   *
+   * @return array<int, array<int|string, mixed>>
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode): array;
+
+}


### PR DESCRIPTION
With the PHPStan level 7 every field formatter starts to reports an error:

```
  XX     Method Drupal\foo\Plugin\Field\FieldFormatter\FooFormatter::viewElements() has parameter $items with generic interface Drupal\Core\Field\FieldItemListInterface but does not  
         specify its types: T                                                                                                                                                                                                   
         🪪  missingType.generics  
```

This PR adds a stub for the method that defines each element of `$items` as an instance of `\Drupal\Core\Field\FieldItemInterface`.

I'm not sure why the `FieldItemListInterface` doesn't handle this case. I'm not sure if my solution is the correct one in this case. Maybe it is possible to improve `FieldItemListInterface.stub`