### PR TITLE
Fix DrushIntegrationTest

### DIFF
--- a/tests/src/DrushIntegrationTest.php
+++ b/tests/src/DrushIntegrationTest.php
@@ -12,7 +12,8 @@ final class DrushIntegrationTest extends DrupalRuleTestCase
         // @phpstan-ignore phpstanApi.constructor
         return new CallToNonExistentFunctionRule(
             $this->createReflectionProvider(),
-            true
+            true,
+            true,
         );
     }
 


### PR DESCRIPTION
The latest CI build has started to fail. You can view the details here: https://github.com/mglaman/phpstan-drupal/actions/runs/14497424898/job/40668597915#step:6:18

PHPStan has recently changed the constructor signature for `\PHPStan\Rules\Functions\CallToNonExistentFunctionRule::__construct`. 

You can view the changes here: https://github.com/phpstan/phpstan-src/blame/db66d83f6ae3dadec529dd53bcde250344c2230f/src/Rules/Functions/CallToNonExistentFunctionRule.php#L23

It's available since 2.1.12: https://github.com/phpstan/phpstan-src/releases/tag/2.1.12