### PR TITLE
Add TodoCommentWithIssueUrlRule to flag @todo comments referencing the current issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,37 @@ parameters:
 
 Both options are enabled by default.
 
+#### Detecting @todo comments referencing the current Drupal.org issue (contrib CI)
+
+`TodoCommentWithIssueUrlRule` is an opt-in rule for Drupal contrib CI pipelines. When running PHPStan as part of a GitLab merge request, it reports an error for any `@todo` comment that contains a drupal.org issue URL matching the current issue — for example:
+
+```php
+// @todo Remove once https://drupal.org/i/3456789 is resolved.
+```
+
+This prevents issue-specific TODOs from being accidentally merged without resolution.
+
+The rule auto-detects the current issue NID from standard GitLab CI environment variables:
+
+- `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` (e.g. `3456789-my-feature`)
+- `CI_MERGE_REQUEST_SOURCE_PROJECT_PATH` (e.g. `issue/mymodule-3456789`)
+
+It is silent when neither variable is set, so it is safe to include in a shared config.
+
+The rule is **not registered by default**. To enable it, add it to your project's `phpstan.neon`:
+
+```neon
+rules:
+    - mglaman\PHPStanDrupal\Rules\Drupal\TodoCommentWithIssueUrlRule
+```
+
+> [!NOTE]
+> When using the [Drupal GitLab CI templates](https://project.pages.drupalcode.org/gitlab_templates/jobs/phpstan/),
+> adding extra rules requires a custom `phpstan.neon` that includes the default configuration, since adding additional
+> rules is not supported directly through the template variables.
+
+Both `drupal.org/i/{nid}` and `drupal.org/project/{project}/issues/{nid}` URL formats are recognized.
+
 ### Entity storage mappings.
 
 The `EntityTypeManagerGetStorageDynamicReturnTypeExtension` service helps map dynamic return types. This inspects the

--- a/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
+++ b/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
@@ -78,13 +78,16 @@ final class TodoCommentWithIssueUrlRule implements Rule
     }
 
     /**
-     * @param Node[] $nodes
+     * @param array<mixed> $nodes
      * @param array<array{Comment, int}> $collected
      * @param array<int, true> $seen
      */
     private function traverseNodes(array $nodes, array &$collected, array &$seen): void
     {
         foreach ($nodes as $node) {
+            if (!$node instanceof Node) {
+                continue;
+            }
             foreach ($node->getComments() as $comment) {
                 $line = $comment->getStartLine();
                 if (isset($seen[$line])) {

--- a/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
+++ b/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
@@ -125,7 +125,7 @@ final class TodoCommentWithIssueUrlRule implements Rule
         foreach ($matches[1] as $nid) {
             if ((int) $nid === $this->issueId) {
                 return RuleErrorBuilder::message(sprintf(
-                    '@todo references the current issue #%d on drupal.org and must be resolved before merging.',
+                    '@todo references the current issue #%d.',
                     $this->issueId
                 ))
                     ->line($line)

--- a/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
+++ b/src/Rules/Drupal/TodoCommentWithIssueUrlRule.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use PhpParser\Comment;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Detects @todo comments that reference the current Drupal.org issue.
+ *
+ * Intended for use in Drupal contrib CI pipelines. When a merge request is
+ * open for a specific issue, any @todo referencing that issue's URL should be
+ * resolved before the MR is merged.
+ *
+ * The current issue NID is detected from GitLab CI environment variables:
+ *   - CI_MERGE_REQUEST_SOURCE_BRANCH_NAME (e.g. "3580523-prompt-user-to")
+ *   - CI_MERGE_REQUEST_SOURCE_PROJECT_PATH (e.g. "issue/canvas-3580523")
+ *
+ * This rule is not registered by default. To use it, add to your phpstan.neon:
+ *
+ * @code
+ * rules:
+ *   - mglaman\PHPStanDrupal\Rules\Drupal\TodoCommentWithIssueUrlRule
+ * @endcode
+ *
+ * @implements Rule<FileNode>
+ */
+final class TodoCommentWithIssueUrlRule implements Rule
+{
+
+    private ?int $issueId;
+
+    public function __construct(?int $issueId = null)
+    {
+        $this->issueId = $issueId ?? self::detectIssueIdFromEnvironment();
+    }
+
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->issueId === null) {
+            return [];
+        }
+
+        /** @var FileNode $node */
+        $comments = $this->collectAllComments($node->getNodes());
+        $errors = [];
+        foreach ($comments as [$comment, $line]) {
+            $result = $this->checkComment($comment, $line);
+            if ($result !== null) {
+                $errors[] = $result;
+            }
+        }
+        return $errors;
+    }
+
+    /**
+     * @param Node[] $nodes
+     * @return array<array{Comment, int}>
+     */
+    private function collectAllComments(array $nodes): array
+    {
+        $collected = [];
+        $seen = [];
+        $this->traverseNodes($nodes, $collected, $seen);
+        return $collected;
+    }
+
+    /**
+     * @param Node[] $nodes
+     * @param array<array{Comment, int}> $collected
+     * @param array<int, true> $seen
+     */
+    private function traverseNodes(array $nodes, array &$collected, array &$seen): void
+    {
+        foreach ($nodes as $node) {
+            foreach ($node->getComments() as $comment) {
+                $line = $comment->getStartLine();
+                if (isset($seen[$line])) {
+                    continue;
+                }
+                $seen[$line] = true;
+                $collected[] = [$comment, $line];
+            }
+            // PHP-Parser sub-nodes are public properties; get_object_vars avoids dynamic property access.
+            $vars = get_object_vars($node);
+            foreach ($node->getSubNodeNames() as $subNodeName) {
+                if (!array_key_exists($subNodeName, $vars)) {
+                    continue;
+                }
+                $subNode = $vars[$subNodeName];
+                if ($subNode instanceof Node) {
+                    $this->traverseNodes([$subNode], $collected, $seen);
+                } elseif (is_array($subNode)) {
+                    $this->traverseNodes($subNode, $collected, $seen);
+                }
+            }
+        }
+    }
+
+    private function checkComment(Comment $comment, int $line): ?IdentifierRuleError
+    {
+        $text = $comment->getText();
+
+        if (stripos($text, '@todo') === false) {
+            return null;
+        }
+
+        $pattern = '#drupal\.org/(?:i/|project/[^/\s]+/issues/)(\d+)#i';
+        if (preg_match_all($pattern, $text, $matches) === 0) {
+            return null;
+        }
+
+        foreach ($matches[1] as $nid) {
+            if ((int) $nid === $this->issueId) {
+                return RuleErrorBuilder::message(sprintf(
+                    '@todo references the current issue #%d on drupal.org and must be resolved before merging.',
+                    $this->issueId
+                ))
+                    ->line($line)
+                    ->identifier('drupal.todoCurrentIssue')
+                    ->build();
+            }
+        }
+
+        return null;
+    }
+
+    private static function detectIssueIdFromEnvironment(): ?int
+    {
+        // CI_MERGE_REQUEST_SOURCE_BRANCH_NAME=3580523-prompt-user-to
+        $branchName = getenv('CI_MERGE_REQUEST_SOURCE_BRANCH_NAME');
+        if (is_string($branchName) && preg_match('/^(\d+)/', $branchName, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        // CI_MERGE_REQUEST_SOURCE_PROJECT_PATH=issue/canvas-3580523
+        $projectPath = getenv('CI_MERGE_REQUEST_SOURCE_PROJECT_PATH');
+        if (is_string($projectPath) && preg_match('/-(\d+)$/', $projectPath, $matches) === 1) {
+            return (int) $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
+++ b/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
@@ -22,15 +22,15 @@ final class TodoCommentWithIssueUrlRuleTest extends DrupalRuleTestCase
             [__DIR__ . '/data/todo-comment-with-issue-url.php'],
             [
                 [
-                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    '@todo references the current issue #3456789.',
                     5,
                 ],
                 [
-                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    '@todo references the current issue #3456789.',
                     11,
                 ],
                 [
-                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    '@todo references the current issue #3456789.',
                     23,
                 ],
             ]

--- a/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
+++ b/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\TodoCommentWithIssueUrlRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class TodoCommentWithIssueUrlRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new TodoCommentWithIssueUrlRule(3456789);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/todo-comment-with-issue-url.php'],
+            [
+                [
+                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    5,
+                ],
+                [
+                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    11,
+                ],
+                [
+                    '@todo references the current issue #3456789 on drupal.org and must be resolved before merging.',
+                    23,
+                ],
+            ]
+        );
+    }
+
+
+}

--- a/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
+++ b/tests/src/Rules/TodoCommentWithIssueUrlRuleTest.php
@@ -23,19 +23,18 @@ final class TodoCommentWithIssueUrlRuleTest extends DrupalRuleTestCase
             [
                 [
                     '@todo references the current issue #3456789.',
-                    5,
+                    5
                 ],
                 [
                     '@todo references the current issue #3456789.',
-                    11,
+                    11
                 ],
                 [
                     '@todo references the current issue #3456789.',
-                    23,
+                    23
                 ],
             ]
         );
     }
-
 
 }

--- a/tests/src/Rules/data/todo-comment-with-issue-url.php
+++ b/tests/src/Rules/data/todo-comment-with-issue-url.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+// @todo This references the current issue https://drupal.org/i/3456789 and should fail.
+$a = 1;
+
+// @todo This references a different issue https://drupal.org/i/1234567 and should pass.
+$b = 2;
+
+// @todo This references the long-form URL https://drupal.org/project/drupal/issues/3456789 and should fail.
+$c = 3;
+
+// @todo This references a different project issue https://drupal.org/project/token/issues/9999999 and should pass.
+$d = 4;
+
+// This is just a regular comment with no todo.
+$e = 5;
+
+// @todo No URL here, just a plain todo.
+$f = 6;
+
+/**
+ * @todo Block comment referencing current issue https://drupal.org/i/3456789 should fail.
+ */
+$g = 7;


### PR DESCRIPTION
## Summary

- Adds `TodoCommentWithIssueUrlRule`, an opt-in PHPStan rule for Drupal contrib CI pipelines
- Reports an error when a `@todo` comment contains a `drupal.org` issue URL matching the current MR's issue NID (e.g. `drupal.org/i/3456789` or `drupal.org/project/foo/issues/3456789`)
- The rule auto-detects the issue NID from GitLab CI env vars (`CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` or `CI_MERGE_REQUEST_SOURCE_PROJECT_PATH`) and is a no-op when neither is set

## Usage

Not registered by default. Contrib projects opt in via their `phpstan.neon`:

```yaml
rules:
  - mglaman\PHPStanDrupal\Rules\Drupal\TodoCommentWithIssueUrlRule
```

See https://project.pages.drupalcode.org/gitlab_templates/jobs/phpstan/ for adding a custom PHPStan configuration alongside the GitLab CI templates.

## Test plan

- [ ] `php vendor/bin/phpunit --filter=TodoCommentWithIssueUrlRuleTest` passes
- [ ] `php vendor/bin/phpstan analyze src/Rules/Drupal/TodoCommentWithIssueUrlRule.php` reports no errors
- [ ] `php vendor/bin/phpcs src/Rules/Drupal/TodoCommentWithIssueUrlRule.php` reports no errors

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)