### PR TITLE
Document opt-in rules and bleedingEdge parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the `extension-installer` documentation for more information: https://github
 
 #### Opt-in rules
 
-Several rules are disabled by default to avoid breaking existing projects in a patch release. They may be enabled by default in a future minor version. Most of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
+Several rules are disabled by default to avoid breaking existing projects in a patch release. They may be enabled by default in a future minor version. All of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
 
 ```neon
 parameters:
@@ -182,6 +182,7 @@ Currently `bleedingEdge.neon` enables the following:
 - `accessResultConditionRule` — flags always-true/always-false `AccessResult` conditions
 - `cacheableDependencyRule` — flags `addCacheableDependency()` calls with non-cacheable arguments
 - `loggerFromFactoryPropertyAssignmentRule` — flags logger channels assigned to properties in classes using `DependencySerializationTrait`
+- `entityStorageDirectInjectionRule` — flags direct injection of entity storage into a constructor; inject `EntityTypeManagerInterface` and call `getStorage()` instead
 
 To enable individual checks instead of all of them, see the parameters above under [Opt-in rules](#opt-in-rules).
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the `extension-installer` documentation for more information: https://github
 
 #### Opt-in rules
 
-Several rules are disabled by default to avoid breaking existing projects in a patch release. They may be enabled by default in a future minor version. All of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
+These rules are disabled by default to avoid unexpected failures in a patch release. They graduate to the default ruleset in a future minor version. Include [bleedingEdge.neon](#bleeding-edge-checks) to enable all of them at once, or enable them individually:
 
 ```neon
 parameters:
@@ -165,14 +165,14 @@ Both options are enabled by default.
 
 #### Bleeding-edge checks
 
