### PR TITLE
2.x: Fix negation types for Inspector

### DIFF
--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -110,7 +110,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[1]->value,
             new IterableType(new MixedType(), new MixedType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -123,7 +123,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), new StringType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -140,7 +140,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             $newType,
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -156,7 +156,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             $newType,
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -176,7 +176,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             $newType,
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -197,7 +197,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             $newType,
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -241,7 +241,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             TypeCombinator::intersect(...$possibleTypes),
         );
 
-        return $this->typeSpecifier->create($traversableArg, $newType, TypeSpecifierContext::createTruthy(), $scope);
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -252,7 +252,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), new IntegerType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -265,7 +265,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), new FloatType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -278,7 +278,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), new CallableType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -302,7 +302,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             $newType,
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -315,7 +315,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), new UnionType([new IntegerType(), new FloatType()])),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -328,7 +328,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[1]->value,
             new IterableType(new MixedType(), new StringType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -343,7 +343,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             // Drupal treats any non-string input in traversable as invalid
             // value, so it is possible to narrow type here.
             new IterableType(new MixedType(), new StringType()),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }
@@ -376,7 +376,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         return $this->typeSpecifier->create(
             $node->getArgs()[0]->value,
             new IterableType(new MixedType(), TypeCombinator::union(...$objectTypes)),
-            TypeSpecifierContext::createTruthy(),
+            $context,
             $scope,
         );
     }

--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -107,6 +107,19 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             return new SpecifiedTypes();
         }
 
