### PR TITLE
Fix FormatterInterfaceGenericTest assertions for unparameterized formatter

### DIFF
--- a/tests/src/Generics/data/formatter-interface.php
+++ b/tests/src/Generics/data/formatter-interface.php
@@ -18,31 +18,31 @@ class EmptyFormatter implements FormatterInterface {
         assertType('array<Drupal\Core\Field\FieldItemListInterface>', $entities_items);
         $items = $entities_items[0];
         assertType('Drupal\Core\Field\FieldItemListInterface', $items);
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
         foreach ($items as $item) {
-            assertType('mixed', $item);
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
         }
     }
 
     public function view(FieldItemListInterface $items, $langcode = NULL) {
         assertType('Drupal\Core\Field\FieldItemListInterface', $items);
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
         foreach ($items as $item) {
-            assertType('mixed', $item);
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
         }
     }
 
     public function viewElements(FieldItemListInterface $items, $langcode) {
         assertType('Drupal\Core\Field\FieldItemListInterface', $items);
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->first());
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->get(0));
-        assertType('Drupal\Core\TypedData\TypedDataInterface|null', $items->offsetGet(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->first());
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->get(0));
+        assertType('Drupal\Core\Field\FieldItemInterface|null', $items->offsetGet(0));
         foreach ($items as $item) {
-            assertType('mixed', $item);
+            assertType('Drupal\Core\Field\FieldItemInterface', $item);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes 12 failing test assertions in `FormatterInterfaceGenericTest`.

When `EmptyFormatter` implements `FormatterInterface` without specifying a generic type parameter, PHPStan resolves the template bound to `FieldItemListInterface<FieldItemInterface>`. The test assertions expected the less specific `TypedDataInterface|null` and `mixed`, but PHPStan correctly resolves to `FieldItemInterface|null` and `FieldItemInterface` based on the `@template T of FieldItemInterface` bound on `FieldItemListInterface`.

Updated the `EmptyFormatter` assertions to match the actual resolved types.

**Before:** 730 tests, 12 failures
**After:** 730 tests, 0 failures