### PR TITLE
Add opt-in rule requiring ConstraintValidator::validate() to narrow the constraint type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -37,6 +37,7 @@ parameters:
 			hookRules: false
 			loggerFromFactoryPropertyAssignmentRule: false
 			entityStorageDirectInjectionRule: false
+			constraintValidatorMustNarrowConstraintType: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -275,6 +276,7 @@ parametersSchema:
 			hookRules: boolean()
 			loggerFromFactoryPropertyAssignmentRule: boolean()
 			entityStorageDirectInjectionRule: boolean()
+			constraintValidatorMustNarrowConstraintType: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/rules.neon
+++ b/rules.neon
@@ -34,6 +34,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.entityStorageDirectInjectionRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\EntityStoragePropertyAssignmentRule:
 		phpstan.rules.rule: %drupal.rules.entityStorageDirectInjectionRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\ConstraintValidatorValidateNarrowsConstraintTypeRule:
+		phpstan.rules.rule: %drupal.rules.constraintValidatorMustNarrowConstraintType%
 
 services:
 	-
@@ -58,3 +60,5 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityStorageDirectInjectionRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityStoragePropertyAssignmentRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\ConstraintValidatorValidateNarrowsConstraintTypeRule

--- a/src/Rules/Drupal/ConstraintValidatorValidateNarrowsConstraintTypeRule.php
+++ b/src/Rules/Drupal/ConstraintValidatorValidateNarrowsConstraintTypeRule.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use function array_key_exists;
+use function count;
+use function str_ends_with;
+use function strrpos;
+use function substr;
+
+/**
+ * Requires ConstraintValidator::validate() to narrow the $constraint parameter type.
+ *
+ * PHPStan cannot infer that `$constraint` is a specific subclass of Constraint
+ * inside a validator's validate() method. Drupal core's convention is to use
+ * `assert($constraint instanceof SpecificConstraint)` to narrow the type, which
+ * PHPStan handles natively.
+ *
+ * This rule fires when a class following the FooValidator/Foo naming convention
+ * does not assert the constraint type in its validate() method.
+ *
+ * @implements Rule<Node\Stmt\ClassMethod>
+ */
+final class ConstraintValidatorValidateNarrowsConstraintTypeRule implements Rule
+{
+
+    private ReflectionProvider $reflectionProvider;
+
+    public function __construct(ReflectionProvider $reflectionProvider)
+    {
+        $this->reflectionProvider = $reflectionProvider;
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt\ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($node->name->toString() !== 'validate') {
+            return [];
+        }
+        if (!$scope->isInClass()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection->isSubclassOfClass($this->reflectionProvider->getClass(ConstraintValidator::class))) {
+            return [];
+        }
+
+        // Derive the matching constraint class name by stripping 'Validator' suffix.
+        $fqcn = $classReflection->getName();
+        if (!str_ends_with($fqcn, 'Validator')) {
+            return [];
+        }
+        $constraintClass = substr($fqcn, 0, -9);
+
+        if (!$this->reflectionProvider->hasClass($constraintClass)) {
+            return [];
+        }
+        $constraintReflection = $this->reflectionProvider->getClass($constraintClass);
+        if (!$constraintReflection->isSubclassOfClass($this->reflectionProvider->getClass(Constraint::class))) {
+            return [];
+        }
+
+        // Find the $constraint parameter name (second param by Symfony convention).
+        $constraintParamName = 'constraint';
+        if (array_key_exists(1, $node->params)) {
+            $param = $node->params[1];
+            if ($param->var instanceof Node\Expr\Variable && is_string($param->var->name)) {
+                $constraintParamName = $param->var->name;
+            }
+        }
+
+        // Check if the method body asserts the concrete constraint type.
+        if ($this->hasConstraintAssertion($node->stmts ?? [], $constraintParamName)) {
+            return [];
+        }
+
+        $validatorFqcn = $classReflection->getName();
+        $validatorPos = strrpos($validatorFqcn, '\\');
+        $validatorShortName = $validatorPos !== false ? substr($validatorFqcn, $validatorPos + 1) : $validatorFqcn;
+        $constraintFqcn = $constraintReflection->getName();
+        $constraintPos = strrpos($constraintFqcn, '\\');
+        $constraintShortName = $constraintPos !== false ? substr($constraintFqcn, $constraintPos + 1) : $constraintFqcn;
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Method %s::validate() does not narrow the $%s parameter type. Add assert($%s instanceof %s) to allow PHPStan to infer constraint-specific properties.',
+                $validatorShortName,
+                $constraintParamName,
+                $constraintParamName,
+                $constraintShortName
+            ))
+            ->identifier('drupal.constraintValidator.missingNarrow')
+            ->tip('See https://www.drupal.org/project/drupal/issues/3246287')
+            ->build(),
+        ];
+    }
+
+    /**
+     * Returns true if any statement in the list is assert($var instanceof SomeClass).
+     *
+     * @param Node\Stmt[] $stmts
+     */
+    private function hasConstraintAssertion(array $stmts, string $paramName): bool
+    {
+        foreach ($stmts as $stmt) {
+            if (!$stmt instanceof Node\Stmt\Expression) {
+                continue;
+            }
+            $expr = $stmt->expr;
+            if (!$expr instanceof Node\Expr\FuncCall) {
+                continue;
+            }
+            if (!$expr->name instanceof Node\Name || $expr->name->toString() !== 'assert') {
+                continue;
+            }
+            $args = $expr->getArgs();
+            if (count($args) === 0) {
+                continue;
+            }
+            $assertArg = $args[0]->value;
+            if (!$assertArg instanceof Node\Expr\Instanceof_) {
+                continue;
+            }
+            if (!$assertArg->expr instanceof Node\Expr\Variable) {
+                continue;
+            }
+            if ($assertArg->expr->name === $paramName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/Drupal/ConstraintValidatorValidateNarrowsConstraintTypeRule.php
+++ b/src/Rules/Drupal/ConstraintValidatorValidateNarrowsConstraintTypeRule.php
@@ -54,6 +54,12 @@ final class ConstraintValidatorValidateNarrowsConstraintTypeRule implements Rule
             return [];
         }
 
+        // Guard: symfony/validator may not be installed in every project.
+        if (!$this->reflectionProvider->hasClass(ConstraintValidator::class)
+            || !$this->reflectionProvider->hasClass(Constraint::class)) {
+            return [];
+        }
+
         $classReflection = $scope->getClassReflection();
         if (!$classReflection->isSubclassOfClass($this->reflectionProvider->getClass(ConstraintValidator::class))) {
             return [];
@@ -84,7 +90,7 @@ final class ConstraintValidatorValidateNarrowsConstraintTypeRule implements Rule
         }
 
         // Check if the method body asserts the concrete constraint type.
-        if ($this->hasConstraintAssertion($node->stmts ?? [], $constraintParamName)) {
+        if ($this->hasConstraintAssertion($node->stmts ?? [], $constraintParamName, $constraintClass, $scope)) {
             return [];
         }
 
@@ -110,11 +116,11 @@ final class ConstraintValidatorValidateNarrowsConstraintTypeRule implements Rule
     }
 
     /**
-     * Returns true if any statement in the list is assert($var instanceof SomeClass).
+     * Returns true if the statement list contains assert($var instanceof ExpectedConstraintClass).
      *
      * @param Node\Stmt[] $stmts
      */
-    private function hasConstraintAssertion(array $stmts, string $paramName): bool
+    private function hasConstraintAssertion(array $stmts, string $paramName, string $expectedConstraintFqcn, Scope $scope): bool
     {
         foreach ($stmts as $stmt) {
             if (!$stmt instanceof Node\Stmt\Expression) {
@@ -138,7 +144,14 @@ final class ConstraintValidatorValidateNarrowsConstraintTypeRule implements Rule
             if (!$assertArg->expr instanceof Node\Expr\Variable) {
                 continue;
             }
-            if ($assertArg->expr->name === $paramName) {
+            if ($assertArg->expr->name !== $paramName) {
+                continue;
+            }
+            if (!$assertArg->class instanceof Node\Name) {
+                continue;
+            }
+            $assertedClass = $scope->resolveName($assertArg->class);
+            if ($assertedClass === $expectedConstraintFqcn) {
                 return true;
             }
         }

--- a/tests/src/Rules/ConstraintValidatorValidateNarrowsConstraintTypeRuleTest.php
+++ b/tests/src/Rules/ConstraintValidatorValidateNarrowsConstraintTypeRuleTest.php
@@ -23,7 +23,7 @@ final class ConstraintValidatorValidateNarrowsConstraintTypeRuleTest extends Dru
             [
                 [
                     'Method UniqueItemValidator::validate() does not narrow the $constraint parameter type. Add assert($constraint instanceof UniqueItem) to allow PHPStan to infer constraint-specific properties.',
-                    23,
+                    22,
                     'See https://www.drupal.org/project/drupal/issues/3246287',
                 ],
             ]

--- a/tests/src/Rules/ConstraintValidatorValidateNarrowsConstraintTypeRuleTest.php
+++ b/tests/src/Rules/ConstraintValidatorValidateNarrowsConstraintTypeRuleTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\ConstraintValidatorValidateNarrowsConstraintTypeRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class ConstraintValidatorValidateNarrowsConstraintTypeRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ConstraintValidatorValidateNarrowsConstraintTypeRule::class);
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/constraint-validator.php'],
+            [
+                [
+                    'Method UniqueItemValidator::validate() does not narrow the $constraint parameter type. Add assert($constraint instanceof UniqueItem) to allow PHPStan to infer constraint-specific properties.',
+                    23,
+                    'See https://www.drupal.org/project/drupal/issues/3246287',
+                ],
+            ]
+        );
+    }
+
+}

--- a/tests/src/Rules/data/constraint-validator.php
+++ b/tests/src/Rules/data/constraint-validator.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules\data\ConstraintValidator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+// Constraint class following the naming convention: UniqueItem / UniqueItemValidator.
+class UniqueItem extends Constraint
+{
+
+    public string $alreadyExists = 'The item %value already exists.';
+
+}
+
+// Error: validate() accesses constraint properties but never asserts the type.
+class UniqueItemValidator extends ConstraintValidator
+{
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        $this->context->addViolation($constraint->alreadyExists);
+    }
+
+}
+
+// No error: validate() uses assert() to narrow the constraint type.
+class UniqueItemValidatorWithAssert extends ConstraintValidator
+{
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        assert($constraint instanceof UniqueItem);
+        $this->context->addViolation($constraint->alreadyExists);
+    }
+
+}
+
+// No error: validator class name does not follow the FooValidator/Foo convention,
+// so no matching constraint class can be derived.
+class StandaloneValidator extends ConstraintValidator
+{
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        $this->context->addViolation('some message');
+    }
+
+}
+
+// No error: 'OrphanedValidator' strips to 'Orphaned', which is not a known constraint.
+class OrphanedValidator extends ConstraintValidator
+{
+
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        $this->context->addViolation('some message');
+    }
+
+}

