### PR TITLE
Add rules to detect missing CacheableMetadata parameter in entity operation methods and hooks

### DIFF
--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -14,5 +14,3 @@ parameters:
 			entityStorageDirectInjectionRule: true
 			symfonyYamlParseRule: true
 			entityListBuilderOperationsCacheabilityRule: true
-			hookEntityOperationCacheabilityRule: true
-			proceduralHookEntityOperationCacheabilityRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -13,3 +13,4 @@ parameters:
 			loggerFromFactoryPropertyAssignmentRule: true
 			entityStorageDirectInjectionRule: true
 			symfonyYamlParseRule: true
+			entityListBuilderOperationsCacheabilityRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -13,4 +13,4 @@ parameters:
 			loggerFromFactoryPropertyAssignmentRule: true
 			entityStorageDirectInjectionRule: true
 			symfonyYamlParseRule: true
-			entityListBuilderOperationsCacheabilityRule: true
+			entityOperationsCacheabilityRule: true

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -14,3 +14,5 @@ parameters:
 			entityStorageDirectInjectionRule: true
 			symfonyYamlParseRule: true
 			entityListBuilderOperationsCacheabilityRule: true
+			hookEntityOperationCacheabilityRule: true
+			proceduralHookEntityOperationCacheabilityRule: true

--- a/extension.neon
+++ b/extension.neon
@@ -39,6 +39,8 @@ parameters:
 			entityStorageDirectInjectionRule: false
 			symfonyYamlParseRule: false
 			entityListBuilderOperationsCacheabilityRule: false
+			hookEntityOperationCacheabilityRule: false
+			proceduralHookEntityOperationCacheabilityRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -279,6 +281,8 @@ parametersSchema:
 			entityStorageDirectInjectionRule: boolean()
 			symfonyYamlParseRule: boolean()
 			entityListBuilderOperationsCacheabilityRule: boolean()
+			hookEntityOperationCacheabilityRule: boolean()
+			proceduralHookEntityOperationCacheabilityRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/extension.neon
+++ b/extension.neon
@@ -39,8 +39,6 @@ parameters:
 			entityStorageDirectInjectionRule: false
 			symfonyYamlParseRule: false
 			entityListBuilderOperationsCacheabilityRule: false
-			hookEntityOperationCacheabilityRule: false
-			proceduralHookEntityOperationCacheabilityRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -281,8 +279,6 @@ parametersSchema:
 			entityStorageDirectInjectionRule: boolean()
 			symfonyYamlParseRule: boolean()
 			entityListBuilderOperationsCacheabilityRule: boolean()
-			hookEntityOperationCacheabilityRule: boolean()
-			proceduralHookEntityOperationCacheabilityRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/extension.neon
+++ b/extension.neon
@@ -38,6 +38,7 @@ parameters:
 			loggerFromFactoryPropertyAssignmentRule: false
 			entityStorageDirectInjectionRule: false
 			symfonyYamlParseRule: false
+			entityListBuilderOperationsCacheabilityRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -277,6 +278,7 @@ parametersSchema:
 			loggerFromFactoryPropertyAssignmentRule: boolean()
 			entityStorageDirectInjectionRule: boolean()
 			symfonyYamlParseRule: boolean()
+			entityListBuilderOperationsCacheabilityRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/extension.neon
+++ b/extension.neon
@@ -38,7 +38,7 @@ parameters:
 			loggerFromFactoryPropertyAssignmentRule: false
 			entityStorageDirectInjectionRule: false
 			symfonyYamlParseRule: false
-			entityListBuilderOperationsCacheabilityRule: false
+			entityOperationsCacheabilityRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -278,7 +278,7 @@ parametersSchema:
 			loggerFromFactoryPropertyAssignmentRule: boolean()
 			entityStorageDirectInjectionRule: boolean()
 			symfonyYamlParseRule: boolean()
