### PR TITLE
Fix InspectorTypeExtension compatibility with PHPStan 2.1.47 mixed~null type

### DIFF
--- a/src/Type/InspectorTypeExtension.php
+++ b/src/Type/InspectorTypeExtension.php
@@ -111,7 +111,7 @@ final class InspectorTypeExtension implements StaticMethodTypeSpecifyingExtensio
         // If it is already not mixed (narrowed by other code, like
         // '::assertAllArray()'), we could not provide any additional
         // information. We can only narrow this method to 'array<mixed, mixed>'.
-        if (!$traversableType->equals(new MixedType())) {
+        if (!$traversableType instanceof MixedType) {
             return new SpecifiedTypes();
         }
 

--- a/tests/src/Type/data/bug-857.php
+++ b/tests/src/Type/data/bug-857.php
@@ -14,7 +14,7 @@ assertType('iterable', $array);
 
 // If the type is narrowed before '::assertAll()', it shouldn't change it.
 $array = mixed_function();
-assertType('mixed', $array);
+assertType('mixed~null', $array);
 \assert(Inspector::assertAllArrays($array));
 assertType('iterable<array>', $array);
 \assert(Inspector::assertAll(fn (array $i): bool => TRUE, $array));


### PR DESCRIPTION
## Summary

- PHPStan 2.1.47 now infers `mixed~null` (mixed with null subtracted) in certain scopes where previously `mixed` was reported
- The `specifyAssertAll` method used `$traversableType->equals(new MixedType())` which rejects `mixed~null`, causing `Inspector::assertAll()` to silently skip type narrowing for affected variables
- Fix the check to use `instanceof MixedType` so both `mixed` and `mixed~null` are handled correctly, while still returning early when the type has been meaningfully narrowed (e.g. `iterable<array>`)
- Update test fixture to reflect the new `mixed~null` inference from PHPStan 2.1.47

## Test plan

- [ ] `php vendor/bin/phpunit --filter=InspectorTypeExtensionTest` passes
- [ ] `php vendor/bin/phpunit` full suite passes (770 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)