--- a/tests/src/Rules/data/constraint-validator.php
+++ b/tests/src/Rules/data/constraint-validator.php
@@ -6,7 +6,6 @@ namespace mglaman\PHPStanDrupal\Tests\Rules\data\ConstraintValidator;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 // Constraint class following the naming convention: UniqueItem / UniqueItemValidator.
 class UniqueItem extends Constraint
@@ -16,7 +15,7 @@ class UniqueItem extends Constraint
 
 }
 
-// Error: validate() accesses constraint properties but never asserts the type.
+// Error: validate() does not assert the concrete constraint type.
 class UniqueItemValidator extends ConstraintValidator
 {
 
@@ -27,20 +26,28 @@ class UniqueItemValidator extends ConstraintValidator
 
 }
 
-// No error: validate() uses assert() to narrow the constraint type.
-class UniqueItemValidatorWithAssert extends ConstraintValidator
+// Constraint class for the assert-detection test case.
+class UniqueItemWithAssert extends Constraint
+{
+
+    public string $alreadyExists = 'The item %value already exists.';
+
+}
+
+// No error: validate() uses assert() to narrow to the expected constraint type.
+class UniqueItemWithAssertValidator extends ConstraintValidator
 {
 
     public function validate(mixed $value, Constraint $constraint): void
     {
-        assert($constraint instanceof UniqueItem);
+        assert($constraint instanceof UniqueItemWithAssert);
         $this->context->addViolation($constraint->alreadyExists);
     }
 
 }
 