-			entityListBuilderOperationsCacheabilityRule: boolean()
+			entityOperationsCacheabilityRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([

--- a/rules.neon
+++ b/rules.neon
@@ -38,6 +38,10 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.symfonyYamlParseRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule:
 		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule:
+		phpstan.rules.rule: %drupal.rules.hookEntityOperationCacheabilityRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule:
+		phpstan.rules.rule: %drupal.rules.proceduralHookEntityOperationCacheabilityRule%
 
 services:
 	-
@@ -66,3 +70,7 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule

--- a/rules.neon
+++ b/rules.neon
@@ -36,6 +36,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.entityStorageDirectInjectionRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule:
 		phpstan.rules.rule: %drupal.rules.symfonyYamlParseRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule:
+		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
 
 services:
 	-
@@ -62,3 +64,5 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityStoragePropertyAssignmentRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule

--- a/rules.neon
+++ b/rules.neon
@@ -37,11 +37,11 @@ conditionalTags:
 	mglaman\PHPStanDrupal\Rules\Drupal\SymfonyYamlParseRule:
 		phpstan.rules.rule: %drupal.rules.symfonyYamlParseRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule:
-		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
+		phpstan.rules.rule: %drupal.rules.entityOperationsCacheabilityRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule:
-		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
+		phpstan.rules.rule: %drupal.rules.entityOperationsCacheabilityRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule:
-		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
+		phpstan.rules.rule: %drupal.rules.entityOperationsCacheabilityRule%
 
 services:
 	-

--- a/rules.neon
+++ b/rules.neon
@@ -39,9 +39,9 @@ conditionalTags:
 	mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule:
 		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule:
-		phpstan.rules.rule: %drupal.rules.hookEntityOperationCacheabilityRule%
+		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule:
-		phpstan.rules.rule: %drupal.rules.proceduralHookEntityOperationCacheabilityRule%
+		phpstan.rules.rule: %drupal.rules.entityListBuilderOperationsCacheabilityRule%
 
 services:
 	-

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -11,7 +11,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
-use function count;
 use function in_array;
 use function version_compare;
 

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
+use function count;
 use function in_array;
 use function version_compare;
 
@@ -71,8 +72,7 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
             return [];
         }
 
-        // Second parameter (CacheableMetadata) must be present and correctly typed.
-        if (isset($node->params[1]) && $this->isValidCacheabilityParam($node->params[1], $scope)) {
+        if (count($node->params) > 1 && ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
             return [];
         }
 
@@ -89,34 +89,5 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
             ->identifier('drupal.entityListBuilderMissingCacheabilityParameter')
             ->build(),
         ];
-    }
-
-    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
-    {
-        if ($param->type === null) {
-            return false;
-        }
-
-        $type = $param->type;
-        $isNullable = false;
-        if ($type instanceof Node\NullableType) {
-            $type = $type->type;
-            $isNullable = true;
-        }
-
-        if ($type instanceof Node\Name) {
-            $resolvedName = $scope->resolveName($type);
-            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
-                return false;
-            }
-        } else {
-            return false;
-        }
-
-        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
-            $isNullable = true;
-        }
-
-        return $isNullable;
     }
 }

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal;
+use Drupal\Core\Entity\EntityListBuilder;
+use Drupal\Core\Entity\EntityListBuilderInterface;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use function count;
+use function explode;
+use function in_array;
+
+/**
+ * Detects EntityListBuilder subclasses overriding getOperations() or
+ * getDefaultOperations() without the CacheableMetadata parameter added in
+ * Drupal 11.3.
+ *
+ * The parameter was introduced as a deprecated workaround (via func_get_args)
+ * in 11.3.0 and becomes a formal required-compatible parameter in 12.0.0.
+ * This rule fires for Drupal 11.3.x only; for 12+ PHPStan's native
+ * method-signature checking handles the incompatibility.
+ *
+ * @implements Rule<ClassMethod>
+ */
+class EntityListBuilderOperationsCacheabilityRule implements Rule
+{
+
+    private const METHODS = ['getOperations', 'getDefaultOperations'];
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // Version gate: only applies for Drupal 11.3.x.
+        [$major, $minor] = explode('.', Drupal::VERSION, 3);
+        $majorVersion = (int) $major;
+        $minorVersion = (int) $minor;
+        if ($majorVersion < 11 || ($majorVersion === 11 && $minorVersion < 3)) {
+            return [];
+        }
+        if ($majorVersion >= 12) {
+            return [];
+        }
+
+        if (!$scope->isInClass()) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        if (!in_array($methodName, self::METHODS, true)) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+
+        // Skip the base class itself — it uses func_get_args() intentionally.
+        if ($classReflection->getName() === EntityListBuilder::class) {
+            return [];
+        }
+
+        $classType = new ObjectType($classReflection->getName());
+
+        // getDefaultOperations is protected and not part of the interface;
+        // only flag it for subclasses of EntityListBuilder.
+        $parentType = $methodName === 'getDefaultOperations'
+            ? new ObjectType(EntityListBuilder::class)
+            : new ObjectType(EntityListBuilderInterface::class);
+
+        if (!$parentType->isSuperTypeOf($classType)->yes()) {
+            return [];
+        }
+
+        // Second parameter (CacheableMetadata) already present — no issue.
+        if (count($node->params) >= 2) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(
+                sprintf(
+                    'Method %s::%s() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    $classReflection->getName(),
+                    $methodName,
+                    $methodName,
+                )
+            )
+            ->tip('See https://www.drupal.org/node/3533080')
+            ->identifier('drupal.entityListBuilderMissingCacheabilityParameter')
+            ->build(),
+        ];
+    }
+}

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use function in_array;
 use function version_compare;

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -72,8 +72,9 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
             return [];
         }
 
-        // Second parameter (CacheableMetadata) already present — no issue.
-        if (count($node->params) >= 2) {
+        // Second parameter (CacheableMetadata) must be present and correctly typed.
+        $params = $node->params;
+        if (isset($params[1]) && $this->isValidCacheabilityParam($params[1], $scope)) {
             return [];
         }
 
@@ -90,5 +91,39 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
             ->identifier('drupal.entityListBuilderMissingCacheabilityParameter')
             ->build(),
         ];
