### PR TITLE
Add entity-type-id custom PHPDoc type

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,50 @@ rules:
 
 Both `drupal.org/i/{nid}` and `drupal.org/project/{project}/issues/{nid}` URL formats are recognized.
 
+### Custom PHPDoc types
+
+phpstan-drupal provides custom PHPDoc types that can be used to improve type safety in Drupal code.
+
+#### `entity-type-id`
+
+The `entity-type-id` type represents a valid Drupal entity type ID string (e.g. `'node'`, `'user'`, `'taxonomy_term'`). PHPStan will report an error when a constant string that is not a known entity type ID is passed where `entity-type-id` is expected.
+
+Drupal coding standards require keeping PHPStan-specific types in `@phpstan-param` and `@phpstan-return` tags rather than in the standard `@param` and `@return` tags:
+
+```php
+/**
+ * Loads an entity by its entity type ID and entity ID.
+ *
+ * @param string $entityTypeId
+ *   The entity type ID.
+ * @param int|string $id
+ *   The entity ID.
+ *
+ * @phpstan-param entity-type-id $entityTypeId
+ */
+public function loadEntity(string $entityTypeId, int|string $id): ?EntityInterface {
+    return $this->entityTypeManager->getStorage($entityTypeId)->load($id);
+}
+```
+
+For return types:
+
+```php
+/**
+ * Returns the entity type ID.
+ *
+ * @return string
+ *   The entity type ID.
+ *
+ * @phpstan-return entity-type-id
+ */
+public function getEntityTypeId(): string {
+    return $this->entityTypeId;
+}
+```
+
+Known entity type IDs are sourced from the `drupal.entityMapping` parameter. See [Entity storage mappings](#entity-storage-mappings) for how to register custom entity types so their IDs are also recognized.
+
 ### Entity storage mappings.
 
 The `EntityTypeManagerGetStorageDynamicReturnTypeExtension` service helps map dynamic return types. This inspects the

--- a/extension.neon
+++ b/extension.neon
@@ -296,6 +296,10 @@ services:
 		arguments:
 			entityMapping: %drupal.entityMapping%
 	-
+		class: mglaman\PHPStanDrupal\Type\EntityTypeId\EntityTypeIdTypeNodeResolverExtension
+		tags:
+			- phpstan.phpDoc.typeNodeResolverExtension
+	-
 		class: mglaman\PHPStanDrupal\Type\EntityIdNarrowedByNew
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-

--- a/src/Drupal/EntityDataRepository.php
+++ b/src/Drupal/EntityDataRepository.php
@@ -25,6 +25,14 @@ final class EntityDataRepository
         }
     }
 
