### PR TITLE
Improve the InspectorTypeExtension and its tests

### DIFF
--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -100,20 +100,20 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAll(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        $callable = $node->getArgs()[0]->value;
-        $callableInfo = $scope->getType($callable);
+        $callableArg = $node->getArgs()[0]->value;
+        $callableInfo = $scope->getType($callableArg);
 
         if (!$callableInfo->isCallable()->yes()) {
             return new SpecifiedTypes();
         }
 
-        $traversable = $node->getArgs()[1]->value;
-        $traversableInfo = $scope->getType($traversable);
+        $traversableArg = $node->getArgs()[1]->value;
+        $traversableType = $scope->getType($traversableArg);
 
         // If it is already not mixed (narrowed by other code, like
         // '::assertAllArray()'), we could not provide any additional
         // information. We can only narrow this method to 'array<mixed, mixed>'.
-        if (!$traversableInfo->equals(new MixedType())) {
+        if (!$traversableType->equals(new MixedType())) {
             return new SpecifiedTypes();
         }
 
@@ -130,12 +130,9 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             return new SpecifiedTypes();
         }
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[1]->value,
-            new IterableType(new MixedType(), new MixedType()),
-            $context,
-            $scope,
-        );
+        $newType = new IterableType(new MixedType(), new MixedType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -143,12 +140,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllStrings(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), new StringType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), new StringType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -156,16 +151,12 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllStringable(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
+        $traversableArg = $node->getArgs()[0]->value;
         // Drupal considers string as part of "stringable" as well.
-        $stringable = TypeCombinator::union(new ObjectType(Stringable::class), new StringType());
-        $newType = new IterableType(new MixedType(), $stringable);
+        $stringableType = TypeCombinator::union(new ObjectType(Stringable::class), new StringType());
+        $newType = new IterableType(new MixedType(), $stringableType);
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            $newType,
-            $context,
-            $scope,
-        );
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -173,15 +164,11 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllArrays(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
+        $traversableArg = $node->getArgs()[0]->value;
         $arrayType = new ArrayType(new MixedType(), new MixedType());
         $newType = new IterableType(new MixedType(), $arrayType);
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            $newType,
-            $context,
-            $scope,
-        );
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -189,19 +176,16 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertStrictArray(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
+        $traversableArg = $node->getArgs()[0]->value;
         $newType = new ArrayType(
-            // In Drupal, 'strict arrays' are defined as arrays whose indexes
-            // consist of integers that are equal to or greater than 0.
+            // In Drupal, 'strict arrays' are defined as arrays whose
+            // indexes consist of integers that are equal to or greater
+            // than 0.
             IntegerRangeType::createAllGreaterThanOrEqualTo(0),
             new MixedType(),
         );
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            $newType,
-            $context,
-            $scope,
-        );
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -209,6 +193,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllStrictArrays(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
+        $traversableArg = $node->getArgs()[0]->value;
         $newType = new IterableType(
             new MixedType(),
             new ArrayType(
@@ -217,12 +202,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             ),
         );
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            $newType,
-            $context,
-            $scope,
-        );
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -272,12 +252,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllIntegers(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), new IntegerType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), new IntegerType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -285,12 +263,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllFloat(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), new FloatType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), new FloatType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -298,12 +274,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllCallable(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), new CallableType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), new CallableType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -311,7 +285,8 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllNotEmpty(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        $non_empty_types = [
+        $traversableArg = $node->getArgs()[0]->value;
+        $nonEmptyTypes = [
             new NonEmptyArrayType(),
             new ObjectType('object'),
             new IntersectionType([new StringType(), new AccessoryNonEmptyStringType()]),
@@ -320,14 +295,9 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
             new FloatType(),
             new ResourceType(),
         ];
-        $newType = new IterableType(new MixedType(), new UnionType($non_empty_types));
+        $newType = new IterableType(new MixedType(), new UnionType($nonEmptyTypes));
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            $newType,
-            $context,
-            $scope,
-        );
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -335,12 +305,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllNumeric(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), new UnionType([new IntegerType(), new FloatType()])),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), new UnionType([new IntegerType(), new FloatType()]));
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -348,12 +316,10 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllMatch(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[1]->value,
-            new IterableType(new MixedType(), new StringType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[1]->value;
+        $newType = new IterableType(new MixedType(), new StringType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -361,14 +327,12 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
      */
     private function specifyAssertAllRegularExpressionMatch(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
-        return $this->typeSpecifier->create(
-            $node->getArgs()[1]->value,
-            // Drupal treats any non-string input in traversable as invalid
-            // value, so it is possible to narrow type here.
-            new IterableType(new MixedType(), new StringType()),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[1]->value;
+        // Drupal treats any non-string input in traversable as invalid
+        // value, so it is possible to narrow type here.
+        $newType = new IterableType(new MixedType(), new StringType());
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 
     /**
@@ -385,22 +349,15 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
 
             $argType = $scope->getType($arg->value);
             foreach ($argType->getConstantStrings() as $stringType) {
-                $classString = $stringType->getValue();
-                // PHPStan does not recognize a string argument like '\\Stringable'
-                // as a class string, so we need to explicitly check it.
-                if (!class_exists($classString) && !interface_exists($classString)) {
-                    continue;
+                if ($stringType->isClassString()->yes()) {
+                    $objectTypes[] = new ObjectType($stringType->getValue());
                 }
-
-                $objectTypes[] = new ObjectType($classString);
             }
         }
 
-        return $this->typeSpecifier->create(
-            $node->getArgs()[0]->value,
-            new IterableType(new MixedType(), TypeCombinator::union(...$objectTypes)),
-            $context,
-            $scope,
-        );
+        $traversableArg = $node->getArgs()[0]->value;
+        $newType = new IterableType(new MixedType(), TypeCombinator::union(...$objectTypes));
+
+        return $this->typeSpecifier->create($traversableArg, $newType, $context, $scope);
     }
 }

--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -31,8 +31,6 @@ use PHPStan\Type\StringType;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use Stringable;
-use function class_exists;
-use function interface_exists;
 
 final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
 {

--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -101,9 +101,9 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
     private function specifyAssertAll(MethodReflection $staticMethodReflection, StaticCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
     {
         $callableArg = $node->getArgs()[0]->value;
-        $callableInfo = $scope->getType($callableArg);
+        $callableType = $scope->getType($callableArg);
 
-        if (!$callableInfo->isCallable()->yes()) {
+        if (!$callableType->isCallable()->yes()) {
             return new SpecifiedTypes();
         }
 

--- a/tests/src/Type/data/inspector.php
+++ b/tests/src/Type/data/inspector.php
@@ -3,155 +3,206 @@
 use Drupal\Component\Assertion\Inspector;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
+use Drupal\node\Entity\Node;
 use function PHPStan\Testing\assertType;
 
-function mixed_function(): mixed {
-  return NULL;
+/**
+ * @see Inspector::assertAll()
+ */
+function assertAll(mixed $mixed_arg, array $array_arg): void {
+    $callable = is_string(...);
+
+    Inspector::assertAll($callable, $mixed_arg)
+        ? assertType('iterable', $mixed_arg)
+        : assertType('mixed', $mixed_arg);
+
+    Inspector::assertAll($callable, $array_arg)
+        ? assertType('array', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAll()
-$callable = fn (string $value): bool => $value === 'foo';
-$input = mixed_function();
-if (Inspector::assertAll($callable, $input)) {
-    assertType("iterable", $input);
-}
-else {
-    assertType('mixed', $input);
+/**
+ * @see Inspector::assertAllStrings()
+ */
+function assertAllStrings(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllStrings($mixed_arg)
+        ? assertType('iterable<string>', $mixed_arg)
+        : assertType('mixed~iterable<string>', $mixed_arg);
+
+    Inspector::assertAllStrings($array_arg)
+        ? assertType('array<string>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-$input = mixed_function();
-$callable = is_string(...);
-if (Inspector::assertAll($callable, $input)) {
-    assertType('iterable', $input);
-}
-else {
-    assertType('mixed', $input);
+/**
+ * @see Inspector::assertAllStringable()
+ */
+function assertAllStringable(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllStringable($mixed_arg)
+        ? assertType('iterable<string|Stringable>', $mixed_arg)
+        : assertType('mixed~iterable<string|Stringable>', $mixed_arg);
+
+    Inspector::assertAllStringable($array_arg)
+        ? assertType('array<string|Stringable>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
+/**
+ * @see Inspector::assertAllArrays()
+ */
+function assertAllArrays(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllArrays($mixed_arg)
+        ? assertType('iterable<array>', $mixed_arg)
+        : assertType('mixed~iterable<array>', $mixed_arg);
 
-// Inspector::assertAllStrings()
-$input = mixed_function();
-if (Inspector::assertAllStrings($input)) {
-    assertType('iterable<string>', $input);
-}
-else {
-    assertType('mixed~iterable<string>', $input);
-}
-
-// Inspector::assertAllStringable()
-$input = mixed_function();
-if (Inspector::assertAllStringable($input)) {
-    assertType('iterable<string|Stringable>', $input);
-}
-else {
-    assertType('mixed~iterable<string|Stringable>', $input);
+    Inspector::assertAllArrays($array_arg)
+        ? assertType('array<array>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllArrays()
-$input = mixed_function();
-if (Inspector::assertAllArrays($input)) {
-    assertType('iterable<array>', $input);
-}
-else {
-    assertType('mixed~iterable<array>', $input);
+/**
+ * @see Inspector::assertStrictArray()
+ */
+function assertStrictArray(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertStrictArray($mixed_arg)
+        ? assertType('array<int<0, max>, mixed>', $mixed_arg)
+        : assertType('mixed~array<int<0, max>, mixed>', $mixed_arg);
+
+    Inspector::assertStrictArray($array_arg)
+        ? assertType('array<int<0, max>, mixed>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertStrictArray()
-$input = mixed_function();
-if (Inspector::assertStrictArray($input)) {
-    assertType('array<int<0, max>, mixed>', $input);
-}
-else {
-    assertType('mixed~array<int<0, max>, mixed>', $input);
+/**
+ * @see Inspector::assertAllStrictArrays()
+ */
+function assertAllStrictArrays(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllStrictArrays($mixed_arg)
+        ? assertType('iterable<array<int<0, max>, mixed>>', $mixed_arg)
+        : assertType('mixed~iterable<array<int<0, max>, mixed>>', $mixed_arg);
+
+    Inspector::assertAllStrictArrays($array_arg)
+        ? assertType('array<array<int<0, max>, mixed>>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllStrictArrays()
-$input = mixed_function();
-if (Inspector::assertAllStrictArrays($input)) {
-    assertType('iterable<array<int<0, max>, mixed>>', $input);
-}
-else {
-    assertType('mixed~iterable<array<int<0, max>, mixed>>', $input);
+/**
+ * @see Inspector::assertAllHaveKey()
+ */
+function assertAllHaveKey(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllHaveKey($mixed_arg, 'foo', 'baz')
+        ? assertType("iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $mixed_arg)
+        : assertType("mixed~iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $mixed_arg);
+
+    Inspector::assertAllHaveKey($array_arg, 'foo', 'baz')
+        ? assertType("array<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllHaveKey()
-$input = mixed_function();
-if (Inspector::assertAllHaveKey($input, 'foo', 'baz')) {
-    assertType("iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $input);
-}
-else {
-    assertType("mixed~iterable<non-empty-array&hasOffset('baz')&hasOffset('foo')>", $input);
+/**
+ * @see Inspector::assertAllIntegers()
+ */
+function assertAllIntegers(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllIntegers($mixed_arg)
+        ? assertType('iterable<int>', $mixed_arg)
+        : assertType('mixed~iterable<int>', $mixed_arg);
+
+    Inspector::assertAllIntegers($array_arg)
+        ? assertType('array<int>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllIntegers()
-$input = mixed_function();
-if (Inspector::assertAllIntegers($input)) {
-    assertType('iterable<int>', $input);
-}
-else {
-    assertType('mixed~iterable<int>', $input);
+/**
+ * @see Inspector::assertAllFloat()
+ */
+function assertAllFloat(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllFloat($mixed_arg)
+        ? assertType('iterable<float>', $mixed_arg)
+        : assertType('mixed~iterable<float>', $mixed_arg);
+
+    Inspector::assertAllFloat($array_arg)
+        ? assertType('array<float>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllFloat()
-$input = mixed_function();
-if (Inspector::assertAllFloat($input)) {
-    assertType('iterable<float>', $input);
-}
-else {
-    assertType('mixed~iterable<float>', $input);
+/**
+ * @see Inspector::assertAllCallable()
+ */
+function assertAllCallable(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllCallable($mixed_arg)
+        ? assertType('iterable<callable(): mixed>', $mixed_arg)
+        : assertType('mixed~iterable<callable(): mixed>', $mixed_arg);
+
+    Inspector::assertAllCallable($array_arg)
+        ? assertType('array<callable(): mixed>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllCallable()
-$input = mixed_function();
-if (Inspector::assertAllCallable($input)) {
-    assertType('iterable<callable(): mixed>', $input);
-}
-else {
-    assertType('mixed~iterable<callable(): mixed>', $input);
+/**
+ * @see Inspector::assertAllNotEmpty()
+ */
+function assertAllNotEmpty(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllNotEmpty($mixed_arg)
+        ? assertType('iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $mixed_arg)
+        : assertType('mixed~iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $mixed_arg);
+
+    Inspector::assertAllNotEmpty($array_arg)
+        ? assertType('array<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllNotEmpty()
-$input = mixed_function();
-if (Inspector::assertAllNotEmpty($input)) {
-    assertType('iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $input);
-}
-else {
-    assertType('mixed~iterable<float|int<min, -1>|int<1, max>|object|resource|non-empty-string|non-empty-array>', $input);
+/**
+ * @see Inspector::assertAllNumeric()
+ */
+function assertAllNumeric(mixed $mixed_arg, array $array_arg): void {
+    Inspector::assertAllNumeric($mixed_arg)
+        ? assertType('iterable<float|int>', $mixed_arg)
+        : assertType('mixed~iterable<float|int>', $mixed_arg);
+
+    Inspector::assertAllNumeric($array_arg)
+        ? assertType('array<float|int>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllNumeric()
-$input = mixed_function();
-if (Inspector::assertAllNumeric($input)) {
-    assertType('iterable<float|int>', $input);
-}
-else {
-    assertType('mixed~iterable<float|int>', $input);
+/**
+ * @see Inspector::assertAllMatch()
+ */
+function assertAllMatch(mixed $mixed_arg, array $array_arg): void {
+    $pattern = 'foo';
+    Inspector::assertAllMatch($pattern, $mixed_arg, false)
+        ? assertType('iterable<string>', $mixed_arg)
+        : assertType('mixed~iterable<string>', $mixed_arg);
+
+    Inspector::assertAllMatch($pattern, $array_arg, false)
+        ? assertType('array<string>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllMatch()
-$pattern = 'foo';
-$input = mixed_function();
-if (Inspector::assertAllMatch($pattern, $input, false)) {
-    assertType('iterable<string>', $input);
-}
-else {
-    assertType('mixed~iterable<string>', $input);
+/**
+ * @see Inspector::assertAllRegularExpressionMatch()
+ */
+function assertAllRegularExpressionMatch(mixed $mixed_arg, array $array_arg): void {
+    $pattern = 'foo';
+    Inspector::assertAllRegularExpressionMatch($pattern, $mixed_arg)
+        ? assertType('iterable<string>', $mixed_arg)
+        : assertType('mixed~iterable<string>', $mixed_arg);
+
+    Inspector::assertAllRegularExpressionMatch($pattern, $array_arg)
+        ? assertType('array<string>', $array_arg)
+        : assertType('array', $array_arg);
 }
 
-// Inspector::assertAllRegularExpressionMatch()
-$input = mixed_function();
-if (Inspector::assertAllRegularExpressionMatch($pattern, $input)) {
-    assertType('iterable<string>', $input);
-}
-else {
-    assertType('mixed~iterable<string>', $input);
-}
+/**
+ * @see Inspector::assertAllObjects()
+ */
+function assertAllObjects(mixed $mixed_arg, array $array_arg): void {
+    // Note: 'TranslatableMarkup' is not mentioned in the final union type,
+    // because it is a subtype of '\Stringable'.
+    Inspector::assertAllObjects($mixed_arg, Node::class, TranslatableMarkup::class, '\\Stringable', '\\Drupal\\jsonapi\\JsonApiResource\\ResourceIdentifier')
+        ? assertType('iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|Drupal\node\Entity\Node|\Stringable>', $mixed_arg)
+        : assertType('mixed~iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|Drupal\node\Entity\Node|\Stringable>', $mixed_arg);
 
-// Inspector::assertAllObjects()
-$input = mixed_function();
-if (Inspector::assertAllObjects($input, TranslatableMarkup::class, '\\Stringable', '\\Drupal\\jsonapi\\JsonApiResource\\ResourceIdentifier')) {
-    assertType('iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|\Stringable>', $input);
-}
-else {
-    assertType('mixed~iterable<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|\Stringable>', $input);
+    Inspector::assertAllObjects($array_arg, Node::class, TranslatableMarkup::class, '\\Stringable', '\\Drupal\\jsonapi\\JsonApiResource\\ResourceIdentifier')
+        ? assertType('array<\Drupal\jsonapi\JsonApiResource\ResourceIdentifier|Drupal\node\Entity\Node|\Stringable>', $array_arg)
+        : assertType('array', $array_arg);
 }


### PR DESCRIPTION
While I've worked and played with different cases for #870, I've improved test cases and unified `InspectorTypeExtension` logic.

The main changes:

* The extension variables are now named identically across all methods, and their names are more clear about what information they contain. For example: `$traversable` (traversable what?) → `$traversableArg` and `$traversableInfo` (too obscure) → `$traversableType`.
* Add the `$newType` variable for the return type, so the `return` statement is much simpler and doesn't contain any logic.
* I improved test cases so they test `mixed` and `array` types at the same time. Using the ternary operator in test cases makes them much simpler and easier to read, and makes the code smaller.

I don't mind if you decide not to merge it. It was done anyway, so think of it as kind of a proposal for improvement. If you wish to merge it, I can prepare a backport for 1.x.