### PR TITLE
Add rule to detect Symfony\Component\Yaml\Yaml::parse() usage

### DIFF
--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -12,3 +12,4 @@ parameters:
 			hookRules: true
 			loggerFromFactoryPropertyAssignmentRule: true
 			entityStorageDirectInjectionRule: true
+			symfonyYamlParseRule: true

--- a/extension.neon
+++ b/extension.neon
@@ -37,6 +37,7 @@ parameters:
 			hookRules: false
 			loggerFromFactoryPropertyAssignmentRule: false
 			entityStorageDirectInjectionRule: false
+			symfonyYamlParseRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -275,6 +276,7 @@ parametersSchema:
 			hookRules: boolean()
 			loggerFromFactoryPropertyAssignmentRule: boolean()
 			entityStorageDirectInjectionRule: boolean()
+			symfonyYamlParseRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/rules.neon
+++ b/rules.neon
@@ -1,7 +1,6 @@
 rules:
 	- mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\StaticServiceDeprecatedServiceRule
@@ -35,6 +34,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.entityStorageDirectInjectionRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\EntityStoragePropertyAssignmentRule:
 		phpstan.rules.rule: %drupal.rules.entityStorageDirectInjectionRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule:
+		phpstan.rules.rule: %drupal.rules.symfonyYamlParseRule%
 
 services:
 	-
@@ -59,3 +60,5 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityStorageDirectInjectionRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityStoragePropertyAssignmentRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule

--- a/rules.neon
+++ b/rules.neon
@@ -1,6 +1,7 @@
 rules:
 	- mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
+	- mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\StaticServiceDeprecatedServiceRule

--- a/src/Rules/Drupal/SymfonyYamlParseRule.php
+++ b/src/Rules/Drupal/SymfonyYamlParseRule.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Detects direct usage of Symfony's YAML parser and suggests the Drupal wrapper.
+ *
+ * Drupal\Component\Serialization\Yaml::decode() respects the yaml_parser_class
+ * setting, allowing sites to override the parser. Using Symfony's class directly
+ * bypasses that setting.
+ *
+ * @implements Rule<StaticCall>
+ */
+class SymfonyYamlParseRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!($node->class instanceof Node\Name\FullyQualified)) {
+            return [];
+        }
+
+        $className = (string) $node->class;
+        if ($className !== 'Symfony\Component\Yaml\Yaml') {
+            return [];
+        }
+
+        if (!($node->name instanceof Node\Identifier)) {
+            return [];
+        }
+
+        if ((string) $node->name !== 'parse') {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.'
+            )
+            ->identifier('drupal.symfonyYamlParse')
+            ->build(),
+        ];
+    }
+}

--- a/src/Rules/Drupal/SymfonyYamlParseRule.php
+++ b/src/Rules/Drupal/SymfonyYamlParseRule.php
@@ -26,11 +26,11 @@ class SymfonyYamlParseRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!($node->class instanceof Node\Name\FullyQualified)) {
+        if (!($node->class instanceof Node\Name)) {
             return [];
         }
 
-        $className = (string) $node->class;
+        $className = $scope->resolveName($node->class);
         if ($className !== 'Symfony\Component\Yaml\Yaml') {
             return [];
         }

--- a/src/Rules/Drupal/SymfonyYamlParseRule.php
+++ b/src/Rules/Drupal/SymfonyYamlParseRule.php
@@ -11,9 +11,9 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * Detects direct usage of Symfony's YAML parser and suggests the Drupal wrapper.
  *
- * Drupal\Component\Serialization\Yaml::decode() respects the yaml_parser_class
- * setting, allowing sites to override the parser. Using Symfony's class directly
- * bypasses that setting.
+ * Drupal\Component\Serialization\Yaml::decode() should be used instead of
+ * Symfony\Component\Yaml\Yaml::parse() because it wraps exceptions as
+ * InvalidDataTypeException and applies consistent parse flags.
  *
  * @implements Rule<StaticCall>
  */
@@ -45,7 +45,7 @@ class SymfonyYamlParseRule implements Rule
 
         return [
             RuleErrorBuilder::message(
-                'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.'
+                'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which handles exceptions consistently and applies the correct parse flags.'
             )
             ->identifier('drupal.symfonyYamlParse')
             ->build(),

--- a/tests/src/Rules/SymfonyYamlParseRuleTest.php
+++ b/tests/src/Rules/SymfonyYamlParseRuleTest.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class SymfonyYamlParseRuleTest extends DrupalRuleTestCase
+{
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new SymfonyYamlParseRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/symfony-yaml-parse.php'],
+            [
+                [
+                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.',
+                    6,
+                ],
+                [
+                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.',
+                    9,
+                ],
+            ]
+        );
+    }
+}

--- a/tests/src/Rules/SymfonyYamlParseRuleTest.php
+++ b/tests/src/Rules/SymfonyYamlParseRuleTest.php
@@ -18,11 +18,11 @@ final class SymfonyYamlParseRuleTest extends DrupalRuleTestCase
             [__DIR__ . '/data/symfony-yaml-parse.php'],
             [
                 [
-                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.',
+                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which handles exceptions consistently and applies the correct parse flags.',
                     6,
                 ],
                 [
-                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which respects the yaml_parser_class setting.',
+                    'Avoid calling Symfony\Component\Yaml\Yaml::parse() directly. Use \Drupal\Component\Serialization\Yaml::decode() instead, which handles exceptions consistently and applies the correct parse flags.',
                     9,
                 ],
             ]

--- a/tests/src/Rules/data/symfony-yaml-parse.php
+++ b/tests/src/Rules/data/symfony-yaml-parse.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+// Direct call — should be flagged.
+$data = Yaml::parse('foo: bar');
+
+// Fully-qualified call — should be flagged.
+$data = \Symfony\Component\Yaml\Yaml::parse('foo: bar');
+
+// Drupal's wrapper — should not be flagged.
+$data = \Drupal\Component\Serialization\Yaml::decode('foo: bar');


### PR DESCRIPTION
## Summary

Adds a new opt-in rule (`drupal.symfonyYamlParseRule`) that flags direct calls to `Symfony\Component\Yaml\Yaml::parse()` and suggests using `\Drupal\Component\Serialization\Yaml::decode()` instead.

Drupal's wrapper should be preferred because it:
- Wraps Symfony YAML exceptions as `Drupal\Component\Serialization\Exception\InvalidDataTypeException`, keeping error handling consistent across the codebase
- Always applies the correct parse flags (`PARSE_EXCEPTION_ON_INVALID_TYPE | PARSE_CUSTOM_TAGS`)

Closes #642.

**Background:** The Drupal core issue linked from #642 ([#3205480](https://www.drupal.org/project/drupal/issues/3205480)) was fixed in Drupal 10.3/11.x — PECL YAML support was removed and `Drupal\Core\Serialization\Yaml` became a `class_alias()` for `Drupal\Component\Serialization\Yaml`. The rule straightforwardly suggests the Component class.

## Test plan

- [ ] `php vendor/bin/phpunit --filter=SymfonyYamlParseRuleTest` — new test passes
- [ ] `php vendor/bin/phpunit` — full suite green (772 tests)
- [ ] `php vendor/bin/phpcs src/Rules/Drupal/SymfonyYamlParseRule.php` — no lint errors
- [ ] `php vendor/bin/phpstan analyze src/Rules/Drupal/SymfonyYamlParseRule.php` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)