### PR TITLE
Make FormatterInterface stub generic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         },
         "classmap": [
             "tests/src/Type/data",
-            "tests/src/Rules/data"
+            "tests/src/Rules/data",
+            "tests/src/Generics/data"
         ]
     },
     "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
 		- tests/src
 	excludePaths:
 		-  tests/src/data/*.php
+		-  tests/src/Generics/data/*.php
 		-  tests/src/Type/data/*.php
 		-  tests/src/Rules/data/*.php
 		-  tests/src/DeprecatedScope/data/*.php

--- a/stubs/Drupal/Component/Plugin/DependentPluginInterface.stub
+++ b/stubs/Drupal/Component/Plugin/DependentPluginInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Component\Plugin;
+
+interface DependentPluginInterface {
+
+}

--- a/stubs/Drupal/Component/Plugin/DerivativeInspectionInterface.stub
+++ b/stubs/Drupal/Component/Plugin/DerivativeInspectionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Component\Plugin;
+
+interface DerivativeInspectionInterface {
+
+}

--- a/stubs/Drupal/Component/Plugin/PluginBase.stub
+++ b/stubs/Drupal/Component/Plugin/PluginBase.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Component\Plugin;
+
+abstract class PluginBase implements PluginInspectionInterface, DerivativeInspectionInterface {
+
+}

--- a/stubs/Drupal/Core/Field/EntityReferenceFieldItemList.stub
+++ b/stubs/Drupal/Core/Field/EntityReferenceFieldItemList.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Core\Field;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+
+/**
+ * @template T of EntityInterface
+ * @extends FieldItemList<EntityReferenceItem<T>>
+ * @implements EntityReferenceFieldItemListInterface<T>
+ */
+class EntityReferenceFieldItemList extends FieldItemList implements EntityReferenceFieldItemListInterface {
+
+}

--- a/stubs/Drupal/Core/Field/FieldItemList.stub
+++ b/stubs/Drupal/Core/Field/FieldItemList.stub
@@ -5,16 +5,15 @@ namespace Drupal\Core\Field;
 use Drupal\Core\TypedData\Plugin\DataType\ItemList;
 
 /**
- * @template T of \Drupal\Core\Field\FieldItemInterface
+ * @template T of FieldItemInterface
  * @extends ItemList<T>
  * @implements FieldItemListInterface<T>
  */
 class FieldItemList extends ItemList implements FieldItemListInterface {
 
   /**
-   * @return \Drupal\Core\Field\FieldItemInterface
+   * @return T
    */
-  protected function createItem(int $offset = 0, ?mixed $value = NULL): \Drupal\Core\Field\FieldItemInterface {
-  }
+  protected function createItem(int $offset = 0, mixed $value = NULL): FieldItemInterface {}
 
 }

--- a/stubs/Drupal/Core/Field/FormatterBase.stub
+++ b/stubs/Drupal/Core/Field/FormatterBase.stub
@@ -3,8 +3,6 @@
 namespace Drupal\Core\Field;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\Field\FormatterInterface;
-use Drupal\Core\Field\PluginSettingsBase;
 
 /**
  * @template TFieldItemList of \Drupal\Core\Field\FieldItemListInterface

--- a/stubs/Drupal/Core/Field/FormatterBase.stub
+++ b/stubs/Drupal/Core/Field/FormatterBase.stub
@@ -5,9 +5,30 @@ namespace Drupal\Core\Field;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 
 /**
- * @template TFieldItemList of \Drupal\Core\Field\FieldItemListInterface
- * @implements FormatterInterface<TFieldItemList>
+ * @template T of FieldItemListInterface
+ * @implements FormatterInterface<T>
  */
 abstract class FormatterBase extends PluginSettingsBase implements FormatterInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * @param array<T> $entities_items
+   */
+  public function prepareView(array $entities_items): void {}
+
+  /**
+   * @param T $items
+   * @param string|null $langcode
+   *
+   * @return array<int|string, mixed>
+   */
+  public function view(FieldItemListInterface $items, $langcode = NULL) {}
+
+  /**
+   * @param T $items
+   * @param string $langcode
+   *
+   * @return array<int, array<int|string, mixed>>
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {}
 
 }

--- a/stubs/Drupal/Core/Field/FormatterBase.stub
+++ b/stubs/Drupal/Core/Field/FormatterBase.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Core\Field;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Field\FormatterInterface;
+use Drupal\Core\Field\PluginSettingsBase;
+
+/**
+ * @template TFieldItemList of \Drupal\Core\Field\FieldItemListInterface
+ * @implements FormatterInterface<TFieldItemList>
+ */
+abstract class FormatterBase extends PluginSettingsBase implements FormatterInterface, ContainerFactoryPluginInterface {
+
+}