+    }
+
+    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
+    {
+        if ($param->type === null) {
+            return false;
+        }
+
+        $type = $param->type;
+        $isNullable = false;
+        if ($type instanceof Node\NullableType) {
+            $type = $type->type;
+            $isNullable = true;
+        }
+
+        if ($type instanceof Node\Name) {
+            $resolvedName = $scope->resolveName($type);
+            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        // It should be nullable, either via ? or by having a default value of NULL.
+        return $isNullable || $this->isDefaultValueNull($param);
+    }
+
+    private function isDefaultValueNull(Node\Param $param): bool
+    {
+        if ($param->default instanceof Node\Expr\ConstFetch) {
+            return $param->default->name->toLowerString() === 'null';
+        }
+        return false;
     }
 }

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use function in_array;
 use function version_compare;
@@ -72,8 +73,7 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
         }
 
         // Second parameter (CacheableMetadata) must be present and correctly typed.
-        $params = $node->params;
-        if (isset($params[1]) && $this->isValidCacheabilityParam($params[1], $scope)) {
+        if (isset($node->params[1]) && $this->isValidCacheabilityParam($node->params[1], $scope)) {
             return [];
         }
 
@@ -114,15 +114,10 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
             return false;
         }
 
-        // It should be nullable, either via ? or by having a default value of NULL.
-        return $isNullable || $this->isDefaultValueNull($param);
-    }
-
-    private function isDefaultValueNull(Node\Param $param): bool
-    {
-        if ($param->default instanceof Node\Expr\ConstFetch) {
-            return $param->default->name->toLowerString() === 'null';
+        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
+            $isNullable = true;
         }
-        return false;
+
+        return $isNullable;
     }
 }

--- a/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
+++ b/src/Rules/Drupal/EntityListBuilderOperationsCacheabilityRule.php
@@ -12,8 +12,8 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ObjectType;
 use function count;
-use function explode;
 use function in_array;
+use function version_compare;
 
 /**
  * Detects EntityListBuilder subclasses overriding getOperations() or
@@ -40,13 +40,7 @@ class EntityListBuilderOperationsCacheabilityRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // Version gate: only applies for Drupal 11.3.x.
-        [$major, $minor] = explode('.', Drupal::VERSION, 3);
-        $majorVersion = (int) $major;
-        $minorVersion = (int) $minor;
-        if ($majorVersion < 11 || ($majorVersion === 11 && $minorVersion < 3)) {
-            return [];
-        }
-        if ($majorVersion >= 12) {
+        if (version_compare(Drupal::VERSION, '11.3', '<') || version_compare(Drupal::VERSION, '12.0', '>=')) {
             return [];
         }
 

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -9,8 +9,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectType;
 use function class_exists;
 use function count;
 use function version_compare;

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal;
+use Drupal\Core\Hook\Attribute\Hook;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function class_exists;
+use function count;
+use function version_compare;
+
+/**
+ * Detects OOP hook implementations of hook_entity_operation and
+ * hook_entity_operation_alter that are missing the CacheableMetadata
+ * parameter added in Drupal 11.3.
+ *
+ * @implements Rule<ClassMethod>
+ */
+class HookEntityOperationCacheabilityRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!class_exists(Hook::class)) {
+            return [];
+        }
+
+        if (version_compare(Drupal::VERSION, '11.3', '<') || version_compare(Drupal::VERSION, '12.0', '>=')) {
+            return [];
+        }
+
+        if (!$scope->isInClass()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        $nativeClass = $classReflection->getNativeReflection();
+        $methodName = $node->name->toString();
+
+        if (!$nativeClass->hasMethod($methodName)) {
+            return [];
+        }
+
+        $nativeMethod = $nativeClass->getMethod($methodName);
+        $hookAttributes = $nativeMethod->getAttributes(Hook::class);
+
+        if (count($hookAttributes) === 0) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($hookAttributes as $hookAttribute) {
+            /** @var Hook $hookInstance */
+            $hookInstance = $hookAttribute->newInstance();
+
+            if ($hookInstance->hook === 'entity_operation' && count($node->params) < 2) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
+                        $classReflection->getName(),
+                        $methodName,
+                    )
+                )
+                ->tip('See https://www.drupal.org/node/3533080')
+                ->identifier('drupal.hookEntityOperationMissingCacheabilityParameter')
+                ->build();
+            }
+
+            if ($hookInstance->hook === 'entity_operation_alter' && count($node->params) < 3) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                        $classReflection->getName(),
+                        $methodName,
+                    )
+                )
+                ->tip('See https://www.drupal.org/node/3533080')
+                ->identifier('drupal.hookEntityOperationAlterMissingCacheabilityParameter')
+                ->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -9,6 +9,8 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
 use function class_exists;
 use function count;
 use function version_compare;
@@ -118,15 +120,10 @@ class HookEntityOperationCacheabilityRule implements Rule
             return false;
         }
 
