### PR TITLE
Fix ContainerInterface::has() returning always-true for known services

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ What it currently enables:
 - `cacheableDependencyRule` — flags `addCacheableDependency()` calls with non-cacheable arguments
 - `loggerFromFactoryPropertyAssignmentRule` — flags logger channels assigned to properties in classes using `DependencySerializationTrait`
 - `entityStorageDirectInjectionRule` — flags direct injection of entity storage into a constructor; inject `EntityTypeManagerInterface` and call `getStorage()` instead
+- `containerHasAlwaysTrue: false` — `ContainerInterface::has()` returns `bool` instead of always-`true` for known services, preventing false positives that may cause developers to remove legitimate conditional service guards
 
 > [!NOTE]
 > `checkDeprecatedHooksInApiFiles` is deprecated. Use `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -4,6 +4,7 @@ parameters:
 			checkDeprecatedHooksInApiFiles: false
 			checkCoreDeprecatedHooksInApiFiles: true
 			checkContribDeprecatedHooksInApiFiles: true
+			containerHasAlwaysTrue: false
 		rules:
 			testClassSuffixNameRule: true
 			dependencySerializationTraitPropertyRule: true

--- a/extension.neon
+++ b/extension.neon
@@ -21,6 +21,7 @@ parameters:
 			checkDeprecatedHooksInApiFiles: false
 			checkCoreDeprecatedHooksInApiFiles: false
 			checkContribDeprecatedHooksInApiFiles: false
+			containerHasAlwaysTrue: true
 		extensions:
 			entityFieldsViaMagicReflection: true
 			entityFieldMethodsViaMagicReflection: true
@@ -259,6 +260,7 @@ parametersSchema:
 			checkDeprecatedHooksInApiFiles: boolean()
 			checkCoreDeprecatedHooksInApiFiles: boolean()
 			checkContribDeprecatedHooksInApiFiles: boolean()
+			containerHasAlwaysTrue: boolean()
 		])
 		extensions: structure([
 			entityFieldsViaMagicReflection: boolean()
@@ -325,6 +327,8 @@ services:
 	-
 		class: mglaman\PHPStanDrupal\Type\ContainerDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+		arguments:
+			containerHasAlwaysTrue: %drupal.bleedingEdge.containerHasAlwaysTrue%
 	-
 		class: mglaman\PHPStanDrupal\Type\DrupalClassResolverDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/ContainerDynamicReturnTypeExtension.php
+++ b/src/Type/ContainerDynamicReturnTypeExtension.php
@@ -7,6 +7,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\BooleanType;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\NullType;
@@ -18,14 +19,11 @@ use function in_array;
 
 class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
-    /**
-     * @var ServiceMap
-     */
-    private ServiceMap $serviceMap;
 
-    public function __construct(ServiceMap $serviceMap)
-    {
-        $this->serviceMap = $serviceMap;
+    public function __construct(
+        private ServiceMap $serviceMap,
+        private bool $containerHasAlwaysTrue,
+    ) {
     }
 
     public function getClass(): string
@@ -62,7 +60,11 @@ class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
             foreach ($argType->getConstantStrings() as $constantStringType) {
                 $serviceId = $constantStringType->getValue();
                 $service = $this->serviceMap->getService($serviceId);
-                $types[] = new ConstantBooleanType($service !== null);
+                if (!$this->containerHasAlwaysTrue && $service !== null) {
+                    $types[] = new BooleanType();
+                } else {
+                    $types[] = new ConstantBooleanType($service !== null);
+                }
             }
 
             return TypeCombinator::union(...$types);

--- a/tests/fixtures/config/phpunit-drupal-phpstan-no-bleedingedge.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan-no-bleedingedge.neon
@@ -1,0 +1,18 @@
+parameters:
+	drupal:
+		entityMapping:
+			content_entity_using_custom_storage:
+				class: Drupal\phpstan_fixtures\Entity\ContentEntityUsingCustomStorage
+				storage: Drupal\phpstan_fixtures\CustomContentEntityStorage
+			config_entity_using_default_storage:
+				class: Drupal\phpstan_fixtures\Entity\ConfigEntityUsingDefaultStorage
+				storage: Drupal\Core\Config\Entity\ConfigEntityStorage
+			config_entity_using_custom_storage:
+				class: Drupal\phpstan_fixtures\Entity\ConfigEntityUsingCustomStorage
+				storage: Drupal\phpstan_fixtures\CustomConfigEntityStorage
+			content_entity_using_default_storage:
+				class: Drupal\phpstan_fixtures\Entity\ContentEntityUsingDefaultStorage
+includes:
+	- ../../../extension.neon
+	- ../../../rules.neon
+	- ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/tests/src/Type/DrupalContainerDynamicReturnTypeLegacyTest.php
+++ b/tests/src/Type/DrupalContainerDynamicReturnTypeLegacyTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class DrupalContainerDynamicReturnTypeLegacyTest extends TypeInferenceTestCase
+{
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return array_merge(parent::getAdditionalConfigFiles(), [
+            __DIR__ . '/../../fixtures/config/phpunit-drupal-phpstan-no-bleedingedge.neon',
+        ]);
+    }
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/container-legacy-has.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Type/data/container-legacy-has.php
+++ b/tests/src/Type/data/container-legacy-has.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DrupalContainerStaticLegacy;
+
+use Drupal\service_map\MyService;
+use function PHPStan\Testing\assertType;
+
+function test(): void {
+    $container = \Drupal::getContainer();
+
+    assertType('true', $container->has('service_map.my_service'));
+    assertType('false', $container->has('unknown_service'));
+}

--- a/tests/src/Type/data/container.php
+++ b/tests/src/Type/data/container.php
@@ -12,7 +12,7 @@ function test(): void {
     $container = \Drupal::getContainer();
 
     assertType(MyService::class, $container->get('service_map.my_service'));
-    assertType('true', $container->has('service_map.my_service'));
+    assertType('bool', $container->has('service_map.my_service'));
     assertType('false', $container->has('unknown_service'));
     assertType(MyService::class, $container->get('service_map.concrete_service'));
     assertType(MyService::class, $container->get('service_map.concrete_service_with_a_parent_which_has_a_parent'));


### PR DESCRIPTION
## Summary

Fixes #668

- Adds `drupal.bleedingEdge.containerHasAlwaysTrue` parameter (default `true` in 2.0.x for backwards compat)
- When `false` (set in `bleedingEdge.neon`), `has()` returns `bool` for found services instead of `ConstantBooleanType(true)`, eliminating false-positive "always true" errors that could cause developers to remove legitimate conditional service guards
- Unknown services still return `ConstantBooleanType(false)` in both modes
- Will become the default behavior in 2.1.0 by flipping the default in `extension.neon`

## Test plan

- [ ] `DrupalContainerDynamicReturnTypeTest` — asserts `'bool'` for known services (bleedingEdge active)
- [ ] `DrupalContainerDynamicReturnTypeLegacyTest` — asserts `'true'` for known services (no bleedingEdge, 2.0.x compat)
- [ ] `php vendor/bin/phpunit --filter="DrupalContainerDynamicReturnType"`
- [ ] `php vendor/bin/phpstan analyze`
- [ ] `php vendor/bin/phpcs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)