### PR TITLE
IDs can be strings, `RevisionableStorageInterface::loadRevision` should accept string ids

### DIFF
--- a/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
@@ -5,7 +5,7 @@ namespace Drupal\Core\Entity;
 interface RevisionableStorageInterface extends EntityStorageInterface {
 
   /**
-   * @param int|numeric-string $revision_id
+   * @param int|numeric-string|string $revision_id
    * @return \Drupal\Core\Entity\RevisionableInterface|null
    */
   public function loadRevision($revision_id);


### PR DESCRIPTION
Same as #894, I did have a stub for `RevisionableStorageInterface` [with this change in scheduled_transitions modul](https://git.drupalcode.org/project/scheduled_transitions/-/blob/2.8.x/stubs/Stubs.stub?ref_type=heads#L33)e, but it is no longer taking effect because phpstan-drupal prevents it.
