### PR TITLE
Fix inverted isCount cache key logic in EntityQueryType

### DIFF
--- a/src/Type/EntityQuery/EntityQueryType.php
+++ b/src/Type/EntityQuery/EntityQueryType.php
@@ -55,7 +55,7 @@ class EntityQueryType extends ObjectType
     {
         $parts = [
             $this->hasAccessCheck ? 'with-access-check' : 'without-access-check',
-            $this->isCount ? '' : 'count'
+            $this->isCount ? 'count' : ''
         ];
         return implode('-', $parts);
     }


### PR DESCRIPTION
## Summary

- `EntityQueryType::describeAdditionalCacheKey()` had an inverted ternary on line 58: `$this->isCount ? '' : 'count'`
- When `$this->isCount` is `true`, the method was returning an empty string instead of `'count'`
- PHPStan uses this key to distinguish cached types, so count and non-count queries of the same entity type could share identical cache keys, leading to incorrect type inference

**Fix:** swap the ternary branches so `true` → `'count'` and `false` → `''`.

Fixes #961

## Test plan

- [x] `php vendor/bin/phpunit --filter=EntityQuery` — 49 tests pass
- [x] `php vendor/bin/phpcs src/` — no coding standard issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)