### PR TITLE
Allow \Drupal usage check on render elements

### DIFF
--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -40,10 +40,6 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             'PHPUnit\Framework\Test',
             // Typed data objects cannot use dependency injection.
             'Drupal\Core\TypedData\TypedDataInterface',
-            // Render elements cannot use dependency injection.
-            'Drupal\Core\Render\Element\ElementInterface',
-            'Drupal\Core\Render\Element\FormElementInterface',
-            'Drupal\config_translation\FormElement\ElementInterface',
             // Entities don't use services for now
             // @see https://www.drupal.org/project/drupal/issues/2913224
             'Drupal\Core\Entity\EntityInterface',

--- a/tests/src/Rules/GlobalDrupalDependencyInjectionRuleTest.php
+++ b/tests/src/Rules/GlobalDrupalDependencyInjectionRuleTest.php
@@ -70,6 +70,16 @@ final class GlobalDrupalDependencyInjectionRuleTest extends DrupalRuleTestCase {
             [],
         ];
 
+        yield [
+            __DIR__ . '/data/bug-828.php',
+            [
+                [
+                    '\Drupal calls should be avoided in classes, use dependency injection instead',
+                    35,
+                ],
+            ],
+        ];
+
     }
 
 

--- a/tests/src/Rules/data/bug-828.php
+++ b/tests/src/Rules/data/bug-828.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Bug828;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Render\Element\RenderElementBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+// A render element using ContainerFactoryPluginInterface for DI.
+// Should NOT trigger the rule since it uses proper DI via create().
+class RenderElementWithDi extends RenderElementBase implements ContainerFactoryPluginInterface {
+
+    public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+        parent::__construct($configuration, $plugin_id, $plugin_definition);
+    }
+
+    public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+        return new static($configuration, $plugin_id, $plugin_definition);
+    }
+
+    public function getInfo() {
+        return [];
+    }
+
+}
+
+// A render element using \Drupal directly. Should trigger the rule.
+class RenderElementWithDrupalCall extends RenderElementBase {
+
+    public function getInfo() {
+        return [];
+    }
+
+    public function someMethod() {
+        \Drupal::service('some.service');
+    }
+
+}


### PR DESCRIPTION
## Summary

Fixes #828.

- `ElementInfoManager` extends `DefaultPluginManager`, which uses `ContainerFactory` for plugin instantiation
- Drupal core ships `\Drupal\Core\TempStore\Element\BreakLockLink` as a concrete example of a render element implementing `ContainerFactoryPluginInterface`
- Removes `ElementInterface`, `FormElementInterface`, and `config_translation` `ElementInterface` from the `GlobalDrupalDependencyInjectionRule` allow-list so that `\Drupal` calls inside render elements are now flagged correctly

## Test plan

- [ ] New fixture `bug-828.php` includes a render element with proper DI (no error expected) and one using `\Drupal` directly (error expected at the call site)
- [ ] `php vendor/bin/phpunit --filter=GlobalDrupalDependencyInjectionRuleTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)