### PR TITLE
Allow symfony/runtime plugin to be blocked in composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
             "composer/installers": true,
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "drupal/core-composer-scaffold": false
+            "drupal/core-composer-scaffold": false,
+            "symfony/runtime": false
         }
     }
 }


### PR DESCRIPTION
Drupal Core added symfony/runtime as a dependency, which is a Composer
plugin that must be explicitly listed in allow-plugins. Setting it to
false suppresses the blocking error without granting unnecessary plugin
execution in this dev-only context.

https://claude.ai/code/session_01VZBvQ1ks9YiyHK1HGMk8Mf