### PR TITLE
Fix wrongly deprecated method RevisionableStorageInterface::loadRevision

### DIFF
--- a/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
+++ b/stubs/Drupal/Core/Entity/RevisionableStorageInterface.stub
@@ -7,11 +7,13 @@ interface RevisionableStorageInterface extends EntityStorageInterface {
   /**
    * @param int|numeric-string|string $revision_id
    * @return \Drupal\Core\Entity\RevisionableInterface|null
+   * @not-deprecated
    */
   public function loadRevision($revision_id);
 
   /**
    * @param int|numeric-string|string $revision_id
+   * @not-deprecated
    */
   public function deleteRevision($revision_id): void;
   


### PR DESCRIPTION
Since `RevisionableStorageInterface` extends `EntityStorageInterface`, the deprecations are also inherited.

The `loadRevision()` method is not supposed to be deprecated on `RevisionableStorageInterface` though.