-        // It should be nullable, either via ? or by having a default value of NULL.
-        return $isNullable || $this->isDefaultValueNull($param);
-    }
-
-    private function isDefaultValueNull(Node\Param $param): bool
-    {
-        if ($param->default instanceof Node\Expr\ConstFetch) {
-            return $param->default->name->toLowerString() === 'null';
+        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
+            $isNullable = true;
         }
-        return false;
+
+        return $isNullable;
     }
 }

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -63,7 +63,7 @@ class HookEntityOperationCacheabilityRule implements Rule
             $hookInstance = $hookAttribute->newInstance();
 
             if ($hookInstance->hook === 'entity_operation') {
-                if (!isset($node->params[1]) || !$this->isValidCacheabilityParam($node->params[1], $scope)) {
+                if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
                             'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the second parameter.',
@@ -78,7 +78,7 @@ class HookEntityOperationCacheabilityRule implements Rule
             }
 
             if ($hookInstance->hook === 'entity_operation_alter') {
-                if (!isset($node->params[2]) || !$this->isValidCacheabilityParam($node->params[2], $scope)) {
+                if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
                             'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
@@ -94,34 +94,5 @@ class HookEntityOperationCacheabilityRule implements Rule
         }
 
         return $errors;
-    }
-
-    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
-    {
-        if ($param->type === null) {
-            return false;
-        }
-
-        $type = $param->type;
-        $isNullable = false;
-        if ($type instanceof Node\NullableType) {
-            $type = $type->type;
-            $isNullable = true;
-        }
-
-        if ($type instanceof Node\Name) {
-            $resolvedName = $scope->resolveName($type);
-            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
-                return false;
-            }
-        } else {
-            return false;
-        }
-
-        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
-            $isNullable = true;
-        }
-
-        return $isNullable;
     }
 }

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -66,7 +66,7 @@ class HookEntityOperationCacheabilityRule implements Rule
                 if (!isset($node->params[1]) || !$this->isValidCacheabilityParam($node->params[1], $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
-                            'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
+                            'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the second parameter.',
                             $classReflection->getName(),
                             $methodName,
                         )
@@ -81,7 +81,7 @@ class HookEntityOperationCacheabilityRule implements Rule
                 if (!isset($node->params[2]) || !$this->isValidCacheabilityParam($node->params[2], $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
-                            'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                            'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
                             $classReflection->getName(),
                             $methodName,
                         )

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -62,33 +62,71 @@ class HookEntityOperationCacheabilityRule implements Rule
             /** @var Hook $hookInstance */
             $hookInstance = $hookAttribute->newInstance();
 
-            if ($hookInstance->hook === 'entity_operation' && count($node->params) < 2) {
-                $errors[] = RuleErrorBuilder::message(
-                    sprintf(
-                        'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
-                        $classReflection->getName(),
-                        $methodName,
+            if ($hookInstance->hook === 'entity_operation') {
+                if (!isset($node->params[1]) || !$this->isValidCacheabilityParam($node->params[1], $scope)) {
+                    $errors[] = RuleErrorBuilder::message(
+                        sprintf(
+                            'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
+                            $classReflection->getName(),
+                            $methodName,
+                        )
                     )
-                )
-                ->tip('See https://www.drupal.org/node/3533080')
-                ->identifier('drupal.hookEntityOperationMissingCacheabilityParameter')
-                ->build();
+                    ->tip('See https://www.drupal.org/node/3533080')
+                    ->identifier('drupal.hookEntityOperationMissingCacheabilityParameter')
+                    ->build();
+                }
             }
 
-            if ($hookInstance->hook === 'entity_operation_alter' && count($node->params) < 3) {
-                $errors[] = RuleErrorBuilder::message(
-                    sprintf(
-                        'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
-                        $classReflection->getName(),
-                        $methodName,
+            if ($hookInstance->hook === 'entity_operation_alter') {
+                if (!isset($node->params[2]) || !$this->isValidCacheabilityParam($node->params[2], $scope)) {
+                    $errors[] = RuleErrorBuilder::message(
+                        sprintf(
+                            'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                            $classReflection->getName(),
+                            $methodName,
+                        )
                     )
-                )
-                ->tip('See https://www.drupal.org/node/3533080')
-                ->identifier('drupal.hookEntityOperationAlterMissingCacheabilityParameter')
-                ->build();
+                    ->tip('See https://www.drupal.org/node/3533080')
+                    ->identifier('drupal.hookEntityOperationAlterMissingCacheabilityParameter')
+                    ->build();
+                }
             }
         }
 
         return $errors;
+    }
+
+    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
+    {
+        if ($param->type === null) {
+            return false;
+        }
+
+        $type = $param->type;
+        $isNullable = false;
+        if ($type instanceof Node\NullableType) {
+            $type = $type->type;
+            $isNullable = true;
+        }
+
+        if ($type instanceof Node\Name) {
+            $resolvedName = $scope->resolveName($type);
+            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        // It should be nullable, either via ? or by having a default value of NULL.
+        return $isNullable || $this->isDefaultValueNull($param);
+    }
+
+    private function isDefaultValueNull(Node\Param $param): bool
+    {
+        if ($param->default instanceof Node\Expr\ConstFetch) {
+            return $param->default->name->toLowerString() === 'null';
+        }
+        return false;
     }
 }

--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -34,7 +34,7 @@ class HookEntityOperationCacheabilityRule implements Rule
             return [];
         }
 
-        if (version_compare(Drupal::VERSION, '11.3', '<') || version_compare(Drupal::VERSION, '12.0', '>=')) {
+        if (version_compare(Drupal::VERSION, '11.3', '<')) {
             return [];
         }
 

--- a/src/Rules/Drupal/ParamHelper.php
+++ b/src/Rules/Drupal/ParamHelper.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+
+final class ParamHelper
+{
+
+    public static function isValidParam(Node\Param $param, string $expectedFqcn, bool $isNullable, Scope $scope): bool
+    {
+        if ($param->type === null) {
+            return false;
+        }
+
+        $type = $param->type;
+        $paramIsNullable = $type instanceof Node\NullableType;
+        if ($paramIsNullable) {
+            $type = $type->type;
+        }
+
+        if (!($type instanceof Node\Name) || $scope->resolveName($type) !== $expectedFqcn) {
+            return false;
+        }
+
+        if (!$paramIsNullable && $param->default !== null) {
+            $paramIsNullable = $scope->getType($param->default)->isNull()->yes();
+        }
+
+        return !$isNullable || $paramIsNullable;
+    }
+}

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal;
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Function_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use function basename;
+use function count;
+use function explode;
+use function str_ends_with;
+use function str_starts_with;
+use function strlen;
+use function substr_replace;
+use function version_compare;
+
+/**
+ * Detects procedural implementations of hook_entity_operation and
+ * hook_entity_operation_alter that are missing the CacheableMetadata
+ * parameter added in Drupal 11.3.
+ *
+ * @implements Rule<Function_>
+ */
+class ProceduralHookEntityOperationCacheabilityRule implements Rule
+{
+
+    public function getNodeType(): string
+    {
+        return Function_::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!str_ends_with($scope->getFile(), '.module') && !str_ends_with($scope->getFile(), '.inc')) {
+            return [];
+        }
+
+        if (version_compare(Drupal::VERSION, '11.3', '<') || version_compare(Drupal::VERSION, '12.0', '>=')) {
+            return [];
+        }
+
+        $moduleName = explode('.', basename($scope->getFile()))[0];
+        $functionName = $node->name->toString();
+
+        if (!str_starts_with($functionName, "{$moduleName}_")) {
+            return [];
+        }
+
+        $hookName = substr_replace($functionName, 'hook', 0, strlen($moduleName));
+
+        if ($hookName === 'hook_entity_operation' && count($node->params) < 2) {
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                        $functionName,
+                        $functionName,
+                    )
+                )
+                ->tip('See https://www.drupal.org/node/3533080')
+                ->identifier('drupal.proceduralHookEntityOperationMissingCacheabilityParameter')
+                ->build(),
+            ];
+        }
+
+        if ($hookName === 'hook_entity_operation_alter' && count($node->params) < 3) {
+            return [
+                RuleErrorBuilder::message(
+                    sprintf(
+                        'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                        $functionName,
+                        $functionName,
+                    )
+                )
+                ->tip('See https://www.drupal.org/node/3533080')
+                ->identifier('drupal.proceduralHookEntityOperationAlterMissingCacheabilityParameter')
+                ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -8,8 +8,6 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\NullType;
-use PHPStan\Type\ObjectType;
 use function basename;
 use function explode;
 use function str_ends_with;

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -9,7 +9,6 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function basename;
-use function count;
 use function explode;
 use function str_ends_with;
 use function str_starts_with;

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -51,36 +51,74 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
 
         $hookName = substr_replace($functionName, 'hook', 0, strlen($moduleName));
 
-        if ($hookName === 'hook_entity_operation' && count($node->params) < 2) {
-            return [
-                RuleErrorBuilder::message(
-                    sprintf(
-                        'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
-                        $functionName,
-                        $functionName,
+        if ($hookName === 'hook_entity_operation') {
+            if (!isset($node->params[1]) || !$this->isValidCacheabilityParam($node->params[1], $scope)) {
+                return [
+                    RuleErrorBuilder::message(
+                        sprintf(
+                            'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                            $functionName,
+                            $functionName,
+                        )
                     )
-                )
-                ->tip('See https://www.drupal.org/node/3533080')
-                ->identifier('drupal.proceduralHookEntityOperationMissingCacheabilityParameter')
-                ->build(),
-            ];
+                    ->tip('See https://www.drupal.org/node/3533080')
+                    ->identifier('drupal.proceduralHookEntityOperationMissingCacheabilityParameter')
+                    ->build(),
+                ];
+            }
         }
 
-        if ($hookName === 'hook_entity_operation_alter' && count($node->params) < 3) {
-            return [
-                RuleErrorBuilder::message(
-                    sprintf(
-                        'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
-                        $functionName,
-                        $functionName,
+        if ($hookName === 'hook_entity_operation_alter') {
+            if (!isset($node->params[2]) || !$this->isValidCacheabilityParam($node->params[2], $scope)) {
+                return [
+                    RuleErrorBuilder::message(
+                        sprintf(
+                            'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                            $functionName,
+                            $functionName,
+                        )
                     )
-                )
-                ->tip('See https://www.drupal.org/node/3533080')
-                ->identifier('drupal.proceduralHookEntityOperationAlterMissingCacheabilityParameter')
-                ->build(),
-            ];
+                    ->tip('See https://www.drupal.org/node/3533080')
+                    ->identifier('drupal.proceduralHookEntityOperationAlterMissingCacheabilityParameter')
+                    ->build(),
+                ];
+            }
         }
 
         return [];
+    }
+
+    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
+    {
+        if ($param->type === null) {
+            return false;
+        }
+
+        $type = $param->type;
+        $isNullable = false;
+        if ($type instanceof Node\NullableType) {
+            $type = $type->type;
+            $isNullable = true;
+        }
+
+        if ($type instanceof Node\Name) {
+            $resolvedName = $scope->resolveName($type);
+            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
+                return false;
+            }
+        } else {
+            return false;
+        }
+
+        // It should be nullable, either via ? or by having a default value of NULL.
+        return $isNullable || $this->isDefaultValueNull($param);
+    }
+
+    private function isDefaultValueNull(Node\Param $param): bool
+    {
+        if ($param->default instanceof Node\Expr\ConstFetch) {
+            return $param->default->name->toLowerString() === 'null';
+        }
+        return false;
     }
 }

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use function basename;
+use function count;
 use function explode;
 use function str_ends_with;
 use function str_starts_with;
@@ -51,7 +52,7 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
         $hookName = substr_replace($functionName, 'hook', 0, strlen($moduleName));
 
         if ($hookName === 'hook_entity_operation') {
-            if (!isset($node->params[1]) || !$this->isValidCacheabilityParam($node->params[1], $scope)) {
+            if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
@@ -68,7 +69,7 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
         }
 
         if ($hookName === 'hook_entity_operation_alter') {
-            if (!isset($node->params[2]) || !$this->isValidCacheabilityParam($node->params[2], $scope)) {
+            if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
@@ -85,34 +86,5 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
         }
 
         return [];
-    }
-
-    private function isValidCacheabilityParam(Node\Param $param, Scope $scope): bool
-    {
-        if ($param->type === null) {
-            return false;
-        }
-
-        $type = $param->type;
-        $isNullable = false;
-        if ($type instanceof Node\NullableType) {
-            $type = $type->type;
-            $isNullable = true;
-        }
-
-        if ($type instanceof Node\Name) {
-            $resolvedName = $scope->resolveName($type);
-            if ($resolvedName !== 'Drupal\Core\Cache\CacheableMetadata') {
-                return false;
-            }
-        } else {
-            return false;
-        }
-
-        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
-            $isNullable = true;
-        }
-
-        return $isNullable;
     }
 }

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -38,7 +38,7 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
             return [];
         }
 
-        if (version_compare(Drupal::VERSION, '11.3', '<') || version_compare(Drupal::VERSION, '12.0', '>=')) {
+        if (version_compare(Drupal::VERSION, '11.3', '<')) {
             return [];
         }
 

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -56,7 +56,7 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
-                            'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                            'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
                             $functionName,
                             $functionName,
                         )
@@ -73,7 +73,7 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
-                            'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                            'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
                             $functionName,
                             $functionName,
                         )

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -8,6 +8,8 @@ use PhpParser\Node\Stmt\Function_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\NullType;
+use PHPStan\Type\ObjectType;
 use function basename;
 use function explode;
 use function str_ends_with;
@@ -109,15 +111,10 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
             return false;
         }
 
-        // It should be nullable, either via ? or by having a default value of NULL.
-        return $isNullable || $this->isDefaultValueNull($param);
-    }
-
-    private function isDefaultValueNull(Node\Param $param): bool
-    {
-        if ($param->default instanceof Node\Expr\ConstFetch) {
-            return $param->default->name->toLowerString() === 'null';
+        if ($param->default !== null && $scope->getType($param->default)->isNull()->yes()) {
+            $isNullable = true;
         }
-        return false;
+
+        return $isNullable;
     }
 }

