### PR TITLE
Fix false positive in entityStoragePropertyAssignment rule when assigning null

### DIFF
--- a/src/Rules/Drupal/EntityStoragePropertyAssignmentRule.php
+++ b/src/Rules/Drupal/EntityStoragePropertyAssignmentRule.php
@@ -38,6 +38,11 @@ final class EntityStoragePropertyAssignmentRule implements Rule
         }
 
         $assignedType = $scope->getType($node->expr);
+        // Bail early when assigning literal null — removeNull(NullType) yields
+        // NeverType, and isSuperTypeOf(NeverType) is vacuously true for any type.
+        if ($assignedType->isNull()->yes()) {
+            return [];
+        }
         $storageType = new ObjectType(EntityStorageInterface::class);
         if (!$storageType->isSuperTypeOf(TypeCombinator::removeNull($assignedType))->yes()) {
             return [];

--- a/tests/src/Rules/data/entity-storage-property-assignment.php
+++ b/tests/src/Rules/data/entity-storage-property-assignment.php
@@ -80,3 +80,14 @@ class ServiceCallingStorageAtCallSite
         $storage->load(1);
     }
 }
+
+// No error: assigning null to a nullable non-storage property (issue #983).
+class ServiceWithNullableNonStorageProperty
+{
+    protected ?int $foo = null;
+
+    public function reset(): void
+    {
+        $this->foo = null;
+    }
+}


### PR DESCRIPTION
## Summary

- `TypeCombinator::removeNull(NullType)` yields `NeverType` (bottom type)
- `isSuperTypeOf(NeverType)` is vacuously true for any type, including `EntityStorageInterface`
- Result: assigning literal `null` to any class property falsely triggered the rule

Fix bails early when `$assignedType->isNull()->yes()` before the `removeNull` call.

Fixes #983

## Test plan

- [ ] Added `ServiceWithNullableNonStorageProperty` fixture to existing test data — assigns `null` to `?int` property, expects no errors
- [ ] Run `php vendor/bin/phpunit --filter=EntityStoragePropertyAssignmentRuleTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)