+    /**
+     * @return list<string>
+     */
+    public function getAllEntityTypeIds(): array
+    {
+        return array_values(array_keys($this->entityData));
+    }
+
     public function get(string $entityTypeId): EntityData
     {
         if (!isset($this->entityData[$entityTypeId])) {

--- a/src/Drupal/EntityDataRepository.php
+++ b/src/Drupal/EntityDataRepository.php
@@ -30,7 +30,7 @@ final class EntityDataRepository
      */
     public function getAllEntityTypeIds(): array
     {
-        return array_values(array_keys($this->entityData));
+        return array_keys($this->entityData);
     }
 
     public function get(string $entityTypeId): EntityData

--- a/src/Type/EntityTypeId/EntityTypeIdType.php
+++ b/src/Type/EntityTypeId/EntityTypeIdType.php
@@ -22,11 +22,6 @@ class EntityTypeIdType extends StringType
         return 'entity-type-id';
     }
 
-    public function describeAdditionalCacheKey(): string
-    {
-        return md5(implode(',', $this->entityTypeIds));
-    }
-
     public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
     {
         if ($type instanceof self) {

--- a/src/Type/EntityTypeId/EntityTypeIdType.php
+++ b/src/Type/EntityTypeId/EntityTypeIdType.php
@@ -2,7 +2,6 @@
 
 namespace mglaman\PHPStanDrupal\Type\EntityTypeId;
 
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
@@ -20,6 +19,7 @@ class EntityTypeIdType extends StringType
      */
     public function __construct(array $entityTypeIds)
     {
+        parent::__construct();
         $this->entityTypeIds = $entityTypeIds;
     }
 
@@ -46,12 +46,16 @@ class EntityTypeIdType extends StringType
         if ($type instanceof self) {
             return IsSuperTypeOfResult::createYes();
         }
-        if ($type instanceof ConstantStringType) {
-            return IsSuperTypeOfResult::createFromBoolean(
-                in_array($type->getValue(), $this->entityTypeIds, true)
-            );
+        $constantStrings = $type->getConstantStrings();
+        foreach ($constantStrings as $constantString) {
+            if (!in_array($constantString->getValue(), $this->entityTypeIds, true)) {
+                return IsSuperTypeOfResult::createNo();
+            }
         }
-        if ($type instanceof StringType) {
+        if ($constantStrings !== []) {
+            return IsSuperTypeOfResult::createYes();
+        }
+        if ($type->isString()->yes()) {
             return IsSuperTypeOfResult::createMaybe();
         }
         return parent::isSuperTypeOf($type);

--- a/src/Type/EntityTypeId/EntityTypeIdType.php
+++ b/src/Type/EntityTypeId/EntityTypeIdType.php
@@ -10,25 +10,11 @@ use PHPStan\Type\VerbosityLevel;
 class EntityTypeIdType extends StringType
 {
     /**
-     * @var list<string>
-     */
-    private array $entityTypeIds;
-
-    /**
      * @param list<string> $entityTypeIds
      */
-    public function __construct(array $entityTypeIds)
+    public function __construct(public readonly array $entityTypeIds)
     {
         parent::__construct();
-        $this->entityTypeIds = $entityTypeIds;
-    }
-
-    /**
-     * @return list<string>
-     */
-    public function getEntityTypeIds(): array
-    {
-        return $this->entityTypeIds;
     }
 
     public function describe(VerbosityLevel $level): string

--- a/src/Type/EntityTypeId/EntityTypeIdType.php
+++ b/src/Type/EntityTypeId/EntityTypeIdType.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Type\EntityTypeId;
+
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\IsSuperTypeOfResult;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+class EntityTypeIdType extends StringType
+{
+    /**
+     * @var list<string>
+     */
+    private array $entityTypeIds;
+
+    /**
+     * @param list<string> $entityTypeIds
+     */
+    public function __construct(array $entityTypeIds)
+    {
+        $this->entityTypeIds = $entityTypeIds;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getEntityTypeIds(): array
+    {
+        return $this->entityTypeIds;
+    }
+
+    public function describe(VerbosityLevel $level): string
+    {
+        return 'entity-type-id';
+    }
+
+    public function describeAdditionalCacheKey(): string
+    {
+        return md5(implode(',', $this->entityTypeIds));
+    }
+
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
+    {
+        if ($type instanceof self) {
+            return IsSuperTypeOfResult::createYes();
+        }
+        if ($type instanceof ConstantStringType) {
+            return IsSuperTypeOfResult::createFromBoolean(
+                in_array($type->getValue(), $this->entityTypeIds, true)
+            );
+        }
+        if ($type instanceof StringType) {
+            return IsSuperTypeOfResult::createMaybe();
+        }
+        return parent::isSuperTypeOf($type);
+    }
+}

--- a/src/Type/EntityTypeId/EntityTypeIdTypeNodeResolverExtension.php
+++ b/src/Type/EntityTypeId/EntityTypeIdTypeNodeResolverExtension.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Type\EntityTypeId;
+
+use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
+use PHPStan\Analyser\NameScope;
+use PHPStan\PhpDoc\TypeNodeResolverExtension;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\Type\Type;
+
+class EntityTypeIdTypeNodeResolverExtension implements TypeNodeResolverExtension
+{
+    private EntityDataRepository $entityDataRepository;
+
+    public function __construct(EntityDataRepository $entityDataRepository)
+    {
+        $this->entityDataRepository = $entityDataRepository;
+    }
+
+    public function resolve(TypeNode $typeNode, NameScope $nameScope): ?Type
+    {
+        if (!$typeNode instanceof IdentifierTypeNode) {
+            return null;
+        }
+        if ($typeNode->name !== 'entity-type-id') {
+            return null;
+        }
+
+        return new EntityTypeIdType($this->entityDataRepository->getAllEntityTypeIds());
+    }
+}

--- a/tests/src/Type/EntityTypeIdTypeTest.php
+++ b/tests/src/Type/EntityTypeIdTypeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Type;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class EntityTypeIdTypeTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/entity-type-id.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Type/data/entity-type-id.php
+++ b/tests/src/Type/data/entity-type-id.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalEntityTypeId;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * @param entity-type-id $entityTypeId
+ */
+function acceptsEntityTypeId(string $entityTypeId): void
+{
+    assertType('entity-type-id', $entityTypeId);
+}
+
+/**
+ * @return entity-type-id
+ */
+function returnsEntityTypeId(): string
+{
+    return 'node';
+}
+
+assertType('entity-type-id', returnsEntityTypeId());


### PR DESCRIPTION
## Summary

- Adds an `entity-type-id` custom PHPDoc type annotation inspired by larastan's `view-string` type
- Users can annotate parameters and return values with `@param entity-type-id $id` to express that only valid Drupal entity type IDs are accepted
- PHPStan validates constant string arguments against all known entity type IDs from `EntityDataRepository`, catching invalid strings at analysis time rather than runtime

**Example usage:**
```php
/**
 * @param entity-type-id $entityTypeId
 */
function doSomethingWithEntity(string $entityTypeId): void { ... }

doSomethingWithEntity('node');         // OK
doSomethingWithEntity('invalid_type'); // PHPStan error
```

## Implementation

- `EntityTypeIdType` — new PHPStan `StringType` subclass that describes as `entity-type-id` and validates constant strings against the known entity type ID list
- `EntityTypeIdTypeNodeResolverExtension` — resolves `entity-type-id` in PHPDoc annotations using `PHPStan\PhpDoc\TypeNodeResolverExtension`
- `EntityDataRepository::getAllEntityTypeIds()` — new method exposing the full list of known entity type IDs
- Registered via `phpstan.phpDoc.typeNodeResolverExtension` tag in `extension.neon`

## Test plan

- [ ] `php vendor/bin/phpunit --filter=EntityTypeIdTypeTest` — new type inference tests pass
- [ ] `php vendor/bin/phpunit` — full suite (770 tests) passes
- [ ] `php vendor/bin/phpcs` — no coding standards violations

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)