--- a/tests/src/Rules/EntityListBuilderOperationsCacheabilityRuleTest.php
+++ b/tests/src/Rules/EntityListBuilderOperationsCacheabilityRuleTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class EntityListBuilderOperationsCacheabilityRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new EntityListBuilderOperationsCacheabilityRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/entity-list-builder-operations-cacheability.php'],
+            [
+                [
+                    'Method MissingCacheabilityGetOperations::getOperations() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: getOperations(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    10,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Method MissingCacheabilityGetDefaultOperations::getDefaultOperations() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: getDefaultOperations(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    19,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Method MissingCacheabilityBoth::getOperations() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: getOperations(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    28,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Method MissingCacheabilityBoth::getDefaultOperations() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: getDefaultOperations(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    33,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+            ]
+        );
+    }
+
+}

--- a/tests/src/Rules/EntityListBuilderOperationsCacheabilityRuleTest.php
+++ b/tests/src/Rules/EntityListBuilderOperationsCacheabilityRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Tests\Rules;
 
+use Drupal;
 use mglaman\PHPStanDrupal\Rules\Drupal\EntityListBuilderOperationsCacheabilityRule;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use function version_compare;
 
 final class EntityListBuilderOperationsCacheabilityRuleTest extends DrupalRuleTestCase
 {
@@ -15,9 +17,10 @@ final class EntityListBuilderOperationsCacheabilityRuleTest extends DrupalRuleTe
 
     public function testRule(): void
     {
+        $isApplicableVersion = version_compare(Drupal::VERSION, '11.3', '>=') && version_compare(Drupal::VERSION, '12.0', '<');
         $this->analyse(
             [__DIR__ . '/data/entity-list-builder-operations-cacheability.php'],
-            [
+            $isApplicableVersion ? [
                 [
                     'Method MissingCacheabilityGetOperations::getOperations() is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: getOperations(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
                     10,
@@ -38,7 +41,7 @@ final class EntityListBuilderOperationsCacheabilityRuleTest extends DrupalRuleTe
                     33,
                     'See https://www.drupal.org/node/3533080',
                 ],
-            ]
+            ] : []
         );
     }
 

--- a/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new HookEntityOperationCacheabilityRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/hook-entity-operation-cacheability.php'],
+            [
+                [
+                    'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
+                    10,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Method BadEntityOperationAlterHookOneParam::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                    20,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Method BadEntityOperationAlterHookTwoParams::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                    29,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+            ]
+        );
+    }
+
+}