-`bleedingEdge.neon` is a convenience include that enables all rules and checks that are disabled by default. New rules are typically added here first and promoted to the default set in a future minor release, so including it lets you adopt upcoming checks early.
+`bleedingEdge.neon` enables all [opt-in rules](#opt-in-rules) plus hook deprecation checks against `.api.php` files. New rules land here first before graduating to the default ruleset in a minor release.
 
 ```neon
 includes:
     - vendor/mglaman/phpstan-drupal/bleedingEdge.neon
 ```
 
-Currently `bleedingEdge.neon` enables the following:
+What it currently enables:
 
 - `checkCoreDeprecatedHooksInApiFiles` — reports hook implementations deprecated in Drupal core `.api.php` files
 - `checkContribDeprecatedHooksInApiFiles` — reports hook implementations deprecated in contrib module `.api.php` files
@@ -184,11 +184,8 @@ Currently `bleedingEdge.neon` enables the following:
 - `loggerFromFactoryPropertyAssignmentRule` — flags logger channels assigned to properties in classes using `DependencySerializationTrait`
 - `entityStorageDirectInjectionRule` — flags direct injection of entity storage into a constructor; inject `EntityTypeManagerInterface` and call `getStorage()` instead
 
-To enable individual checks instead of all of them, see the parameters above under [Opt-in rules](#opt-in-rules).
-
 > [!NOTE]
-> The older `checkDeprecatedHooksInApiFiles` parameter is deprecated and will be removed in a future release. Use
-> `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.
+> `checkDeprecatedHooksInApiFiles` is deprecated. Use `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.
 
 #### Detecting @todo comments referencing the current Drupal.org issue (contrib CI)
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the `extension-installer` documentation for more information: https://github
 
 #### Opt-in rules
 
-Several rules are disabled by default because they may produce noise on existing codebases or require additional setup. Enable them one at a time as your codebase is ready.
+Several rules are disabled by default because they may produce noise on existing codebases or require additional setup. Most of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
 
 ```neon
 parameters:
@@ -163,20 +163,27 @@ parameters:
 
 Both options are enabled by default.
 
-#### Bleeding-edge hook deprecation checks
+#### Bleeding-edge checks
 
-Hook deprecation checks against `.api.php` files are opt-in because they can produce false positives on projects that have not yet fully declared their `.api.php` files. Enable them separately for Drupal core hooks, contributed module hooks, or both:
+`bleedingEdge.neon` is a convenience include that enables all rules and checks that are disabled by default. New rules are typically added here first and promoted to the default set in a future minor release, so including it lets you adopt upcoming checks early.
 
 ```neon
-parameters:
-    drupal:
-        bleedingEdge:
-            # Report hook implementations that are deprecated in Drupal core's .api.php files.
-            checkCoreDeprecatedHooksInApiFiles: true
-
-            # Report hook implementations that are deprecated in contrib module .api.php files.
-            checkContribDeprecatedHooksInApiFiles: true
+includes:
+    - vendor/mglaman/phpstan-drupal/bleedingEdge.neon
 ```
+
+Currently `bleedingEdge.neon` enables the following:
+
+- `checkCoreDeprecatedHooksInApiFiles` — reports hook implementations deprecated in Drupal core `.api.php` files
+- `checkContribDeprecatedHooksInApiFiles` — reports hook implementations deprecated in contrib module `.api.php` files
+- `hookRules` — validates OOP hook method signatures (requires Drupal 10.3+)
+- `testClassSuffixNameRule` — non-abstract test class names must end with `Test`
+- `dependencySerializationTraitPropertyRule` — flags private or read-only properties in classes using `DependencySerializationTrait`
+- `accessResultConditionRule` — flags always-true/always-false `AccessResult` conditions
+- `cacheableDependencyRule` — flags `addCacheableDependency()` calls with non-cacheable arguments
+- `loggerFromFactoryPropertyAssignmentRule` — flags logger channels assigned to properties in classes using `DependencySerializationTrait`
+
+To enable individual checks instead of all of them, see the parameters above under [Opt-in rules](#opt-in-rules).
 
 > [!NOTE]
 > The older `checkDeprecatedHooksInApiFiles` parameter is deprecated and will be removed in a future release. Use

--- a/README.md
+++ b/README.md
@@ -97,6 +97,44 @@ See the `extension-installer` documentation for more information: https://github
 
 ### Customizing rules
 
+#### Opt-in rules
+
+Several rules are disabled by default because they may produce noise on existing codebases or require additional setup. Enable them one at a time as your codebase is ready.
+
+```neon
+parameters:
+    drupal:
+        rules:
+            # Enforces that OOP hook implementations using the Hook attribute have the
+            # correct method signature for hook_form_alter, hook_form_FORM_ID_alter, etc.
+            # Requires Drupal 10.3+ (Hook attribute).
+            hookRules: true
+
+            # Flags non-abstract test classes whose names do not end with "Test".
+            testClassSuffixNameRule: true
+
+            # Flags properties that are private or read-only in classes using
+            # DependencySerializationTrait, which does not support them.
+            dependencySerializationTraitPropertyRule: true
+
+            # Flags calls to AccessResult static methods (::allowed(), ::forbidden(), etc.)
+            # whose argument type already makes the condition always true or always false.
+            accessResultConditionRule: true
+
+            # Flags addCacheableDependency() calls whose argument does not implement
+            # CacheableDependencyInterface.
+            cacheableDependencyRule: true
+
+            # Flags logger channel objects (from LoggerChannelFactoryInterface::get()) that
+            # are assigned to a property in a class using DependencySerializationTrait,
+            # which cannot serialize logger channels correctly.
+            loggerFromFactoryPropertyAssignmentRule: true
+
+            # Flags direct injection of EntityStorageInterface (or a subtype) into a
+            # constructor. Inject EntityTypeManagerInterface and call getStorage() instead.
+            entityStorageDirectInjectionRule: true
+```
+
 #### Disabling checks for extending `@internal` classes
 
 You can disable the `ClassExtendsInternalClassRule` rule by adding the following to your `phpstan.neon`:
@@ -124,6 +162,25 @@ parameters:
 ```
 
 Both options are enabled by default.
+
+#### Bleeding-edge hook deprecation checks
+
+Hook deprecation checks against `.api.php` files are opt-in because they can produce false positives on projects that have not yet fully declared their `.api.php` files. Enable them separately for Drupal core hooks, contributed module hooks, or both:
+
+```neon
+parameters:
+    drupal:
+        bleedingEdge:
+            # Report hook implementations that are deprecated in Drupal core's .api.php files.
+            checkCoreDeprecatedHooksInApiFiles: true
+
+            # Report hook implementations that are deprecated in contrib module .api.php files.
+            checkContribDeprecatedHooksInApiFiles: true
+```
+
+> [!NOTE]
+> The older `checkDeprecatedHooksInApiFiles` parameter is deprecated and will be removed in a future release. Use
+> `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.
 
 #### Detecting @todo comments referencing the current Drupal.org issue (contrib CI)
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See the `extension-installer` documentation for more information: https://github
 
 #### Opt-in rules
 
-Several rules are disabled by default because they may produce noise on existing codebases or require additional setup. Most of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
+Several rules are disabled by default to avoid breaking existing projects in a patch release. They may be enabled by default in a future minor version. Most of them are enabled together via [bleedingEdge.neon](#bleeding-edge-checks); the list below lets you enable them individually.
 
 ```neon
 parameters:

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -11,4 +11,4 @@ parameters:
 			cacheableDependencyRule: true
 			hookRules: true
 			loggerFromFactoryPropertyAssignmentRule: true
-		entityStorageDirectInjectionRule: true
+			entityStorageDirectInjectionRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -11,3 +11,4 @@ parameters:
 			cacheableDependencyRule: true
 			hookRules: true
 			loggerFromFactoryPropertyAssignmentRule: true
+		entityStorageDirectInjectionRule: true


### PR DESCRIPTION
## Summary

- Adds an **Opt-in rules** section documenting all 7 rules that are disabled by default, with inline comments explaining what each one checks for
- Adds a **Bleeding-edge hook deprecation checks** section explaining `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles`, why they are opt-in, and a deprecation notice for the old `checkDeprecatedHooksInApiFiles` parameter

## Test plan

- [ ] Read through the new README sections and verify the descriptions match the rule implementations
- [ ] Confirm the neon snippets are syntactically valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)