### PR TITLE
1.x: Fix assertAll causes staticMethod.alreadyNarrowedType

### DIFF
--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -130,16 +130,6 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             return new SpecifiedTypes();
         }
 
-        $traversable = $node->getArgs()[1]->value;
-        $traversableInfo = $scope->getType($traversable);
-
-        // If it is already not mixed (narrowed by other code, like
-        // '::assertAllArray()'), we could not provide any additional
-        // information. We can only narrow this method to 'array<mixed, mixed>'.
-        if (!$traversableInfo instanceof MixedType) {
-            return new SpecifiedTypes();
-        }
-
         return $this->typeSpecifier->create(
             $node->getArgs()[1]->value,
             new IterableType(new MixedType(), new MixedType()),

--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -107,6 +107,16 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             return new SpecifiedTypes();
         }
 
+        $traversable = $node->getArgs()[1]->value;
+        $traversableInfo = $scope->getType($traversable);
+
+        // If it is already not mixed (narrowed by other code, like
+        // '::assertAllArray()'), we could not provide any additional
+        // information. We can only narrow this method to 'array<mixed, mixed>'.
+        if (!$traversableInfo->equals(new MixedType())) {
+            return new SpecifiedTypes();
+        }
+
         // In a negation context, we cannot precisely narrow types because we do
         // not know the exact logic of the callable function. This means we
         // cannot safely return 'mixed~iterable' since the value might still be
@@ -117,6 +127,16 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         // 'iterable<int>'. In such cases, it is safer to skip type narrowing
         // altogether to prevent introducing new bugs into the code.
         if ($context->false()) {
+            return new SpecifiedTypes();
+        }
+
+        $traversable = $node->getArgs()[1]->value;
+        $traversableInfo = $scope->getType($traversable);
+
+        // If it is already not mixed (narrowed by other code, like
+        // '::assertAllArray()'), we could not provide any additional
+        // information. We can only narrow this method to 'array<mixed, mixed>'.
+        if (!$traversableInfo instanceof MixedType) {
             return new SpecifiedTypes();
         }
 

--- a/tests/src/Rules/ImpossibleCheckTypeStaticMethodCallRuleTest.php
+++ b/tests/src/Rules/ImpossibleCheckTypeStaticMethodCallRuleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\Tests\TestClassSuffixNameRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Comparison\ImpossibleCheckTypeHelper;
+use PHPStan\Rules\Comparison\ImpossibleCheckTypeStaticMethodCallRule;
+use PHPStan\Rules\Rule;
+
+class ImpossibleCheckTypeStaticMethodCallRuleTest extends DrupalRuleTestCase
+{
+
+    private bool $treatPhpDocTypesAsCertain = false;
+
+    private bool $reportAlwaysTrueInLastCondition = false;
+
+    protected function getRule(): Rule
+    {
+        /** @phpstan-ignore phpstanApi.constructor */
+        return new ImpossibleCheckTypeStaticMethodCallRule(
+            /** @phpstan-ignore phpstanApi.constructor */
+            new ImpossibleCheckTypeHelper(
+                $this->createReflectionProvider(),
+                $this->getTypeSpecifier(),
+                [],
+                $this->treatPhpDocTypesAsCertain,
+                false,
+            ),
+            true,
+            $this->treatPhpDocTypesAsCertain,
+            $this->reportAlwaysTrueInLastCondition,
+            true,
+        );
+    }
+
+    protected function shouldTreatPhpDocTypesAsCertain(): bool
+    {
+        return $this->treatPhpDocTypesAsCertain;
+    }
+
+
+    public function testBug857(): void
+    {
+        $this->treatPhpDocTypesAsCertain = true;
+        // It shouldn't report anything.
+        $this->analyse([__DIR__ . '/data/bug-857.php'], []);
+    }
+
+}

--- a/tests/src/Rules/data/bug-857.php
+++ b/tests/src/Rules/data/bug-857.php
@@ -1,0 +1,11 @@
+<?php
+
+use Drupal\Component\Assertion\Inspector;
+use Drupal\Core\Url;
+
+function foo(array $images) {
+    // This call is crucial for the bug, because it narrows type to
+    // 'array<array>'.
+    Inspector::assertAllArrays($images);
+    Inspector::assertAll(fn (array $i): bool => $i['file'] instanceof Url, $images);
+}

--- a/tests/src/Type/InspectorTypeExtensionTest.php
+++ b/tests/src/Type/InspectorTypeExtensionTest.php
@@ -14,6 +14,7 @@ final class InspectorTypeExtensionTest extends TypeInferenceTestCase {
   public static function dataFileAsserts(): iterable {
     yield from self::gatherAssertTypes(__DIR__ . '/data/inspector.php');
     yield from self::gatherAssertTypes(__DIR__ . '/data/bug-852.php');
+    yield from self::gatherAssertTypes(__DIR__ . '/data/bug-857.php');
   }
 
   /**

--- a/tests/src/Type/data/bug-857.php
+++ b/tests/src/Type/data/bug-857.php
@@ -1,0 +1,21 @@
+<?php
+
+use Drupal\Component\Assertion\Inspector;
+use function PHPStan\Testing\assertType;
+
+function mixed_function(): mixed {}
+
+// If the type is not narrowed from 'mixed' before call, it is narrowed to
+// 'iterable'.
+$array = mixed_function();
+assertType('mixed', $array);
+\assert(Inspector::assertAll(fn (array $i): bool => TRUE, $array));
+assertType('iterable', $array);
+
+// If the type is narrowed before '::assertAll()', it shouldn't change it.
+$array = mixed_function();
+assertType('mixed', $array);
+\assert(Inspector::assertAllArrays($array));
+assertType('iterable<array>', $array);
+\assert(Inspector::assertAll(fn (array $i): bool => TRUE, $array));
+assertType('iterable<array>', $array);


### PR DESCRIPTION
Backport for #858 