### PR TITLE
Add LoggerFromFactoryPropertyAssignmentRule

### DIFF
--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -10,4 +10,4 @@ parameters:
 			accessResultConditionRule: true
 			cacheableDependencyRule: true
 			hookRules: true
-			loggerFromFactoryPropertyRule: true
+			loggerFromFactoryPropertyAssignmentRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -10,3 +10,4 @@ parameters:
 			accessResultConditionRule: true
 			cacheableDependencyRule: true
 			hookRules: true
+			loggerFromFactoryPropertyRule: true

--- a/extension.neon
+++ b/extension.neon
@@ -35,7 +35,7 @@ parameters:
 			pluginManagerInspectionRule: false
 			cacheableDependencyRule: false
 			hookRules: false
-			loggerFromFactoryPropertyRule: false
+			loggerFromFactoryPropertyAssignmentRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -272,7 +272,7 @@ parametersSchema:
 			pluginManagerInspectionRule: boolean()
 			cacheableDependencyRule: boolean()
 			hookRules: boolean()
-			loggerFromFactoryPropertyRule: boolean()
+			loggerFromFactoryPropertyAssignmentRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/extension.neon
+++ b/extension.neon
@@ -35,6 +35,7 @@ parameters:
 			pluginManagerInspectionRule: false
 			cacheableDependencyRule: false
 			hookRules: false
+			loggerFromFactoryPropertyRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -271,6 +272,7 @@ parametersSchema:
 			pluginManagerInspectionRule: boolean()
 			cacheableDependencyRule: boolean()
 			hookRules: boolean()
+			loggerFromFactoryPropertyRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/rules.neon
+++ b/rules.neon
@@ -29,7 +29,7 @@ conditionalTags:
 	mglaman\PHPStanDrupal\Rules\Drupal\CacheableDependencyRule:
 		phpstan.rules.rule: %drupal.rules.cacheableDependencyRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\LoggerFromFactoryPropertyAssignmentRule:
-		phpstan.rules.rule: %drupal.rules.loggerFromFactoryPropertyRule%
+		phpstan.rules.rule: %drupal.rules.loggerFromFactoryPropertyAssignmentRule%
 
 services:
 	-

--- a/rules.neon
+++ b/rules.neon
@@ -28,6 +28,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.pluginManagerInspectionRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\CacheableDependencyRule:
 		phpstan.rules.rule: %drupal.rules.cacheableDependencyRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\LoggerFromFactoryPropertyAssignmentRule:
+		phpstan.rules.rule: %drupal.rules.loggerFromFactoryPropertyRule%
 
 services:
 	-
@@ -46,3 +48,5 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Classes\PluginManagerInspectionRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\CacheableDependencyRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\LoggerFromFactoryPropertyAssignmentRule

--- a/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
+++ b/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
@@ -60,7 +60,7 @@ final class LoggerFromFactoryPropertyAssignmentRule implements Rule
 
         return [
             RuleErrorBuilder::message(
-                'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.'
+                'Logger assigned from LoggerChannelFactory in a class using DependencySerializationTrait will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.'
             )
                 ->identifier('loggerFromFactory.propertyAssignment')
                 ->build(),

--- a/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
+++ b/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<Node\Expr\Assign>
+ */
+final class LoggerFromFactoryPropertyAssignmentRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\Assign::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // LHS must be a property fetch on $this.
+        if (!$node->var instanceof Node\Expr\PropertyFetch) {
+            return [];
+        }
+        if (!$node->var->var instanceof Node\Expr\Variable || $node->var->var->name !== 'this') {
+            return [];
+        }
+
+        // RHS must be a method call named 'get'.
+        if (!$node->expr instanceof Node\Expr\MethodCall) {
+            return [];
+        }
+        if (!$node->expr->name instanceof Identifier || $node->expr->name->toString() !== 'get') {
+            return [];
+        }
+
+        // Must be inside __construct.
+        $scopeFunction = $scope->getFunction();
+        if ($scopeFunction === null) {
+            return [];
+        }
+        if (!$scopeFunction instanceof ExtendedMethodReflection) {
+            return [];
+        }
+        if ($scopeFunction->getName() !== '__construct') {
+            return [];
+        }
+
+        // The receiver of ->get() must be LoggerChannelFactoryInterface.
+        $receiverType = $scope->getType($node->expr->var);
+        $factoryType = new ObjectType(LoggerChannelFactoryInterface::class);
+        if (!$factoryType->isSuperTypeOf($receiverType)->yes()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.'
+            )
+                ->identifier('loggerFromFactory.propertyAssignment')
+                ->tip('See https://www.drupal.org/node/3038430')
+                ->build(),
+        ];
+    }
+}

