### PR TITLE
IDs can be strings, `RevisionableStorageInterface::deleteRevision` should accept string ids

### DIFF
--- a/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
@@ -11,7 +11,7 @@ interface RevisionableStorageInterface extends EntityStorageInterface {
   public function loadRevision($revision_id);
 
   /**
-   * @param int|numeric-string $revision_id
+   * @param int|numeric-string|string $revision_id
    */
   public function deleteRevision($revision_id): void;
   


### PR DESCRIPTION
Similar to #895, as found in https://git.drupalcode.org/project/scheduled_transitions/-/merge_requests/73