### PR TITLE
Fix hook_entity_operation cacheability parameter should not be nullable

### DIFF
--- a/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/HookEntityOperationCacheabilityRule.php
@@ -63,10 +63,10 @@ class HookEntityOperationCacheabilityRule implements Rule
             $hookInstance = $hookAttribute->newInstance();
 
             if ($hookInstance->hook === 'entity_operation') {
-                if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
+                if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', false, $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
-                            'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the second parameter.',
+                            'Method %s::%s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include \Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
                             $classReflection->getName(),
                             $methodName,
                         )
@@ -78,10 +78,10 @@ class HookEntityOperationCacheabilityRule implements Rule
             }
 
             if ($hookInstance->hook === 'entity_operation_alter') {
-                if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
+                if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', false, $scope)) {
                     $errors[] = RuleErrorBuilder::message(
                         sprintf(
-                            'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
+                            'Method %s::%s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include \Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
                             $classReflection->getName(),
                             $methodName,
                         )

--- a/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
+++ b/src/Rules/Drupal/ProceduralHookEntityOperationCacheabilityRule.php
@@ -52,11 +52,11 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
         $hookName = substr_replace($functionName, 'hook', 0, strlen($moduleName));
 
         if ($hookName === 'hook_entity_operation') {
-            if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
+            if (count($node->params) < 2 || !ParamHelper::isValidParam($node->params[1], 'Drupal\Core\Cache\CacheableMetadata', false, $scope)) {
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
-                            'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                            'Function %s() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
                             $functionName,
                             $functionName,
                         )
@@ -69,11 +69,11 @@ class ProceduralHookEntityOperationCacheabilityRule implements Rule
         }
 
         if ($hookName === 'hook_entity_operation_alter') {
-            if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', true, $scope)) {
+            if (count($node->params) < 3 || !ParamHelper::isValidParam($node->params[2], 'Drupal\Core\Cache\CacheableMetadata', false, $scope)) {
                 return [
                     RuleErrorBuilder::message(
                         sprintf(
-                            'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                            'Function %s() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: %s(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
                             $functionName,
                             $functionName,
                         )

--- a/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/HookEntityOperationCacheabilityRuleTest.php
@@ -22,17 +22,17 @@ final class HookEntityOperationCacheabilityRuleTest extends DrupalRuleTestCase
             [__DIR__ . '/data/hook-entity-operation-cacheability.php'],
             $isApplicableVersion ? [
                 [
-                    'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the second parameter.',
+                    'Method BadEntityOperationHook::entityOperation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include \Drupal\Core\Cache\CacheableMetadata $cacheability as the second parameter.',
                     10,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Method BadEntityOperationAlterHookOneParam::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
+                    'Method BadEntityOperationAlterHookOneParam::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include \Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
                     20,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Method BadEntityOperationAlterHookTwoParams::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL as the third parameter.',
+                    'Method BadEntityOperationAlterHookTwoParams::entityOperationAlter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to include \Drupal\Core\Cache\CacheableMetadata $cacheability as the third parameter.',
                     29,
                     'See https://www.drupal.org/node/3533080',
                 ],

--- a/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
+++ b/tests/src/Rules/ProceduralHookEntityOperationCacheabilityRuleTest.php
@@ -22,12 +22,12 @@ final class ProceduralHookEntityOperationCacheabilityRuleTest extends DrupalRule
             [__DIR__ . '/data/mymodule.module'],
             $isApplicableVersion ? [
                 [
-                    'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    'Function mymodule_entity_operation() implements hook_entity_operation but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation(\Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
                     7,
                     'See https://www.drupal.org/node/3533080',
                 ],
                 [
-                    'Function mymodule_entity_operation_alter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, ?\Drupal\Core\Cache\CacheableMetadata $cacheability = NULL).',
+                    'Function mymodule_entity_operation_alter() implements hook_entity_operation_alter but is missing the CacheableMetadata parameter added in Drupal 11.3. Update the signature to: mymodule_entity_operation_alter(array &$operations, \Drupal\Core\Entity\EntityInterface $entity, \Drupal\Core\Cache\CacheableMetadata $cacheability).',
                     12,
                     'See https://www.drupal.org/node/3533080',
                 ],

--- a/tests/src/Rules/data/hook-entity-operation-cacheability.php
+++ b/tests/src/Rules/data/hook-entity-operation-cacheability.php
@@ -32,8 +32,27 @@ class BadEntityOperationAlterHookTwoParams
     }
 }
 
-// Good: entity_operation with CacheableMetadata.
+// Good: entity_operation with non-nullable CacheableMetadata (canonical form).
 class GoodEntityOperationHook
+{
+    #[Hook('entity_operation')]
+    public function entityOperation(EntityInterface $entity, CacheableMetadata $cacheability): array
+    {
+        return [];
+    }
+}
+
+// Good: entity_operation_alter with non-nullable CacheableMetadata (canonical form).
+class GoodEntityOperationAlterHook
+{
+    #[Hook('entity_operation_alter')]
+    public function entityOperationAlter(array &$operations, EntityInterface $entity, CacheableMetadata $cacheability): void
+    {
+    }
+}
+
+// Good: nullable CacheableMetadata also accepted.
+class GoodEntityOperationHookNullable
 {
     #[Hook('entity_operation')]
     public function entityOperation(EntityInterface $entity, ?CacheableMetadata $cacheability = null): array
@@ -42,8 +61,8 @@ class GoodEntityOperationHook
     }
 }
 
-// Good: entity_operation_alter with CacheableMetadata.
-class GoodEntityOperationAlterHook
+// Good: nullable CacheableMetadata also accepted for alter.
+class GoodEntityOperationAlterHookNullable
 {
     #[Hook('entity_operation_alter')]
     public function entityOperationAlter(array &$operations, EntityInterface $entity, ?CacheableMetadata $cacheability = null): void

--- a/tests/src/Rules/data/mymodule.module
+++ b/tests/src/Rules/data/mymodule.module
@@ -16,3 +16,21 @@ function mymodule_entity_operation_alter(array &$operations, EntityInterface $en
 function other_module_entity_operation(EntityInterface $entity): array {
     return [];
 }
+
+// Good: non-nullable CacheableMetadata (canonical form).
+function mymodule_entity_operation_good(EntityInterface $entity, CacheableMetadata $cacheability): array {
+    return [];
+}
+
+// Good: nullable CacheableMetadata also accepted.
+function mymodule_entity_operation_good_nullable(EntityInterface $entity, ?CacheableMetadata $cacheability = null): array {
+    return [];
+}
+
+// Good: entity_operation_alter with non-nullable CacheableMetadata.
+function mymodule_entity_operation_alter_good(array &$operations, EntityInterface $entity, CacheableMetadata $cacheability): void {
+}
+
+// Good: entity_operation_alter with nullable CacheableMetadata also accepted.
+function mymodule_entity_operation_alter_good_nullable(array &$operations, EntityInterface $entity, ?CacheableMetadata $cacheability = null): void {
+}


### PR DESCRIPTION
## Summary

- Fixes #984: `$cacheability` in `hook_entity_operation` and `hook_entity_operation_alter` is not nullable — only `EntityListBuilder` methods use nullable for BC (removed in D12)
- Changed `isValidParam(..., true, ...)` → `false` in both hook rules so non-nullable `CacheableMetadata $cacheability` is accepted (nullable is also still accepted)
- Updated error messages to recommend `\Drupal\Core\Cache\CacheableMetadata $cacheability` without `?` / `= NULL`
- Added non-nullable "good" fixture examples; kept nullable variants to confirm both pass

## Test plan

- [ ] `php vendor/bin/phpunit --filter=HookEntityOperationCacheabilityRuleTest`
- [ ] `php vendor/bin/phpunit --filter=ProceduralHookEntityOperationCacheabilityRuleTest`
- [ ] `php vendor/bin/phpunit --filter=EntityListBuilderOperationsCacheabilityRuleTest` (unchanged, still nullable)
- [ ] `php vendor/bin/phpcs src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)