--- a/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
+++ b/src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ExtendedMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
@@ -26,7 +26,18 @@ final class LoggerFromFactoryPropertyAssignmentRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        // LHS must be a property fetch on $this.
+        if (!$scope->isInClass()) {
+            return [];
+        }
+        if (!$scope->getClassReflection()->hasTraitUse(DependencySerializationTrait::class)) {
+            return [];
+        }
+
+        $scopeFunction = $scope->getFunction();
+        if ($scopeFunction === null || $scopeFunction->getName() !== '__construct') {
+            return [];
+        }
+
         if (!$node->var instanceof Node\Expr\PropertyFetch) {
             return [];
         }
@@ -34,7 +45,6 @@ final class LoggerFromFactoryPropertyAssignmentRule implements Rule
             return [];
         }
 
-        // RHS must be a method call named 'get'.
         if (!$node->expr instanceof Node\Expr\MethodCall) {
             return [];
         }
@@ -42,19 +52,6 @@ final class LoggerFromFactoryPropertyAssignmentRule implements Rule
             return [];
         }
 
-        // Must be inside __construct.
-        $scopeFunction = $scope->getFunction();
-        if ($scopeFunction === null) {
-            return [];
-        }
-        if (!$scopeFunction instanceof ExtendedMethodReflection) {
-            return [];
-        }
-        if ($scopeFunction->getName() !== '__construct') {
-            return [];
-        }
-
-        // The receiver of ->get() must be LoggerChannelFactoryInterface.
         $receiverType = $scope->getType($node->expr->var);
         $factoryType = new ObjectType(LoggerChannelFactoryInterface::class);
         if (!$factoryType->isSuperTypeOf($receiverType)->yes()) {
@@ -66,7 +63,6 @@ final class LoggerFromFactoryPropertyAssignmentRule implements Rule
                 'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.'
             )
                 ->identifier('loggerFromFactory.propertyAssignment')
-                ->tip('See https://www.drupal.org/node/3038430')
                 ->build(),
         ];
     }

--- a/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
+++ b/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
@@ -25,6 +25,10 @@ final class LoggerFromFactoryPropertyAssignmentRuleTest extends DrupalRuleTestCa
                     'Logger assigned from LoggerChannelFactory in a class using DependencySerializationTrait will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
                     23,
                 ],
+                [
+                    'Logger assigned from LoggerChannelFactory in a class using DependencySerializationTrait will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
+                    36,
+                ],
             ]
         );
     }

--- a/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
+++ b/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
@@ -22,7 +22,7 @@ final class LoggerFromFactoryPropertyAssignmentRuleTest extends DrupalRuleTestCa
             [__DIR__ . '/data/logger-from-factory-property-assignment.php'],
             [
                 [
-                    'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
+                    'Logger assigned from LoggerChannelFactory in a class using DependencySerializationTrait will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
                     23,
                 ],
             ]

--- a/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
+++ b/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\LoggerFromFactoryPropertyAssignmentRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class LoggerFromFactoryPropertyAssignmentRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new LoggerFromFactoryPropertyAssignmentRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/logger-from-factory-property-assignment.php'],
+            [
+                [
+                    'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
+                    20,
+                    'See https://www.drupal.org/node/3038430',
+                ],
+            ]
+        );
+    }
+}

--- a/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
+++ b/tests/src/Rules/LoggerFromFactoryPropertyAssignmentRuleTest.php
@@ -23,8 +23,7 @@ final class LoggerFromFactoryPropertyAssignmentRuleTest extends DrupalRuleTestCa
             [
                 [
                     'Logger assigned from LoggerChannelFactory will break serialization. Inject a named logger channel service directly (e.g. @logger.channel.my_channel) instead.',
-                    20,
-                    'See https://www.drupal.org/node/3038430',
+                    23,
                 ],
             ]
         );

--- a/tests/src/Rules/data/logger-from-factory-property-assignment.php
+++ b/tests/src/Rules/data/logger-from-factory-property-assignment.php
@@ -24,6 +24,19 @@ class ClassWithLoggerFromFactory
     }
 }
 
