### PR TITLE
✨ Narrow return value of getLinkTemplate by whether hastLinkTemplate was called beforehand

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -291,6 +291,9 @@ services:
 		class: mglaman\PHPStanDrupal\Type\EntityIdNarrowedByNew
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
+		class: mglaman\PHPStanDrupal\Type\EntityTypeLinkTemplateByExistence
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+	-
 		class: mglaman\PHPStanDrupal\Type\EntityTypeManagerGetStorageDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-

--- a/src/Type/EntityTypeLinkTemplateByExistence.php
+++ b/src/Type/EntityTypeLinkTemplateByExistence.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Type;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+/**
+ * @author Daniel Phin <pro@danielph.in>
+ */
+class EntityTypeLinkTemplateByExistence implements DynamicMethodReturnTypeExtension
+{
+
+    public function getClass(): string
+    {
+        return EntityTypeInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getLinkTemplate';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        if (null === ($keyArg = $methodCall->getArg('key', 0))) {
+            return null;
+        }
+
+        $originalReturnType = $methodReflection->getVariants()[0]->getReturnType();
+        $hasKeyMethodCall = new MethodCall($methodCall->var, new Identifier('hasLinkTemplate'), [$keyArg]);
+        if ($scope->getType($hasKeyMethodCall)->isTrue()->yes()) {
+            return $originalReturnType->tryRemove(new ConstantBooleanType(false));
+        } elseif ($scope->getType($hasKeyMethodCall)->isFalse()->yes()) {
+            return $originalReturnType->tryRemove(new StringType());
+        }
+
+        return $originalReturnType;
+    }
+}

--- a/stubs/Drupal/Core/Entity/EntityTypeInterface.stub
+++ b/stubs/Drupal/Core/Entity/EntityTypeInterface.stub
@@ -4,4 +4,9 @@ namespace Drupal\Core\Entity;
 
 interface EntityTypeInterface {
 
+    /**
+     * @return string|false
+     */
+    public function getLinkTemplate(string $key);
+
 }

--- a/tests/src/Type/data/entity-type-stubs.php
+++ b/tests/src/Type/data/entity-type-stubs.php
@@ -3,6 +3,7 @@
 namespace EntityTypeStubs;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityType;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\node\Entity\Node;
 
@@ -15,3 +16,24 @@ function (ContentEntityInterface $entity): void
         assertType(FieldItemListInterface::class, $field);
     }
 };
+
+assert($entityTypeDefault instanceof EntityType);
+assertType('string|false', $entityTypeDefault->getLinkTemplate('foo'));
+
+assert($noLinkTemplate instanceof EntityType);
+assert($noLinkTemplate->hasLinkTemplate('foo') === FALSE);
+assertType('false', $noLinkTemplate->getLinkTemplate('foo'));
+
+assert($hasLinkTemplate instanceof EntityType);
+assert($hasLinkTemplate->hasLinkTemplate('foo') === TRUE);
+assertType('string', $hasLinkTemplate->getLinkTemplate('foo'));
+
+// Test getting a link template doesn't affect another link template.
+assert($entityType instanceof EntityType);
+assert($entityType->hasLinkTemplate('foo') === TRUE);
+assertType('string', $entityType->getLinkTemplate('foo'));
+// A different arg that wasn't narrowed previously:
+assertType('string|false', $entityType->getLinkTemplate('bar'));
+// ...until we know better:
+assert($entityType->hasLinkTemplate('bar') === TRUE);
+assertType('string', $entityType->getLinkTemplate('bar'));


### PR DESCRIPTION
Another one of https://github.com/mglaman/phpstan-drupal/pull/905

I'd like to rid myself of https://git.drupalcode.org/project/scheduled_transitions/-/blame/2.8.x/src/Routing/ScheduledTransitionRouteProvider.php#L40-41