+        // In a negation context, we cannot precisely narrow types because we do
+        // not know the exact logic of the callable function. This means we
+        // cannot safely return 'mixed~iterable' since the value might still be
+        // a valid iterable.
+        //
+        // For example, a negation context with an 'is_string(...)' callable
+        // does not necessarily mean that the value cannot be an
+        // 'iterable<int>'. In such cases, it is safer to skip type narrowing
+        // altogether to prevent introducing new bugs into the code.
+        if ($context->false()) {
+            return new SpecifiedTypes();
+        }
+
         return $this->typeSpecifier->create(
             $node->getArgs()[1]->value,
             new IterableType(new MixedType(), new MixedType()),

--- a/tests/src/Type/data/inspector.php
+++ b/tests/src/Type/data/inspector.php
@@ -12,82 +12,146 @@ function mixed_function(): mixed {
 // Inspector::assertAll()
 $callable = fn (string $value): bool => $value === 'foo';
 $input = mixed_function();
-assert(Inspector::assertAll($callable, $input));
-assertType("iterable", $input);
+if (Inspector::assertAll($callable, $input)) {
+    assertType("iterable", $input);
+}
+else {
+    assertType('mixed~iterable', $input);
+}
 
 $input = mixed_function();
 $callable = is_string(...);
-assert(Inspector::assertAll($callable, $input));
-assertType('iterable', $input);
+if (Inspector::assertAll($callable, $input)) {
+    assertType('iterable', $input);
+}
+else {
+    assertType('mixed~iterable', $input);
+}
 
 
 // Inspector::assertAllStrings()
 $input = mixed_function();
-assert(Inspector::assertAllStrings($input));
-assertType('iterable<string>', $input);
+if (Inspector::assertAllStrings($input)) {
+    assertType('iterable<string>', $input);
+}
+else {
+    assertType('mixed~iterable<string>', $input);
+}
 
 // Inspector::assertAllStringable()
 $input = mixed_function();
-assert(Inspector::assertAllStringable($input));
-assertType('iterable<string|Stringable>', $input);
+if (Inspector::assertAllStringable($input)) {
+    assertType('iterable<string|Stringable>', $input);
+}
+else {
+    assertType('mixed~iterable<string|Stringable>', $input);
+}
 
 // Inspector::assertAllArrays()
 $input = mixed_function();
-\assert(Inspector::assertAllArrays($input));
-assertType('iterable<array>', $input);
+if (Inspector::assertAllArrays($input)) {
+    assertType('iterable<array>', $input);
+}
+else {
+    assertType('mixed~iterable<array>', $input);
+}
 
 // Inspector::assertStrictArray()
 $input = mixed_function();
-assert(Inspector::assertStrictArray($input));
-assertType('array<int<0, max>, mixed>', $input);
+if (Inspector::assertStrictArray($input)) {
+    assertType('array<int<0, max>, mixed>', $input);
+}
+else {
+    assertType('mixed~array<int<0, max>, mixed>', $input);
+}
 
 // Inspector::assertAllStrictArrays()
 $input = mixed_function();
-assert(Inspector::assertAllStrictArrays($input));
-assertType('iterable<array<int<0, max>, mixed>>', $input);
+if (Inspector::assertAllStrictArrays($input)) {
+    assertType('iterable<array<int<0, max>, mixed>>', $input);
+}
+else {
+    assertType('mixed~iterable<array<int<0, max>, mixed>>', $input);
+}
 
 // Inspector::assertAllHaveKey()
 $input = mixed_function();
-assert(Inspector::assertAllHaveKey($input, 'foo', 'baz'));
-assertType("iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $input);
+if (Inspector::assertAllHaveKey($input, 'foo', 'baz')) {
+    assertType("iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $input);
+}
+else {
+    assertType("mixed~iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $input);
+}
 
 // Inspector::assertAllIntegers()
 $input = mixed_function();
-assert(Inspector::assertAllIntegers($input));
-assertType('iterable<int>', $input);
+if (Inspector::assertAllIntegers($input)) {
+    assertType('iterable<int>', $input);
+}
+else {
+    assertType('mixed~iterable<int>', $input);
+}
 
 // Inspector::assertAllFloat()
 $input = mixed_function();
-assert(Inspector::assertAllFloat($input));
-assertType('iterable<float>', $input);
+if (Inspector::assertAllFloat($input)) {
+    assertType('iterable<float>', $input);
+}
+else {
+    assertType('mixed~iterable<float>', $input);
+}
 
 // Inspector::assertAllCallable()
 $input = mixed_function();
-assert(Inspector::assertAllCallable($input));
-assertType('iterable<callable(): mixed>', $input);
+if (Inspector::assertAllCallable($input)) {
+    assertType('iterable<callable(): mixed>', $input);
+}
+else {
+    assertType('mixed~iterable<callable(): mixed>', $input);
+}
 
 // Inspector::assertAllNotEmpty()
 $input = mixed_function();
-assert(Inspector::assertAllNotEmpty($input));
-assertType('iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $input);
+if (Inspector::assertAllNotEmpty($input)) {
+    assertType('iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $input);
+}
+else {
+    assertType('mixed~iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $input);
+}
 
 // Inspector::assertAllNumeric()
 $input = mixed_function();
-assert(Inspector::assertAllNumeric($input));
-assertType('iterable<float|int>', $input);
+if (Inspector::assertAllNumeric($input)) {
+    assertType('iterable<float|int>', $input);
+}
+else {
+    assertType('mixed~iterable<float|int>', $input);
+}
 
 // Inspector::assertAllMatch()
 $pattern = 'foo';
 $input = mixed_function();
-assert(Inspector::assertAllMatch($pattern, $input, false));
-assertType('iterable<string>', $input);
+if (Inspector::assertAllMatch($pattern, $input, false)) {
+    assertType('iterable<string>', $input);
+}
+else {
+    assertType('mixed~iterable<string>', $input);
+}
 
 // Inspector::assertAllRegularExpressionMatch()
 $input = mixed_function();
-assert(Inspector::assertAllRegularExpressionMatch($pattern, $input));
-assertType('iterable<string>', $input);
+if (Inspector::assertAllRegularExpressionMatch($pattern, $input)) {
+    assertType('iterable<string>', $input);
+}
+else {
+    assertType('mixed~iterable<string>', $input);
+}
 
 // Inspector::assertAllObjects()
 $input = mixed_function();
-assert(Inspector::assertAllObjects($input, TranslatableMarkup::class, '\\Stringable', '\\Drupal\\jsonapi\\JsonApiResource\\ResourceIdentifier'));
-assertType('iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|\Stringable>', $input);
+if (Inspector::assertAllObjects($input, TranslatableMarkup::class, '\\Stringable', '\\Drupal\\jsonapi\\JsonApiResource\\ResourceIdentifier')) {
+    assertType('iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|\Stringable>', $input);
+}
+else {
+    assertType('mixed~iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|\Stringable>', $input);
+}

--- a/tests/src/Type/data/inspector.php
+++ b/tests/src/Type/data/inspector.php
@@ -16,7 +16,7 @@ if (Inspector::assertAll($callable, $input)) {
     assertType("iterable", $input);
 }
 else {
-    assertType('mixed~iterable', $input);
+    assertType('mixed', $input);
 }
 
 $input = mixed_function();
@@ -25,7 +25,7 @@ if (Inspector::assertAll($callable, $input)) {
     assertType('iterable', $input);
 }
 else {
-    assertType('mixed~iterable', $input);
+    assertType('mixed', $input);
 }
 
 


### PR DESCRIPTION
As discussed in Slack: https://drupal.slack.com/archives/C033S2JUMLJ/p1744383402099899?thread_ts=1744246451.941499&cid=C033S2JUMLJ, the current Inspector implementation doesn't handle negation at all.

For example:

```php
$array = mixed_function();
assertType('mixed', $array);
Inspector::assertAll(fn (array $i): bool => TRUE, $array);
assertType('iterable', $array);
```

After passing `Inspector::assertAll(fn (array $i): bool => TRUE, $array);` line, PHPStan would think it is always iterable, even if it is not passed `::assertAll()` and the result was `FALSE`. This works fine with `assert()`, but breaks under other conditions, for example:

```php
$array = mixed_function();
assertType('mixed', $array);
if (!Inspector::assertAll(fn (array $i): bool => TRUE, $array)) {
    assertType('mixed~iterable', $array);
}
```

This leads to a test failure:

```
--- Expected
+++ Actual
@@ @@
-'mixed~iterable'
+'iterable'
```

PHPStan thinks it is `iterable`, but if it's not passed the assertion, it is anything else but not iterable (`mixed~iterable`).

It looks like PHPStan is using the `~` symbol for type negation, like `mixed~string`, which reads as: This type is anything (`mixed`), but definitely not `string`.

This PR fixes the issue, and previous tests pass properly as before. This PR is required for #858 because it is not possible to provide proper test cases for it unless negation is supported.