+// Error: factory used directly as constructor parameter (not stored as property first).
+class ClassWithLoggerFromFactoryParam
+{
+    use DependencySerializationTrait;
+
+    private LoggerChannelInterface $logger;
+
+    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
+    {
+        $this->logger = $loggerFactory->get('my_module'); // error on this line
+    }
+}
+
 // No error: class does not use DependencySerializationTrait.
 class ClassWithoutTrait
 {

--- a/tests/src/Rules/data/logger-from-factory-property-assignment.php
+++ b/tests/src/Rules/data/logger-from-factory-property-assignment.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules\data;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+
+// Error: logger stored from factory->get() in constructor.
+class ClassWithLoggerFromFactory
+{
+    private LoggerChannelInterface $logger;
+
+    private LoggerChannelFactoryInterface $loggerFactory;
+
+    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
+    {
+        $this->loggerFactory = $loggerFactory;
+        $this->logger = $this->loggerFactory->get('my_module'); // error on this line
+    }
+}
+
+// No error: factory->get() called outside constructor.
+class ClassWithLoggerFromFactoryOutsideConstructor
+{
+    private LoggerChannelInterface $logger;
+
+    private LoggerChannelFactoryInterface $loggerFactory;
+
+    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
+    {
+        $this->loggerFactory = $loggerFactory;
+    }
+
+    public function setLogger(): void
+    {
+        $this->logger = $this->loggerFactory->get('my_module'); // no error
+    }
+}
+
+// No error: direct service injection (not from factory->get()).
+class ClassWithDirectLoggerInjection
+{
+    private LoggerChannelInterface $logger;
+
+    public function __construct(LoggerChannelInterface $logger)
+    {
+        $this->logger = $logger; // no error
+    }
+}
+
+// No error: local variable assignment from factory->get() in constructor.
+class ClassWithLocalLoggerVariable
+{
+    private LoggerChannelFactoryInterface $loggerFactory;
+
+    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
+    {
+        $this->loggerFactory = $loggerFactory;
+        $logger = $this->loggerFactory->get('my_module'); // no error: not a property
+    }
+}

--- a/tests/src/Rules/data/logger-from-factory-property-assignment.php
+++ b/tests/src/Rules/data/logger-from-factory-property-assignment.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Tests\Rules\data;
 
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 
-// Error: logger stored from factory->get() in constructor.
+// Error: logger stored from factory->get() in constructor, class uses DependencySerializationTrait.
 class ClassWithLoggerFromFactory
 {
+    use DependencySerializationTrait;
+
     private LoggerChannelInterface $logger;
 
     private LoggerChannelFactoryInterface $loggerFactory;
@@ -21,9 +24,25 @@ class ClassWithLoggerFromFactory
     }
 }
 
+// No error: class does not use DependencySerializationTrait.
+class ClassWithoutTrait
+{
+    private LoggerChannelInterface $logger;
+
+    private LoggerChannelFactoryInterface $loggerFactory;
+
+    public function __construct(LoggerChannelFactoryInterface $loggerFactory)
+    {
+        $this->loggerFactory = $loggerFactory;
+        $this->logger = $this->loggerFactory->get('my_module');
+    }
+}
+
 // No error: factory->get() called outside constructor.
 class ClassWithLoggerFromFactoryOutsideConstructor
 {
+    use DependencySerializationTrait;
+
     private LoggerChannelInterface $logger;
 
     private LoggerChannelFactoryInterface $loggerFactory;
@@ -35,29 +54,33 @@ class ClassWithLoggerFromFactoryOutsideConstructor
 
     public function setLogger(): void
     {
-        $this->logger = $this->loggerFactory->get('my_module'); // no error
+        $this->logger = $this->loggerFactory->get('my_module');
     }
 }
 
 // No error: direct service injection (not from factory->get()).
 class ClassWithDirectLoggerInjection
 {
+    use DependencySerializationTrait;
+
     private LoggerChannelInterface $logger;
 
     public function __construct(LoggerChannelInterface $logger)
     {
-        $this->logger = $logger; // no error
+        $this->logger = $logger;
     }
 }
 
 // No error: local variable assignment from factory->get() in constructor.
 class ClassWithLocalLoggerVariable
 {
+    use DependencySerializationTrait;
+
     private LoggerChannelFactoryInterface $loggerFactory;
 
     public function __construct(LoggerChannelFactoryInterface $loggerFactory)
     {
         $this->loggerFactory = $loggerFactory;
-        $logger = $this->loggerFactory->get('my_module'); // no error: not a property
+        $logger = $this->loggerFactory->get('my_module');
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new opt-in rule `LoggerFromFactoryPropertyAssignmentRule` that flags assignments in constructors where a logger obtained via `LoggerChannelFactoryInterface::get()` is stored as a class property (`$this->logger = $this->loggerFactory->get(...)` or `$this->logger = $loggerFactory->get(...)`)
- This pattern breaks serialization for classes using `DependencySerializationTrait`; the fix is to inject a named logger channel service directly (e.g. `@logger.channel.my_channel`)
- Rule is disabled by default (`loggerFromFactoryPropertyAssignmentRule: false`) and enabled in `bleedingEdge.neon`

Closes #138

## Test plan

- [x] New test class `LoggerFromFactoryPropertyAssignmentRuleTest` covers: two error cases (factory via stored property and direct constructor param), and non-error cases (outside constructor, no trait, direct injection, local variable)
- [x] `php vendor/bin/phpunit --filter=LoggerFromFactoryPropertyAssignmentRuleTest` passes
- [x] `php vendor/bin/phpcs src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php` passes
- [x] `php vendor/bin/phpstan analyze src/Rules/Drupal/LoggerFromFactoryPropertyAssignmentRule.php` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)