--- a/stubs/Drupal/Core/Field/FormatterInterface.stub
+++ b/stubs/Drupal/Core/Field/FormatterInterface.stub
@@ -3,24 +3,29 @@
 namespace Drupal\Core\Field;
 
 /**
- * @template TFieldItemList of \Drupal\Core\Field\FieldItemListInterface
+ * @template T of FieldItemListInterface
  */
-interface FormatterInterface {
+interface FormatterInterface extends PluginSettingsInterface {
 
   /**
-   * @param TFieldItemList $items
-   * @param string $langcode
-   *
-   * @return array<int, array<int|string, mixed>>
+   * @param array<T> $entities_items
    */
-  public function viewElements(FieldItemListInterface $items, $langcode): array;
+  public function prepareView(array $entities_items): void;
 
   /**
-   * @param TFieldItemList $items
-   * @param string $langcode
+   * @param T $items
+   * @param string|null $langcode
    *
    * @return array<int|string, mixed>
    */
   public function view(FieldItemListInterface $items, $langcode = NULL);
+
+  /**
+   * @param T $items
+   * @param string $langcode
+   *
+   * @return array<int, array<int|string, mixed>>
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode);
 
 }

--- a/stubs/Drupal/Core/Field/FormatterInterface.stub
+++ b/stubs/Drupal/Core/Field/FormatterInterface.stub
@@ -2,14 +2,25 @@
 
 namespace Drupal\Core\Field;
 
+/**
+ * @template TFieldItemList of \Drupal\Core\Field\FieldItemListInterface
+ */
 interface FormatterInterface {
 
   /**
-   * @param \Drupal\Core\Field\FieldItemListInterface<\Drupal\Core\Field\FieldItemInterface> $items
+   * @param TFieldItemList $items
    * @param string $langcode
    *
    * @return array<int, array<int|string, mixed>>
    */
   public function viewElements(FieldItemListInterface $items, $langcode): array;
+
+  /**
+   * @param TFieldItemList $items
+   * @param string $langcode
+   *
+   * @return array<int|string, mixed>
+   */
+  public function view(FieldItemListInterface $items, $langcode = NULL);
 
 }

--- a/stubs/Drupal/Core/Field/Plugin/Field/FieldFormatter/EntityReferenceFormatterBase.stub
+++ b/stubs/Drupal/Core/Field/Plugin/Field/FieldFormatter/EntityReferenceFormatterBase.stub
@@ -4,7 +4,7 @@ namespace Drupal\Core\Field\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemList;
-use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
 
 /**

--- a/stubs/Drupal/Core/Field/Plugin/Field/FieldFormatter/EntityReferenceFormatterBase.stub
+++ b/stubs/Drupal/Core/Field/Plugin/Field/FieldFormatter/EntityReferenceFormatterBase.stub
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Core\Field\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+
+/**
+ * @template T of EntityInterface
+ * @extends FormatterBase<EntityReferenceFieldItemList<T>>
+ */
+abstract class EntityReferenceFormatterBase extends FormatterBase {
+
+  /**
+   * @param array<EntityReferenceFieldItemList<T>> $entities_items
+   */
+  public function prepareView(array $entities_items): void {}
+
+  /**
+   * @param EntityReferenceFieldItemList<T> $items
+   * @param string|null $langcode
+   *
+   * @return array<int|string, mixed>
+   */
+  public function view(FieldItemListInterface $items, $langcode = NULL) {}
+
+  /**
+   * @param EntityReferenceFieldItemList<T> $items
+   * @param string $langcode
+   *
+   * @return array<int, array<int|string, mixed>>
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {}
+
+}

--- a/stubs/Drupal/Core/Field/PluginSettingsBase.stub
+++ b/stubs/Drupal/Core/Field/PluginSettingsBase.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\Core\Field;
+
+use Drupal\Component\Plugin\DependentPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+
+abstract class PluginSettingsBase extends PluginBase implements PluginSettingsInterface, DependentPluginInterface {
+
+}

--- a/stubs/Drupal/Core/Field/PluginSettingsInterface.stub
+++ b/stubs/Drupal/Core/Field/PluginSettingsInterface.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\Core\Field;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Config\Entity\ThirdPartySettingsInterface;
+
+interface PluginSettingsInterface extends PluginInspectionInterface, ThirdPartySettingsInterface {
+
+}

--- a/stubs/Drupal/Core/Plugin/ContainerFactoryPluginInterface.stub
+++ b/stubs/Drupal/Core/Plugin/ContainerFactoryPluginInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Drupal\Core\Plugin;
+
+interface ContainerFactoryPluginInterface {
+
+}

--- a/stubs/Drupal/Core/Plugin/PluginBase.stub
+++ b/stubs/Drupal/Core/Plugin/PluginBase.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Core\Plugin;
+
+use Drupal\Component\Plugin\PluginBase as ComponentPluginBase;
+
+abstract class PluginBase extends ComponentPluginBase {
+
+}

--- a/stubs/Drupal/Core/TypedData/Plugin/DataType/ItemList.stub
+++ b/stubs/Drupal/Core/TypedData/Plugin/DataType/ItemList.stub
@@ -13,4 +13,10 @@ use Drupal\Core\TypedData\TypedDataInterface;
  * @implements ListInterface<T>
  */
 class ItemList extends TypedData implements \IteratorAggregate, ListInterface {
+
+  /**
+   * @return \ArrayIterator<int, T>
+   */
+  public function getIterator(): \ArrayIterator {}
+
 }

--- a/tests/src/Generics/EntityReferenceFieldItemListGenericTest.php
+++ b/tests/src/Generics/EntityReferenceFieldItemListGenericTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Generics;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class EntityReferenceFieldItemListGenericTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/entity-reference-field-item-list.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Generics/EntityReferenceFormatterBaseGenericTest.php
+++ b/tests/src/Generics/EntityReferenceFormatterBaseGenericTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Generics;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class EntityReferenceFormatterBaseGenericTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/entity-reference-formatter-base.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Generics/EntityReferenceItemGenericTest.php
+++ b/tests/src/Generics/EntityReferenceItemGenericTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Generics;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class EntityReferenceItemGenericTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/entity-reference-item.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Generics/FormatterBaseGenericTest.php
+++ b/tests/src/Generics/FormatterBaseGenericTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Generics;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class FormatterBaseGenericTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/formatter-base.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Generics/FormatterInterfaceGenericTest.php
+++ b/tests/src/Generics/FormatterInterfaceGenericTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Generics;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class FormatterInterfaceGenericTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/formatter-interface.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Generics/data/entity-reference-field-item-list.php
+++ b/tests/src/Generics/data/entity-reference-field-item-list.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace DrupalEntityReferenceFieldItemListGeneric;
+
+use Drupal\Core\Field\EntityReferenceFieldItemList;
+use Drupal\node\NodeInterface;
+use function PHPStan\Testing\assertType;
+
+function defaultItemList(EntityReferenceFieldItemList $items): void {
+    assertType('Drupal\Core\Field\EntityReferenceFieldItemList', $items);
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
+    foreach ($items as $item) {
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
+        assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
+        assertType('int|string|null', $item->target_id);
+    }
+    assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
+    foreach ($items->referencedEntities() as $entity) {
+        assertType('Drupal\Core\Entity\EntityInterface', $entity);
+    }
+}
+
+/**
+ * @param EntityReferenceFieldItemList<NodeInterface> $items
+ */
+function phpDocOverride(EntityReferenceFieldItemList $items): void {
+    assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
+    foreach ($items as $item) {
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+        assertType('Drupal\node\NodeInterface|null', $item->entity);
+        assertType('int|string|null', $item->target_id);
+    }
+    assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
+    foreach ($items->referencedEntities() as $entity) {
+        assertType('Drupal\node\NodeInterface', $entity);
+    }
+}
+
+/**
+ * @extends EntityReferenceFieldItemList<NodeInterface>
+ */
+class ExtendedEntityReferenceFieldItemList extends EntityReferenceFieldItemList {}
+
+function extendedItemList(ExtendedEntityReferenceFieldItemList $items): void {
+    assertType('DrupalEntityReferenceFieldItemListGeneric\ExtendedEntityReferenceFieldItemList', $items);
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
+    foreach ($items as $item) {
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+        assertType('Drupal\node\NodeInterface|null', $item->entity);
+        assertType('int|string|null', $item->target_id);
+    }
+    assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
+    foreach ($items->referencedEntities() as $entity) {
+        assertType('Drupal\node\NodeInterface', $entity);
+    }
+}

--- a/tests/src/Generics/data/entity-reference-field-item-list.php
+++ b/tests/src/Generics/data/entity-reference-field-item-list.php
@@ -13,8 +13,6 @@ function defaultItemList(EntityReferenceFieldItemList $items): void {
     assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
     foreach ($items as $item) {
         assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
-        assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
-        assertType('int|string|null', $item->target_id);
     }
     assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
     foreach ($items->referencedEntities() as $entity) {
@@ -32,8 +30,6 @@ function phpDocOverride(EntityReferenceFieldItemList $items): void {
     assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
     foreach ($items as $item) {
         assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
-        assertType('Drupal\node\NodeInterface|null', $item->entity);
-        assertType('int|string|null', $item->target_id);
     }
     assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
     foreach ($items->referencedEntities() as $entity) {

--- a/tests/src/Generics/data/entity-reference-formatter-base.php
+++ b/tests/src/Generics/data/entity-reference-formatter-base.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace DrupalEntityReferenceFormatterBaseGeneric;
+
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceFormatterBase;
+use Drupal\node\NodeInterface;
+use function PHPStan\Testing\assertType;
+
+class InheritedEntityReferenceFormatterBase extends EntityReferenceFormatterBase {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
+            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\Core\Entity\EntityInterface', $entity);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
+            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\Core\Entity\EntityInterface', $entity);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
+            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\Core\Entity\EntityInterface', $entity);
+        }
+    }
+
+}
+
+/**
+ * @extends EntityReferenceFormatterBase<NodeInterface>
+ */
+class SpecifiedEntityTypeEntityReferenceFormatterBase extends EntityReferenceFormatterBase {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+            assertType('Drupal\node\NodeInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\node\NodeInterface', $entity);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+            assertType('Drupal\node\NodeInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\node\NodeInterface', $entity);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+            assertType('Drupal\node\NodeInterface|null', $item->entity);
+            assertType('int|string|null', $item->target_id);
+        }
+        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
+        foreach ($items->referencedEntities() as $entity) {
+            assertType('Drupal\node\NodeInterface', $entity);
+        }
+    }
+
+}

--- a/tests/src/Generics/data/entity-reference-formatter-base.php
+++ b/tests/src/Generics/data/entity-reference-formatter-base.php
@@ -13,50 +13,14 @@ class InheritedEntityReferenceFormatterBase extends EntityReferenceFormatterBase
         assertType('array<Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>>', $entities_items);
         $items = $entities_items[0];
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
-            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\Core\Entity\EntityInterface', $entity);
-        }
     }
 
     public function view(FieldItemListInterface $items, $langcode = NULL) {
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
-            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\Core\Entity\EntityInterface', $entity);
-        }
     }
 
     public function viewElements(FieldItemListInterface $items, $langcode) {
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\Core\Entity\EntityInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\Core\Entity\EntityInterface>', $item);
-            assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\Core\Entity\EntityInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\Core\Entity\EntityInterface', $entity);
-        }
     }
 
 }