--- a/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Tests\Rules;
 
+use Drupal;
 use mglaman\PHPStanDrupal\Rules\Drupal\HookEntityOperationCacheabilityRule;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use function version_compare;
 
 final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
 {
@@ -15,9 +17,10 @@ final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
 
     public function testRule(): void
     {
+        $isApplicableVersion = version_compare(Drupal::VERSION, '11.3', '>=') && version_compare(Drupal::VERSION, '12.0', '<');
         $this->analyse(
             [__DIR__ . '/data/hook-entity-operation-cacheability.php'],
-            [
+            $isApplicableVersion ? [
                 [
                     'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
                     10,
@@ -33,7 +36,7 @@ final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
                     29,
                     'See https://www.drupal.org/node/3533080',
                 ],
-            ]
+            ] : []
         );
     }
 

--- a/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
@@ -22,17 +22,17 @@ final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
             [__DIR__ . '/data/hook-entity-operation-cacheability.php'],
             $isApplicableVersion ? [
                 [
-                    'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
+                    'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the second parameter.',
                     10,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Method BadEntityOperationAlterHookOneParam::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                    'Method BadEntityOperationAlterHookOneParam::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
                     20,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Method BadEntityOperationAlterHookTwoParams::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
+                    'Method BadEntityOperationAlterHookTwoParams::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
                     29,
                     'See https://www.drupal.org/node/3533080',
                 ],

--- a/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
@@ -2,8 +2,10 @@
 
 namespace mglaman\PHPStanDrupal\Tests\Rules;
 
+use Drupal;
 use mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use function version_compare;
 
 final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
 {
@@ -15,9 +17,10 @@ final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRule
 
     public function testRule(): void
     {
+        $isApplicableVersion = version_compare(Drupal::VERSION, '11.3', '>=') && version_compare(Drupal::VERSION, '12.0', '<');
         $this->analyse(
             [__DIR__ . '/data/mymodule.module'],
-            [
+            $isApplicableVersion ? [
                 [
                     'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
                     7,
@@ -28,7 +31,7 @@ final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRule
                     12,
                     'See https://www.drupal.org/node/3533080',
                 ],
-            ]
+            ] : []
         );
     }
 

--- a/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\ProceduralHookEntityOperationCacheabilityRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return new ProceduralHookEntityOperationCacheabilityRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse(
+            [__DIR__ . '/data/mymodule.module'],
+            [
+                [
+                    'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                    7,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+                [
+                    'Function mymodule_entity_operation_alter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                    12,
+                    'See https://www.drupal.org/node/3533080',
+                ],
+            ]
+        );
+    }
+
+}

--- a/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
@@ -22,12 +22,12 @@ final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRule
             [__DIR__ . '/data/mymodule.module'],
             $isApplicableVersion ? [
                 [
-                    'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                    'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
                     7,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Function mymodule_entity_operation_alter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
+                    'Function mymodule_entity_operation_alter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
                     12,
                     'See https://www.drupal.org/node/3533080',
                 ],

--- a/tests/src/Rules/data/entity-list-builder-operations-cacheability.php
+++ b/tests/src/Rules/data/entity-list-builder-operations-cacheability.php
@@ -1,0 +1,65 @@
+<?php
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityListBuilder;
+
+// Bad: overrides getOperations() without CacheableMetadata.
+class MissingCacheabilityGetOperations extends EntityListBuilder
+{
+    public function getOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+}
+
+// Bad: overrides getDefaultOperations() without CacheableMetadata.
+class MissingCacheabilityGetDefaultOperations extends EntityListBuilder
+{
+    protected function getDefaultOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+}
+
+// Bad: overrides both without CacheableMetadata.
+class MissingCacheabilityBoth extends EntityListBuilder
+{
+    public function getOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+
+    protected function getDefaultOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+}
+
+// Good: both methods include the CacheableMetadata parameter.
+class CorrectCacheabilityBoth extends EntityListBuilder
+{
+    public function getOperations(EntityInterface $entity, ?CacheableMetadata $cacheability = null): array
+    {
+        return [];
+    }
+
+    protected function getDefaultOperations(EntityInterface $entity, ?CacheableMetadata $cacheability = null): array
+    {
+        return [];
+    }
+}
+
+// Not related to EntityListBuilder — no errors expected.
+class UnrelatedClass
+{
+    public function getOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+
+    public function getDefaultOperations(EntityInterface $entity): array
+    {
+        return [];
+    }
+}

--- a/tests/src/Rules/data/hook-entity-operation-cacheability.php
+++ b/tests/src/Rules/data/hook-entity-operation-cacheability.php
@@ -1,0 +1,62 @@
+<?php
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+
+// Bad: entity_operation without CacheableMetadata.
+class BadEntityOperationHook
+{
+    #[Hook('entity_operation')]
+    public function entityOperation(EntityInterface $entity): array
+    {
+        return [];
+    }
+}
+
+// Bad: entity_operation_alter with only operations param.
+class BadEntityOperationAlterHookOneParam
+{
+    #[Hook('entity_operation_alter')]
+    public function entityOperationAlter(array &$operations): void
+    {
+    }
+}
+
+// Bad: entity_operation_alter missing CacheableMetadata (2 params, needs 3).
+class BadEntityOperationAlterHookTwoParams
+{
+    #[Hook('entity_operation_alter')]
+    public function entityOperationAlter(array &$operations, EntityInterface $entity): void
+    {
+    }
+}
+
+// Good: entity_operation with CacheableMetadata.
+class GoodEntityOperationHook
+{
+    #[Hook('entity_operation')]
+    public function entityOperation(EntityInterface $entity, ?CacheableMetadata $cacheability = null): array
+    {
+        return [];
+    }
+}
+
+// Good: entity_operation_alter with CacheableMetadata.
+class GoodEntityOperationAlterHook
+{
+    #[Hook('entity_operation_alter')]
+    public function entityOperationAlter(array &$operations, EntityInterface $entity, ?CacheableMetadata $cacheability = null): void
+    {
+    }
+}
+
+// Not an entity operation hook — no errors expected.
+class UnrelatedHook
+{
+    #[Hook('some_other_hook')]
+    public function someOtherHook(EntityInterface $entity): array
+    {
+        return [];
+    }
+}

--- a/tests/src/Rules/data/mymodule.module
+++ b/tests/src/Rules/data/mymodule.module
@@ -1,0 +1,18 @@
+<?php
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Entity\EntityInterface;
+
+// Bad: missing CacheableMetadata (1 param instead of 2).
+function mymodule_entity_operation(EntityInterface $entity): array {
+    return [];
+}
+
+// Bad: entity_operation_alter missing CacheableMetadata (2 params instead of 3).
+function mymodule_entity_operation_alter(array &$operations, EntityInterface $entity): void {
+}
+
+// Not flagged: different module prefix — not from this module.
+function other_module_entity_operation(EntityInterface $entity): array {
+    return [];
+}


### PR DESCRIPTION
## Summary

Closes #930

Drupal 11.3 introduced a deprecation for `EntityListBuilder::getOperations()` and `EntityListBuilder::getDefaultOperations()` — both methods now accept an optional `?CacheableMetadata $cacheability = NULL` second parameter (via a `func_get_args()` workaround until it becomes formal in Drupal 12.0.0). Custom subclasses that override these methods without the new parameter silently miss cacheability bubbling for access checks.

Similarly, `hook_entity_operation` and `hook_entity_operation_alter` now also accept a `CacheableMetadata` argument.

This PR adds rules to detect these outdated overrides and hook implementations:

• `EntityListBuilderOperationsCacheabilityRule`: detects outdated overrides in `EntityListBuilder` subclasses.
• `HookEntityOperationCacheabilityRule` and `ProceduralHookEntityOperationCacheabilityRule`: detects outdated `hook_entity_operation(_alter)` implementations.

All rules are registered behind the `entityOperationsCacheabilityRule` bleeding-edge flag.

• Version-gated: only fires for Drupal 11.3.x by reading `\Drupal::VERSION`; skips `< 11.3` (parameter didn't exist yet) and `>= 12` (PHPStan's native signature checking handles it once the parameter is formal).
• Error includes a tip linking to the change record https://www.drupal.org/node/3533080

## Test plan

[ ] `php vendor/bin/phpunit --filter=EntityListBuilderOperationsCacheabilityRuleTest` — new test passes
[ ] `php vendor/bin/phpunit` — full suite green
[ ] `php vendor/bin/phpstan analyze` — no errors
[ ] `php vendor/bin/phpcs` — clean