-// No error: validator class name does not follow the FooValidator/Foo convention,
-// so no matching constraint class can be derived.
+// No error: 'StandaloneValidator' strips to 'Standalone', but there is no
+// corresponding constraint class with that name.
 class StandaloneValidator extends ConstraintValidator
 {
 


### PR DESCRIPTION
## Summary

Closes #466

PHPStan reports \"Access to an undefined property\" when a `ConstraintValidator` subclass accesses constraint-specific properties, because `$constraint` is typed as the base `Symfony\Component\Validator\Constraint` class in the method signature. `phpstan-symfony` does not handle this use case (phpstan/phpstan-symfony#16).

Drupal core's own convention — visible in `ConfigExistsConstraintValidator` — is to add `assert($constraint instanceof SpecificConstraint)` at the top of `validate()`, which PHPStan narrows natively.

## What changed

- New opt-in rule `ConstraintValidatorValidateNarrowsConstraintTypeRule` that fires when a class following the `FooValidator`/`Foo` naming convention does not narrow `$constraint` in its `validate()` method
- The rule suggests the exact `assert()` call to add
- Registered as an opt-in conditional rule (default `false`), enabled with:

```yaml
parameters:
    drupal:
        rules:
            constraintValidatorMustNarrowConstraintType: true
```

## How it works

1. Finds `validate()` methods in classes extending `ConstraintValidator`
2. Strips the `Validator` suffix from the FQCN to derive the expected constraint class (e.g. `UniqueItemValidator` → `UniqueItem`)
3. Confirms the derived class exists and extends `Constraint`
4. Checks if the method body contains `assert($constraint instanceof MatchingClass)` — if not, reports an error

## Test plan

- [x] New fixture covers: error case (no assert), no-error case (with assert), no-error case (no naming-convention match)
- [x] `php vendor/bin/phpunit --filter=ConstraintValidatorValidateNarrowsConstraintTypeRuleTest` passes
- [x] Full test suite (772 tests) passes with no regressions
- [x] `php vendor/bin/phpstan analyze` passes on the new rule file
- [x] `php vendor/bin/phpcs` passes on the new rule file

🤖 Generated with [Claude Code](https://claude.com/claude-code)