### PR TITLE
Add more specific typehint for EntityStorageInterface::loadMultiple()

### DIFF
--- a/stubs/Drupal/Core/Entity/EntityStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/EntityStorageInterface.stub
@@ -4,4 +4,10 @@ namespace Drupal\Core\Entity;
 
 interface EntityStorageInterface {
 
+  /**
+   * @param array<int|string>|null $ids
+   * @return \Drupal\Core\Entity\EntityInterface[]
+   */
+  public function loadMultiple(?array $ids = NULL);
+
 }


### PR DESCRIPTION
## Problem/motivation

Drupal has received these changes to the core: https://git.drupalcode.org/project/drupal/-/commit/bc6599bf54ebd08b971db297ba0153a1d5711efb

One of them is about `EntityStorageInterface`:

```diff
  /**
   * Resets the internal entity cache.
   *
-  * @param $ids
+  * @param int[]|null $ids
   *   (optional) If specified, the cache is reset for the entities with the
   *   given ids only.
   */
  /**
   * Loads one or more entities.
   *
-  * @param $ids
+  * @param int[]|null $ids
   *   An array of entity IDs, or NULL to load all entities.
   *
   * @return \Drupal\Core\Entity\EntityInterface[]
```

This is a completely incorrect type, which already leads to issues with PHPStan (the next major version). For example, we encountered this today in a custom project:

```php
Parameter #1 $ids of method Drupal\Core\Entity\EntityStorageInterface::loadMultiple() expects array<int>|null, array<int, int<1, max>|string> given.  
```

There are multiple problems at the same time:

- Entity IDs are not guaranteed to be integer, more likely they will be strings, since even base filed definition for entity IDs uses string type, not int.
  ```php
    if ($entity_type->hasKey('id')) {
      $fields[$entity_type->getKey('id')] = BaseFieldDefinition::create('integer')
        ->setLabel(new TranslatableMarkup('ID'))
        ->setReadOnly(TRUE)
        ->setSetting('unsigned', TRUE);
    }
  ```
- `Drupal\Core\Entity\EntityInterface::id()` specifies return types as `@return string|int|null`, which already makes a simple use of `::loadMultiple([$node->id()])` completely incorrect.
- `Drupal\Core\Config\Entity\ConfigEntityStorageInterface` extends this interface, making it problematic as well, because in general, Drupal configurations use strings as their IDs, not integers.

This PR makes the types wider and more appropriate, which can actually be used for entity storage. I think it should remain in this package until Drupal core resolves this issue. It appears that this is [not the only issue](https://www.drupal.org/project/drupal/issues/3478204#comment-15925008) that needs fixing, and it was simply pushed into the mainstream "as is".