### PR TITLE
Allow installers v2 so we can get rid of PHP 8.4 errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "behat/mink": "^1.10",
-        "composer/installers": "^1.9",
+        "composer/installers": "^1.9 || ^2",
         "drupal/core-recommended": "^10",
         "drush/drush": "^11 || ^12 || ^13",
         "phpstan/extension-installer": "^1.4.3",


### PR DESCRIPTION
>  Implicitly marking parameter $filesystem as nullable is deprecated
> Composer/Installers/Installer.php:136