### PR TITLE
Make FieldItemListPropertyReflection entity property nullable

### DIFF
--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -9,6 +9,7 @@ use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 use function in_array;
 
 /**
@@ -42,7 +43,7 @@ class FieldItemListPropertyReflection implements PropertyReflection
     public function getReadableType(): Type
     {
         if ($this->propertyName === 'entity') {
-            return new ObjectType('Drupal\Core\Entity\EntityInterface');
+            return new UnionType([new ObjectType('Drupal\Core\Entity\EntityInterface'), new NullType()]);
         }
         if ($this->propertyName === 'target_id') {
             // @todo needs to be union type.
@@ -60,7 +61,7 @@ class FieldItemListPropertyReflection implements PropertyReflection
     public function getWritableType(): Type
     {
         if ($this->propertyName === 'entity') {
-            return new ObjectType('Drupal\Core\Entity\EntityInterface');
+            return new UnionType([new ObjectType('Drupal\Core\Entity\EntityInterface'), new NullType()]);
         }
         if ($this->propertyName === 'target_id') {
             return new StringType();

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -13,6 +13,7 @@ use PHPStan\Testing\PHPStanTestCase;
 use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\VerbosityLevel;
 
 final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase {
 
@@ -119,7 +120,7 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
         self::assertInstanceOf(StringType::class, $readableType);
         $propertyReflection = $this->extension->getProperty($classReflection, 'entity');
         $readableType = $propertyReflection->getReadableType();
-        self::assertInstanceOf(ObjectType::class, $readableType);
+        self::assertSame('Drupal\Core\Entity\EntityInterface|null', $readableType->describe(VerbosityLevel::typeOnly()));
         $propertyReflection = $this->extension->getProperty($classReflection, 'format');
         $readableType = $propertyReflection->getReadableType();
         self::assertInstanceOf(NullType::class, $readableType);


### PR DESCRIPTION
Currently, code like:

```php
public function getFoo(): ?Foo {
  return $this->get('foo')->entity;
}
```

will produce an error: `return.unusedType` — "never returns null so it can be removed from the return type".

This is not true, because Drupal has no entity reference integrity by default. It means even if the field is required and has a value, it doesn't mean that the referenced entity actually exists. For example: the `foo` field has a reference ID 123, but the entity with ID 123 is no longer available (removed or otherwise).

But this rule forces a fix like this one:

```diff
-public function getFoo(): ?Foo {
+public function getFoo(): Foo {
   return $this->get('foo')->entity;
 }
```

And when the referenced entity is actually missing, you will have a fatal error in production, because `->entity` will return `null`.

Because of this, when you understand the issue, you have to ignore every other line with that magic property, which is also not a valid solution. The most appropriate options are:

```php
public function getFoo(): ?Foo {
  $entity = $this->get('foo')->entity;
  \assert($entity instanceof Foo || $entity === null);
  return $entity;
}
```

or

```php
public function getFoo(): Foo {
  $entity = $this->get('foo')->entity;
  if (!$entity instanceof Foo) {
    throw new \RuntimeException('Required reference is missing');
  }
  return $entity;
}
```

It depends on project requirements, environment (with entity integrity protection it is safe to force a specific return type with an exception if needed), or style. But the current behavior simply forces developers down a path which will introduce dangerous bugs.