@@ -70,50 +34,14 @@ class SpecifiedEntityTypeEntityReferenceFormatterBase extends EntityReferenceFor
         assertType('array<Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>>', $entities_items);
         $items = $entities_items[0];
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
-            assertType('Drupal\node\NodeInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\node\NodeInterface', $entity);
-        }
     }
 
     public function view(FieldItemListInterface $items, $langcode = NULL) {
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
-            assertType('Drupal\node\NodeInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\node\NodeInterface', $entity);
-        }
     }
 
     public function viewElements(FieldItemListInterface $items, $langcode) {
         assertType('Drupal\Core\Field\EntityReferenceFieldItemList<Drupal\node\NodeInterface>', $items);
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->first());
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->get(0));
-        assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>|null', $items->offsetGet(0));
-        foreach ($items as $item) {
-            assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
-            assertType('Drupal\node\NodeInterface|null', $item->entity);
-            assertType('int|string|null', $item->target_id);
-        }
-        assertType('array<int, Drupal\node\NodeInterface>', $items->referencedEntities());
-        foreach ($items->referencedEntities() as $entity) {
-            assertType('Drupal\node\NodeInterface', $entity);
-        }
     }
 
 }

--- a/tests/src/Generics/data/entity-reference-item.php
+++ b/tests/src/Generics/data/entity-reference-item.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DrupalEntityReferenceItemGeneric;
+
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\node\NodeInterface;
+use function PHPStan\Testing\assertType;
+
+function defaultItem(EntityReferenceItem $item): void {
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem', $item);
+    assertType('Drupal\Core\Entity\EntityInterface|null', $item->entity);
+    assertType('int|string|null', $item->target_id);
+}
+
+/**
+ * @param EntityReferenceItem<NodeInterface> $item
+ */
+function phpDocOverride(EntityReferenceItem $item): void {
+    assertType('Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem<Drupal\node\NodeInterface>', $item);
+    assertType('Drupal\node\NodeInterface|null', $item->entity);
+    assertType('int|string|null', $item->target_id);
+}
+
+/**
+ * @extends EntityReferenceItem<NodeInterface>
+ */
+class ExtendedEntityReferenceItem extends EntityReferenceItem {}
+
+function extendedItem(ExtendedEntityReferenceItem $item): void {
+    assertType('DrupalEntityReferenceItemGeneric\ExtendedEntityReferenceItem', $item);
+    assertType('Drupal\node\NodeInterface|null', $item->entity);
+    assertType('int|string|null', $item->target_id);
+}

