### PR TITLE
Fix InspectorTypeExtensionTest failure with PHPStan HEAD

### DIFF
--- a/tests/src/Type/data/bug-857.php
+++ b/tests/src/Type/data/bug-857.php
@@ -14,7 +14,7 @@ assertType('iterable', $array);
 
 // If the type is narrowed before '::assertAll()', it shouldn't change it.
 $array = mixed_function();
-assertType('mixed~null', $array);
+assertType('mixed', $array);
 \assert(Inspector::assertAllArrays($array));
 assertType('iterable<array>', $array);
 \assert(Inspector::assertAll(fn (array $i): bool => TRUE, $array));


### PR DESCRIPTION
PHPStan HEAD no longer infers mixed~null (introduced in 2.1.47) in this
scope after reassigning $array. Revert the fixture expectation to mixed.

The instanceof MixedType check in InspectorTypeExtension::specifyAssertAll()
remains correct as it handles both mixed and mixed~null inputs.

https://claude.ai/code/session_01HQDbrBSq6Hs6sZNLpZGq5z