### PR TITLE
Remove FilterProcessResult test case from RenderCallbackRuleTest

### DIFF
--- a/tests/src/Rules/RenderCallbackRuleTest.php
+++ b/tests/src/Rules/RenderCallbackRuleTest.php
@@ -145,10 +145,6 @@ final class RenderCallbackRuleTest extends DrupalRuleTestCase {
             __DIR__ . '/data/bug-424.php',
             $bug424
         ];
-        yield [
-            __DIR__ . '/../../fixtures/drupal/core/modules/filter/src/FilterProcessResult.php',
-            []
-        ];
         if (version_compare(\Drupal::VERSION, '10.1', '>=')) {
             yield [
                 __DIR__ . '/data/bug-527.php',


### PR DESCRIPTION
PHPStan changed how stubs are loaded, and testing FilterProcessResult for our own stub doesn't work anymore.

fixes #938