--- a/tests/src/Generics/data/formatter-base.php
+++ b/tests/src/Generics/data/formatter-base.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace DrupalFormatterBaseGeneric;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem;
+use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
+use function PHPStan\Testing\assertType;
+
+/**
+ * Provides a custom field item list with concrete FieldItemListInterface<T>.
+ *
+ * @implements FieldItemListInterface<BooleanItem>
+ */
+class BooleanFieldItemList implements FieldItemListInterface {}
+
+/**
+ * @extends FormatterBase<BooleanFieldItemList>
+ */
+class ExtendsBooleanItemFormatter extends FormatterBase {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<DrupalFormatterBaseGeneric\BooleanFieldItemList>', $entities_items);
+        $items = $entities_items[0];
+        assertType('DrupalFormatterBaseGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('DrupalFormatterBaseGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('DrupalFormatterBaseGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+}
+
+/**
+ * @extends FormatterBase<FieldItemList<StringItem>>
+ */
+class ExtendedDeepFormatter extends FormatterBase {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+}

--- a/tests/src/Generics/data/formatter-interface.php
+++ b/tests/src/Generics/data/formatter-interface.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace DrupalFormatterInterfaceGeneric;
+
+use Drupal\Core\Field\FieldItemList;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem;
+use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
+use function PHPStan\Testing\assertType;
+
+/**
+ * Tests the class which doesn't use generics at all.
+ */
+class EmptyFormatter implements FormatterInterface {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\FieldItemListInterface>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\FieldItemListInterface', $items);
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('mixed', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\FieldItemListInterface', $items);
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('mixed', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\FieldItemListInterface', $items);
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
+        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('mixed', $item);
+        }
+    }
+
+}
+
+/**
+ * Tests the class which provides TFieldItemList data to generic.
+ *
+ * @implements FormatterInterface<FieldItemList>
+ */
+class FieldItemListFormatter implements FormatterInterface {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\FieldItemList>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\FieldItemList', $items);
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\FieldItemList', $items);
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\FieldItemList', $items);
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
+        }
+    }
+
+}
+
+/**
+ * Tests hierarchical generics.
+ *
+ * Provides TFieldItemList data to generic with specifying FieldItemList<T>.
+ *
+ * @implements FormatterInterface<FieldItemList<StringItem>>
+ */
+class StringItemFormatter implements FormatterInterface {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+}
+
+/**
+ * Tests providing union types with hierarchical generics.
+ *
+ * @implements FormatterInterface<FieldItemList<StringItem|BooleanItem>>
+ */
+class UnionTypeFormatter implements FormatterInterface {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem>>', $entities_items);
+        $items = $entities_items[0];
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('Drupal\Core\Field\FieldItemList<Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem>', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|Drupal\Core\Field\Plugin\Field\FieldType\StringItem', $item);
+        }
+    }
+
+}
+
+/**
+ * Provides a custom field item list with concrete FieldItemListInterface<T>.
+ *
+ * @implements FieldItemListInterface<BooleanItem>
+ */
+class BooleanFieldItemList implements FieldItemListInterface {}
+
+/**
+ * @implements FormatterInterface<BooleanFieldItemList>
+ */
+class BooleanItemFormatter implements FormatterInterface {
+
+    public function prepareView(array $entities_items): void {
+        assertType('array<DrupalFormatterInterfaceGeneric\BooleanFieldItemList>', $entities_items);
+        $items = $entities_items[0];
+        assertType('DrupalFormatterInterfaceGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+    public function view(FieldItemListInterface $items, $langcode = NULL) {
+        assertType('DrupalFormatterInterfaceGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+    public function viewElements(FieldItemListInterface $items, $langcode) {
+        assertType('DrupalFormatterInterfaceGeneric\BooleanFieldItemList', $items);
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->first());
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->get(0));
+        assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem|null', $items->offsetGet(0));
+        foreach ($items as $item) {
+            assertType('Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem', $item);
+        }
+    }
+
+}


### PR DESCRIPTION
From #822: This PR changes FormatterStub to be a proper generic instead of narrowing types for others.

**Conflict with #845.**