### PR TITLE
Config::get return type extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,35 @@ What it currently enables:
 > [!NOTE]
 > `checkDeprecatedHooksInApiFiles` is deprecated. Use `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.
 
+#### Config schema-based checks (experimental)
+
+Two opt-in features use Drupal's config schema files to analyze `Config::get()` calls. Both only act on config objects whose schema has the `FullyValidatable` constraint, since only those schemas are guaranteed complete. Schema files are parsed lazily on first use, so there is no cost when the features are disabled.
+
+```neon
+parameters:
+    drupal:
+        # Narrows Config::get() return types from the config schema, e.g.
+        # \Drupal::config('system.cron')->get('logging') resolves to bool|null
+        # instead of mixed. Types are nullable because any key can be absent
+        # at runtime.
+        configGetReturnType: true
+        rules:
+            # Reports Config::get() calls with a key that does not exist in the
+            # config schema, catching typos at analysis time.
+            configGetUnknownKeyRule: true
+```
+
+Recognized call patterns:
+
+- `\Drupal::config('...')->get('...')`
+- `$configFactory->get('...')->get('...')`
+- `$configFactory->getEditable('...')->get('...')`
+- `$this->config('...')->get('...')` in classes using `ConfigFormBaseTrait`
+
+The config name and key must be literal strings. Config entity schemas with wildcard names (e.g. `block.block.*`) are not supported yet, and keys beneath dynamic type references (e.g. `mailer_dsn.options.[%parent.scheme]`) are not validated.
+
+Neither feature is included in `bleedingEdge.neon` yet.
+
 #### Detecting @todo comments referencing the current Drupal.org issue (contrib CI)
 
 `TodoCommentWithIssueUrlRule` is an opt-in rule for Drupal contrib CI pipelines. When running PHPStan as part of a GitLab merge request, it reports an error for any `@todo` comment that contains a drupal.org issue URL matching the current issue — for example:

--- a/extension.neon
+++ b/extension.neon
@@ -28,6 +28,7 @@ parameters:
 			entityQuery: true
 			entityRepository: true
 			stubFiles: true
+		configGetReturnType: false
 		rules:
 			testClassSuffixNameRule: false
 			dependencySerializationTraitPropertyRule: false
@@ -270,6 +271,7 @@ parametersSchema:
 			entityRepository: boolean()
 			stubFiles: boolean()
 		])
+		configGetReturnType: boolean()
 		rules: structure([
 			testClassSuffixNameRule: boolean()
 			dependencySerializationTraitPropertyRule: boolean()
@@ -336,6 +338,8 @@ services:
 	-
 		class: mglaman\PHPStanDrupal\Type\ConfigGetDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+		arguments:
+			configGetReturnType: %drupal.configGetReturnType%
 	-
 		class: mglaman\PHPStanDrupal\Type\DrupalClassResolverDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/extension.neon
+++ b/extension.neon
@@ -40,6 +40,7 @@ parameters:
 			entityStorageDirectInjectionRule: false
 			symfonyYamlParseRule: false
 			entityOperationsCacheabilityRule: false
+			configGetUnknownKeyRule: false
 		entityMapping:
 			aggregator_feed:
 				class: Drupal\aggregator\Entity\Feed
@@ -281,6 +282,7 @@ parametersSchema:
 			entityStorageDirectInjectionRule: boolean()
 			symfonyYamlParseRule: boolean()
 			entityOperationsCacheabilityRule: boolean()
+			configGetUnknownKeyRule: boolean()
 		])
 		entityMapping: arrayOf(anyOf(
 			structure([
@@ -297,6 +299,8 @@ services:
 		class: mglaman\PHPStanDrupal\Drupal\ServiceMap
 	-
 		class: mglaman\PHPStanDrupal\Drupal\ExtensionMap
+	-
+		class: mglaman\PHPStanDrupal\Drupal\ConfigSchemaData
 	-
 		class: mglaman\PHPStanDrupal\Drupal\EntityDataRepository
 		arguments:
@@ -329,6 +333,9 @@ services:
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 		arguments:
 			containerHasAlwaysTrue: %drupal.bleedingEdge.containerHasAlwaysTrue%
+	-
+		class: mglaman\PHPStanDrupal\Type\ConfigGetDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
 		class: mglaman\PHPStanDrupal\Type\DrupalClassResolverDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/rules.neon
+++ b/rules.neon
@@ -14,6 +14,8 @@ rules:
 	- mglaman\PHPStanDrupal\Rules\Drupal\TestClassesProtectedPropertyModulesRule
 
 conditionalTags:
+	mglaman\PHPStanDrupal\Rules\Drupal\ConfigGetUnknownKeyRule:
+		phpstan.rules.rule: %drupal.rules.configGetUnknownKeyRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\HookFormAlterRule:
 		phpstan.rules.rule: %drupal.rules.hookRules%
 	mglaman\PHPStanDrupal\Rules\Drupal\Tests\TestClassSuffixNameRule:
@@ -44,6 +46,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.entityOperationsCacheabilityRule%
 
 services:
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\ConfigGetUnknownKeyRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\HookFormAlterRule
 	-

--- a/src/Drupal/ConfigNameResolverTrait.php
+++ b/src/Drupal/ConfigNameResolverTrait.php
@@ -3,9 +3,11 @@
 namespace mglaman\PHPStanDrupal\Drupal;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBaseTrait;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Type\ObjectType;
@@ -42,12 +44,23 @@ trait ConfigNameResolverTrait
 
         // Pattern 1: \Drupal::config('name')
         if ($var instanceof StaticCall && $methodName === 'config') {
+            if (!$var->class instanceof Name || $scope->resolveName($var->class) !== 'Drupal') {
+                return null;
+            }
             return $this->extractFirstStringArg($var->getArgs());
         }
 
-        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
+        // Pattern 2: $this->config('name') from ConfigFormBaseTrait. The trait
+        // passes the name through unchanged; a same-named helper on another
+        // class may not (e.g. prefixing the config name), so require the trait.
         if ($var instanceof MethodCall && $methodName === 'config') {
-            return $this->extractFirstStringArg($var->getArgs());
+            $receiverType = $scope->getType($var->var);
+            foreach ($receiverType->getObjectClassReflections() as $classReflection) {
+                if ($classReflection->hasTraitUse(ConfigFormBaseTrait::class)) {
+                    return $this->extractFirstStringArg($var->getArgs());
+                }
+            }
+            return null;
         }
 
         // Pattern 3: $configFactory->get('name')

--- a/src/Drupal/ConfigNameResolverTrait.php
+++ b/src/Drupal/ConfigNameResolverTrait.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Drupal;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+use function count;
+
+/**
+ * Provides helpers to resolve a Drupal config name from a method call chain.
+ *
+ * Used by ConfigGetUnknownKeyRule and ConfigGetDynamicReturnTypeExtension to
+ * share the logic for extracting the config name from patterns such as:
+ *   - \Drupal::config('name')->get(...)
+ *   - $configFactory->get('name')->get(...)
+ *   - $configFactory->getEditable('name')->get(...)
+ *   - $this->config('name')->get(...)  (ConfigFormBaseTrait)
+ */
+trait ConfigNameResolverTrait
+{
+
+    private function resolveConfigName(MethodCall $methodCall, Scope $scope): ?string
+    {
+        $var = $methodCall->var;
+
+        if (!$var instanceof MethodCall && !$var instanceof StaticCall) {
+            return null;
+        }
+
+        $methodName = $var instanceof MethodCall
+            ? ($var->name instanceof Identifier ? $var->name->name : null)
+            : ($var->name instanceof Identifier ? $var->name->name : null);
+
+        if ($methodName === null) {
+            return null;
+        }
+
+        // Pattern 1: \Drupal::config('name')
+        if ($var instanceof StaticCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
+        if ($var instanceof MethodCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 3: $configFactory->get('name')
+        if ($var instanceof MethodCall && $methodName === 'get') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        // Pattern 4: $configFactory->getEditable('name')
+        if ($var instanceof MethodCall && $methodName === 'getEditable') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $args
+     */
+    private function extractFirstStringArg(array $args): ?string
+    {
+        if (count($args) === 0) {
+            return null;
+        }
+
+        $argValue = $args[0]->value;
+        if ($argValue instanceof String_) {
+            return $argValue->value;
+        }
+
+        return null;
+    }
+}

--- a/src/Drupal/ConfigSchemaData.php
+++ b/src/Drupal/ConfigSchemaData.php
@@ -100,8 +100,14 @@ class ConfigSchemaData
             // Recurse into the element definition.
             if (isset($definition['sequence']) && is_array($definition['sequence'])) {
                 $seq = $definition['sequence'];
-                $elementDef = isset($seq[0]) && is_array($seq[0]) ? $seq[0] : (!isset($seq[0]) ? $seq : null);
-                if ($elementDef !== null && is_array($elementDef)) {
+                /** @var array<mixed>|null $elementDef */
+                $elementDef = null;
+                if (isset($seq[0]) && is_array($seq[0])) {
+                    $elementDef = $seq[0];
+                } elseif (!isset($seq[0])) {
+                    $elementDef = $seq;
+                }
+                if ($elementDef !== null) {
                     return $this->keyExistsInDefinition($elementDef, $parts);
                 }
             }
@@ -217,8 +223,14 @@ class ConfigSchemaData
             }
             if (isset($definition['sequence']) && is_array($definition['sequence'])) {
                 $seq = $definition['sequence'];
-                $elementDef = isset($seq[0]) && is_array($seq[0]) ? $seq[0] : (!isset($seq[0]) ? $seq : null);
-                if ($elementDef !== null && is_array($elementDef)) {
+                /** @var array<mixed>|null $elementDef */
+                $elementDef = null;
+                if (isset($seq[0]) && is_array($seq[0])) {
+                    $elementDef = $seq[0];
+                } elseif (!isset($seq[0])) {
+                    $elementDef = $seq;
+                }
+                if ($elementDef !== null) {
                     return $this->resolveKeyType($elementDef, $parts);
                 }
             }

--- a/src/Drupal/ConfigSchemaData.php
+++ b/src/Drupal/ConfigSchemaData.php
@@ -1,0 +1,287 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Drupal;
+
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use function array_key_exists;
+use function array_shift;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_string;
+
+class ConfigSchemaData
+{
+    /**
+     * Raw schema definitions keyed by schema type name.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private static $definitions = [];
+
+    /**
+     * Config names that have FullyValidatable constraint.
+     *
+     * @var array<string, bool>
+     */
+    private static $fullyValidatable = [];
+
+    /**
+     * @param array<string, array<string, mixed>> $definitions
+     * @param array<string, bool> $fullyValidatable
+     */
+    public function setSchema(array $definitions, array $fullyValidatable): void
+    {
+        self::$definitions = $definitions;
+        self::$fullyValidatable = $fullyValidatable;
+    }
+
+    public function isFullyValidatable(string $configName): bool
+    {
+        return self::$fullyValidatable[$configName] ?? false;
+    }
+
+    /**
+     * Returns true if the given key path exists in the schema for a FullyValidatable config.
+     */
+    public function keyExistsInSchema(string $configName, string $key): bool
+    {
+        if (!$this->isFullyValidatable($configName)) {
+            // Can't validate keys for non-FullyValidatable configs.
+            return true;
+        }
+
+        $definition = self::$definitions[$configName] ?? null;
+        if ($definition === null) {
+            return true;
+        }
+
+        $definition = $this->resolveDefinition($definition);
+        $parts = explode('.', $key);
+        return $this->keyExistsInDefinition($definition, $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @param string[] $parts
+     */
+    private function keyExistsInDefinition(array $definition, array $parts): bool
+    {
+        $definition = $this->resolveDefinition($definition);
+
+        if ($parts === []) {
+            return true;
+        }
+
+        if (!isset($definition['mapping']) || !is_array($definition['mapping'])) {
+            return false;
+        }
+
+        $currentKey = array_shift($parts);
+        if (!array_key_exists($currentKey, $definition['mapping'])) {
+            return false;
+        }
+
+        $childDef = $definition['mapping'][$currentKey];
+        if (!is_array($childDef)) {
+            return false;
+        }
+
+        return $this->keyExistsInDefinition($childDef, $parts);
+    }
+
+    public function getTypeForKey(string $configName, string $key): ?Type
+    {
+        if (!$this->isFullyValidatable($configName)) {
+            return null;
+        }
+
+        $definition = self::$definitions[$configName] ?? null;
+        if ($definition === null) {
+            return null;
+        }
+
+        // Resolve the base type if this definition uses `type:`.
+        $definition = $this->resolveDefinition($definition);
+
+        // Traverse dotted key path through nested mappings.
+        $parts = explode('.', $key);
+        $type = $this->resolveKeyType($definition, $parts);
+        if ($type === null) {
+            return null;
+        }
+
+        // Config::get() can always return null when a key is absent.
+        return new UnionType([$type, new NullType()]);
+    }
+
+    /**
+     * Resolve a definition that uses `type:` to reference another definition.
+     *
+     * @param array<string, mixed> $definition
+     * @return array<string, mixed>
+     */
+    private function resolveDefinition(array $definition, int $depth = 0): array
+    {
+        if ($depth > 10) {
+            return $definition;
+        }
+
+        if (isset($definition['type']) && is_string($definition['type'])) {
+            $typeName = $definition['type'];
+            $parent = self::$definitions[$typeName] ?? null;
+            if ($parent !== null) {
+                $resolved = $this->resolveDefinition($parent, $depth + 1);
+                // Merge: child overrides parent.
+                $definition = $this->mergeDefinitions($resolved, $definition);
+            }
+        }
+
+        return $definition;
+    }
+
+    /**
+     * @param array<string, mixed> $parent
+     * @param array<string, mixed> $child
+     * @return array<string, mixed>
+     */
+    private function mergeDefinitions(array $parent, array $child): array
+    {
+        $result = $parent;
+        foreach ($child as $key => $value) {
+            if ($key === 'mapping' && is_array($value) && isset($result['mapping']) && is_array($result['mapping'])) {
+                $result['mapping'] = array_merge($result['mapping'], $value);
+            } else {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @param string[] $parts
+     */
+    private function resolveKeyType(array $definition, array $parts): ?Type
+    {
+        $definition = $this->resolveDefinition($definition);
+
+        if ($parts === []) {
+            return $this->mapSchemaTypeToPhpStanType($definition);
+        }
+
+        // Must be a mapping to traverse further.
+        if (!isset($definition['mapping']) || !is_array($definition['mapping'])) {
+            return null;
+        }
+
+        $currentKey = array_shift($parts);
+        if (!array_key_exists($currentKey, $definition['mapping'])) {
+            return null;
+        }
+
+        $childDef = $definition['mapping'][$currentKey];
+        if (!is_array($childDef)) {
+            return null;
+        }
+
+        return $this->resolveKeyType($childDef, $parts);
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function mapSchemaTypeToPhpStanType(array $definition): ?Type
+    {
+        $typeName = $definition['type'] ?? null;
+        if ($typeName === null) {
+            // If it has 'mapping', it's a mapping type.
+            if (isset($definition['mapping'])) {
+                return new ArrayType(new StringType(), new MixedType());
+            }
+            return null;
+        }
+
+        return $this->scalarTypeFromName($typeName, $definition);
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function scalarTypeFromName(string $typeName, array $definition = []): ?Type
+    {
+        // Direct scalar types.
+        if (in_array($typeName, ['string', 'label', 'path', 'uri', 'email', 'color_hex', 'text', 'date_format', 'machine_name', 'langcode', 'uuid', 'required_label', 'plural_label', 'bytes'], true)) {
+            return new StringType();
+        }
+        if (in_array($typeName, ['integer', 'weight', 'timestamp'], true)) {
+            return new IntegerType();
+        }
+        if ($typeName === 'float') {
+            return new FloatType();
+        }
+        if ($typeName === 'boolean') {
+            return new BooleanType();
+        }
+        if ($typeName === 'sequence') {
+            // Try to resolve the element type from the sequence definition.
+            $elementType = $this->resolveSequenceElementType($definition);
+            return new ArrayType(new MixedType(), $elementType);
+        }
+        if ($typeName === 'mapping') {
+            return new ArrayType(new StringType(), new MixedType());
+        }
+
+        // Try to resolve via type references.
+        $referenced = self::$definitions[$typeName] ?? null;
+        if ($referenced !== null) {
+            $resolved = $this->resolveDefinition($referenced);
+            return $this->mapSchemaTypeToPhpStanType($resolved);
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolve the element type of a sequence definition.
+     *
+     * @param array<string, mixed> $definition
+     */
+    private function resolveSequenceElementType(array $definition): Type
+    {
+        // Drupal sequence schemas define the element type under a `sequence:` key.
+        // It can be either a single definition (list) or keyed array.
+        if (!isset($definition['sequence']) || !is_array($definition['sequence'])) {
+            return new MixedType();
+        }
+
+        $sequence = $definition['sequence'];
+
+        // Sequence can be a list (numeric keys) or a single associative definition.
+        // When it's a list, take the first item's type.
+        if (isset($sequence[0]) && is_array($sequence[0])) {
+            $elementDef = $sequence[0];
+        } elseif (!isset($sequence[0])) {
+            // Single associative definition.
+            $elementDef = $sequence;
+        } else {
+            return new MixedType();
+        }
+
+        $elementTypeName = $elementDef['type'] ?? null;
+        if (!is_string($elementTypeName)) {
+            return new MixedType();
+        }
+
+        $resolved = $this->scalarTypeFromName($elementTypeName, $elementDef);
+        return $resolved ?? new MixedType();
+    }
+}

--- a/src/Drupal/ConfigSchemaData.php
+++ b/src/Drupal/ConfigSchemaData.php
@@ -23,16 +23,21 @@ class ConfigSchemaData
     /**
      * Raw schema definitions keyed by schema type name.
      *
+     * Static so that schema data loaded by the bootstrap survives across
+     * PHPStan container re-instantiations in the test infrastructure.
+     *
      * @var array<string, array<string, mixed>>
      */
-    private static $definitions = [];
+    private static array $definitions = [];
 
     /**
      * Config names that have FullyValidatable constraint.
      *
+     * Static for the same reason as $definitions.
+     *
      * @var array<string, bool>
      */
-    private static $fullyValidatable = [];
+    private static array $fullyValidatable = [];
 
     /**
      * @param array<string, array<string, mixed>> $definitions
@@ -78,6 +83,29 @@ class ConfigSchemaData
         $definition = $this->resolveDefinition($definition);
 
         if ($parts === []) {
+            return true;
+        }
+
+        // If the definition is a sequence, the next path segment is a dynamic
+        // element key (e.g. 'default' in 'interface.default'). We cannot
+        // statically validate element keys, so consume the segment and recurse
+        // into the element definition with the remaining parts.
+        $typeName = $definition['type'] ?? null;
+        if ($typeName === 'sequence' || (isset($definition['sequence']) && !isset($definition['mapping']))) {
+            // Discard the dynamic element key.
+            array_shift($parts);
+            if ($parts === []) {
+                return true;
+            }
+            // Recurse into the element definition.
+            if (isset($definition['sequence']) && is_array($definition['sequence'])) {
+                $seq = $definition['sequence'];
+                $elementDef = isset($seq[0]) && is_array($seq[0]) ? $seq[0] : (!isset($seq[0]) ? $seq : null);
+                if ($elementDef !== null && is_array($elementDef)) {
+                    return $this->keyExistsInDefinition($elementDef, $parts);
+                }
+            }
+            // Fall back: accept any further path under a sequence.
             return true;
         }
 
@@ -176,6 +204,25 @@ class ConfigSchemaData
 
         if ($parts === []) {
             return $this->mapSchemaTypeToPhpStanType($definition);
+        }
+
+        // If the definition is a sequence, the next path segment is a dynamic
+        // element key. Discard it and recurse into the element definition.
+        $typeName = $definition['type'] ?? null;
+        if ($typeName === 'sequence' || (isset($definition['sequence']) && !isset($definition['mapping']))) {
+            array_shift($parts);
+            if ($parts === []) {
+                // The key resolves to the element type (caller adds null).
+                return $this->resolveSequenceElementType($definition);
+            }
+            if (isset($definition['sequence']) && is_array($definition['sequence'])) {
+                $seq = $definition['sequence'];
+                $elementDef = isset($seq[0]) && is_array($seq[0]) ? $seq[0] : (!isset($seq[0]) ? $seq : null);
+                if ($elementDef !== null && is_array($elementDef)) {
+                    return $this->resolveKeyType($elementDef, $parts);
+                }
+            }
+            return null;
         }
 
         // Must be a mapping to traverse further.

--- a/src/Drupal/ConfigSchemaData.php
+++ b/src/Drupal/ConfigSchemaData.php
@@ -10,21 +10,40 @@ use PHPStan\Type\MixedType;
 use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
 use function array_key_exists;
 use function array_shift;
 use function explode;
+use function glob;
 use function in_array;
 use function is_array;
 use function is_string;
+use function str_contains;
 
 class ConfigSchemaData
 {
     /**
+     * Schema directories collected by the bootstrap.
+     *
+     * Static because PHPStan executes the bootstrap file once per process,
+     * while the test infrastructure creates multiple containers — each with
+     * its own ConfigSchemaData instance — after the bootstrap has run.
+     *
+     * @var list<string>
+     */
+    private static array $schemaDirectories = [];
+
+    /**
+     * Whether the schema files have been parsed.
+     */
+    private static bool $loaded = false;
+
+    /**
      * Raw schema definitions keyed by schema type name.
      *
-     * Static so that schema data loaded by the bootstrap survives across
-     * PHPStan container re-instantiations in the test infrastructure.
+     * Static for the same reason as $schemaDirectories.
      *
      * @var array<string, array<string, mixed>>
      */
@@ -33,24 +52,99 @@ class ConfigSchemaData
     /**
      * Config names that have FullyValidatable constraint.
      *
-     * Static for the same reason as $definitions.
+     * Static for the same reason as $schemaDirectories.
      *
      * @var array<string, bool>
      */
     private static array $fullyValidatable = [];
 
     /**
-     * @param array<string, array<string, mixed>> $definitions
-     * @param array<string, bool> $fullyValidatable
+     * @param list<string> $schemaDirectories
      */
-    public function setSchema(array $definitions, array $fullyValidatable): void
+    public function setSchemaDirectories(array $schemaDirectories): void
     {
-        self::$definitions = $definitions;
-        self::$fullyValidatable = $fullyValidatable;
+        if ($schemaDirectories !== self::$schemaDirectories) {
+            self::$schemaDirectories = $schemaDirectories;
+            self::$loaded = false;
+        }
+    }
+
+    /**
+     * Parses the schema files on first query.
+     *
+     * Parsing every schema file of every extension is too expensive to do
+     * eagerly in the bootstrap: neither configGetReturnType nor
+     * configGetUnknownKeyRule may be enabled, and those consumers gate their
+     * own queries, so unused schema data would only waste memory.
+     */
+    private function ensureLoaded(): void
+    {
+        if (self::$loaded) {
+            return;
+        }
+        self::$loaded = true;
+        self::$definitions = [];
+        self::$fullyValidatable = [];
+
+        foreach (self::$schemaDirectories as $dir) {
+            $files = glob($dir . '/*.schema.yml');
+            if ($files === false) {
+                continue;
+            }
+            foreach ($files as $file) {
+                try {
+                    $yaml = Yaml::parseFile($file);
+                } catch (Throwable $e) {
+                    continue;
+                }
+                if (!is_array($yaml)) {
+                    continue;
+                }
+                foreach ($yaml as $typeName => $definition) {
+                    if (!is_array($definition)) {
+                        continue;
+                    }
+                    self::$definitions[(string) $typeName] = $definition;
+                }
+            }
+        }
+
+        foreach (self::$definitions as $typeName => $definition) {
+            if ($this->hasFullyValidatableConstraint($definition)) {
+                self::$fullyValidatable[$typeName] = true;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     */
+    private function hasFullyValidatableConstraint(array $definition, int $depth = 0): bool
+    {
+        if ($depth > 10) {
+            return false;
+        }
+
+        if (isset($definition['constraints']) && is_array($definition['constraints'])
+            && array_key_exists('FullyValidatable', $definition['constraints'])
+        ) {
+            return true;
+        }
+
+        // Check the parent type.
+        if (isset($definition['type']) && is_string($definition['type'])) {
+            $parent = self::$definitions[$definition['type']] ?? null;
+            if ($parent !== null) {
+                return $this->hasFullyValidatableConstraint($parent, $depth + 1);
+            }
+        }
+
+        return false;
     }
 
     public function isFullyValidatable(string $configName): bool
     {
+        $this->ensureLoaded();
         return self::$fullyValidatable[$configName] ?? false;
     }
 
@@ -83,6 +177,12 @@ class ConfigSchemaData
         $definition = $this->resolveDefinition($definition);
 
         if ($parts === []) {
+            return true;
+        }
+
+        // A dynamic type reference (e.g. `mailer_dsn.options.[%parent.scheme]`)
+        // cannot be statically resolved, so any key beneath it is unverifiable.
+        if ($this->hasDynamicTypeReference($definition)) {
             return true;
         }
 
@@ -154,7 +254,18 @@ class ConfigSchemaData
         }
 
         // Config::get() can always return null when a key is absent.
-        return new UnionType([$type, new NullType()]);
+        return TypeCombinator::union($type, new NullType());
+    }
+
+    /**
+     * Whether the definition's type is a dynamic reference like `foo.[%key]`.
+     *
+     * @param array<string, mixed> $definition
+     */
+    private function hasDynamicTypeReference(array $definition): bool
+    {
+        $typeName = $definition['type'] ?? null;
+        return is_string($typeName) && str_contains($typeName, '[');
     }
 
     /**
@@ -210,6 +321,11 @@ class ConfigSchemaData
 
         if ($parts === []) {
             return $this->mapSchemaTypeToPhpStanType($definition);
+        }
+
+        // Keys beneath a dynamic type reference cannot be resolved statically.
+        if ($this->hasDynamicTypeReference($definition)) {
+            return null;
         }
 
         // If the definition is a sequence, the next path segment is a dynamic

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -23,6 +23,7 @@ use function array_walk;
 use function class_exists;
 use function dirname;
 use function file_exists;
+use function glob;
 use function in_array;
 use function interface_exists;
 use function is_array;
@@ -254,6 +255,8 @@ class DrupalAutoloader
             }
         }
 
+        $this->loadConfigSchemas($container);
+
         $service_map = $container->getByType(ServiceMap::class);
         $service_map->setDrupalServices($this->serviceMap);
 
@@ -264,6 +267,93 @@ class DrupalAutoloader
 
         $extension_map = $container->getByType(ExtensionMap::class);
         $extension_map->setExtensions($this->moduleData, $this->themeData, $profiles);
+    }
+
+    protected function loadConfigSchemas(Container $container): void
+    {
+        $definitions = [];
+        $fullyValidatable = [];
+
+        // Collect schema directories.
+        $schemaDirs = [];
+        $coreSchemaDir = $this->drupalRoot . '/core/config/schema';
+        if (is_dir($coreSchemaDir)) {
+            $schemaDirs[] = $coreSchemaDir;
+        }
+        foreach ($this->moduleData as $extension) {
+            $schemaDir = $this->drupalRoot . '/' . $extension->getPath() . '/config/schema';
+            if (is_dir($schemaDir)) {
+                $schemaDirs[] = $schemaDir;
+            }
+        }
+        foreach ($this->themeData as $extension) {
+            $schemaDir = $this->drupalRoot . '/' . $extension->getPath() . '/config/schema';
+            if (is_dir($schemaDir)) {
+                $schemaDirs[] = $schemaDir;
+            }
+        }
+
+        // Parse all schema files.
+        foreach ($schemaDirs as $dir) {
+            $files = glob($dir . '/*.schema.yml');
+            if ($files === false) {
+                continue;
+            }
+            foreach ($files as $file) {
+                try {
+                    $yaml = Yaml::parseFile($file);
+                } catch (Throwable $e) {
+                    continue;
+                }
+                if (!is_array($yaml)) {
+                    continue;
+                }
+                foreach ($yaml as $typeName => $definition) {
+                    if (!is_array($definition)) {
+                        continue;
+                    }
+                    $definitions[(string) $typeName] = $definition;
+                }
+            }
+        }
+
+        // Detect FullyValidatable configs.
+        foreach ($definitions as $typeName => $definition) {
+            if ($this->hasFullyValidatableConstraint($definition, $definitions)) {
+                $fullyValidatable[$typeName] = true;
+            }
+        }
+
+        $configSchemaData = $container->getByType(ConfigSchemaData::class);
+        $configSchemaData->setSchema($definitions, $fullyValidatable);
+    }
+
+    /**
+     * @param array<string, mixed> $definition
+     * @param array<string, array<string, mixed>> $allDefinitions
+     */
+    private function hasFullyValidatableConstraint(array $definition, array $allDefinitions, int $depth = 0): bool
+    {
+        if ($depth > 10) {
+            return false;
+        }
+
+        // Check direct constraints.
+        if (isset($definition['constraints']) && is_array($definition['constraints'])) {
+            if (array_key_exists('FullyValidatable', $definition['constraints'])) {
+                return true;
+            }
+        }
+
+        // Check parent type.
+        if (isset($definition['type']) && is_string($definition['type'])) {
+            $parent = $allDefinitions[$definition['type']] ?? null;
+            if ($parent !== null) {
+                return $this->hasFullyValidatableConstraint($parent, $allDefinitions, $depth + 1);
+            }
+        }
+
+        return false;
     }
 
     protected function loadLegacyIncludes(): void

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -23,7 +23,6 @@ use function array_walk;
 use function class_exists;
 use function dirname;
 use function file_exists;
-use function glob;
 use function in_array;
 use function interface_exists;
 use function is_array;
@@ -271,11 +270,11 @@ class DrupalAutoloader
 
     protected function loadConfigSchemas(Container $container): void
     {
-        // TODO: lazy-load schemas when neither configGetReturnType nor configGetUnknownKeyRule is active.
-        $definitions = [];
-        $fullyValidatable = [];
-
-        // Collect schema directories.
+        // Only collect the schema directories here. Parsing every schema file
+        // has a real memory cost, and this bootstrap runs regardless of
+        // whether a schema-consuming feature (configGetReturnType or
+        // configGetUnknownKeyRule) is enabled, so ConfigSchemaData parses the
+        // files lazily on first query.
         $schemaDirs = [];
         $coreSchemaDir = $this->drupalRoot . '/core/config/schema';
         if (is_dir($coreSchemaDir)) {
@@ -294,67 +293,8 @@ class DrupalAutoloader
             }
         }
 
-        // Parse all schema files.
-        foreach ($schemaDirs as $dir) {
-            $files = glob($dir . '/*.schema.yml');
-            if ($files === false) {
-                continue;
-            }
-            foreach ($files as $file) {
-                try {
-                    $yaml = Yaml::parseFile($file);
-                } catch (Throwable $e) {
-                    continue;
-                }
-                if (!is_array($yaml)) {
-                    continue;
-                }
-                foreach ($yaml as $typeName => $definition) {
-                    if (!is_array($definition)) {
-                        continue;
-                    }
-                    $definitions[(string) $typeName] = $definition;
-                }
-            }
-        }
-
-        // Detect FullyValidatable configs.
-        foreach ($definitions as $typeName => $definition) {
-            if ($this->hasFullyValidatableConstraint($definition, $definitions)) {
-                $fullyValidatable[$typeName] = true;
-            }
-        }
-
         $configSchemaData = $container->getByType(ConfigSchemaData::class);
-        $configSchemaData->setSchema($definitions, $fullyValidatable);
-    }
-
-    /**
-     * @param array<string, mixed> $definition
-     * @param array<string, array<string, mixed>> $allDefinitions
-     */
-    private function hasFullyValidatableConstraint(array $definition, array $allDefinitions, int $depth = 0): bool
-    {
-        if ($depth > 10) {
-            return false;
-        }
-
-        // Check direct constraints.
-        if (isset($definition['constraints']) && is_array($definition['constraints'])) {
-            if (array_key_exists('FullyValidatable', $definition['constraints'])) {
-                return true;
-            }
-        }
-
-        // Check parent type.
-        if (isset($definition['type']) && is_string($definition['type'])) {
-            $parent = $allDefinitions[$definition['type']] ?? null;
-            if ($parent !== null) {
-                return $this->hasFullyValidatableConstraint($parent, $allDefinitions, $depth + 1);
-            }
-        }
-
-        return false;
+        $configSchemaData->setSchemaDirectories($schemaDirs);
     }
 
     protected function loadLegacyIncludes(): void

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -271,6 +271,7 @@ class DrupalAutoloader
 
     protected function loadConfigSchemas(Container $container): void
     {
+        // TODO: lazy-load schemas when neither configGetReturnType nor configGetUnknownKeyRule is active.
         $definitions = [];
         $fullyValidatable = [];
 

--- a/src/Rules/Drupal/ConfigGetUnknownKeyRule.php
+++ b/src/Rules/Drupal/ConfigGetUnknownKeyRule.php
@@ -3,13 +3,10 @@
 namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
 use Drupal\Core\Config\Config;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use mglaman\PHPStanDrupal\Drupal\ConfigNameResolverTrait;
 use mglaman\PHPStanDrupal\Drupal\ConfigSchemaData;
 use PhpParser\Node;
-use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -27,6 +24,7 @@ use function sprintf;
  */
 final class ConfigGetUnknownKeyRule implements Rule
 {
+    use ConfigNameResolverTrait;
 
     public function __construct(
         private ConfigSchemaData $configSchemaData,
@@ -83,71 +81,5 @@ final class ConfigGetUnknownKeyRule implements Rule
         }
 
         return $errors;
-    }
-
-    private function resolveConfigName(MethodCall $methodCall, Scope $scope): ?string
-    {
-        $var = $methodCall->var;
-
-        if (!$var instanceof MethodCall && !$var instanceof StaticCall) {
-            return null;
-        }
-
-        $methodName = $var instanceof MethodCall
-            ? ($var->name instanceof Identifier ? $var->name->name : null)
-            : ($var->name instanceof Identifier ? $var->name->name : null);
-
-        if ($methodName === null) {
-            return null;
-        }
-
-        // Pattern 1: \Drupal::config('name')
-        if ($var instanceof StaticCall && $methodName === 'config') {
-            return $this->extractFirstStringArg($var->getArgs());
-        }
-
-        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
-        if ($var instanceof MethodCall && $methodName === 'config') {
-            return $this->extractFirstStringArg($var->getArgs());
-        }
-
-        // Pattern 3: $configFactory->get('name')
-        if ($var instanceof MethodCall && $methodName === 'get') {
-            $receiverType = $scope->getType($var->var);
-            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
-            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
-                return $this->extractFirstStringArg($var->getArgs());
-            }
-            return null;
-        }
-
-        // Pattern 4: $configFactory->getEditable('name')
-        if ($var instanceof MethodCall && $methodName === 'getEditable') {
-            $receiverType = $scope->getType($var->var);
-            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
-            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
-                return $this->extractFirstStringArg($var->getArgs());
-            }
-            return null;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param \PhpParser\Node\Arg[] $args
-     */
-    private function extractFirstStringArg(array $args): ?string
-    {
-        if (count($args) === 0) {
-            return null;
-        }
-
-        $argValue = $args[0]->value;
-        if ($argValue instanceof String_) {
-            return $argValue->value;
-        }
-
-        return null;
     }
 }

--- a/src/Rules/Drupal/ConfigGetUnknownKeyRule.php
+++ b/src/Rules/Drupal/ConfigGetUnknownKeyRule.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use mglaman\PHPStanDrupal\Drupal\ConfigSchemaData;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use function count;
+use function sprintf;
+
+/**
+ * Reports calls to Config::get() with a key that does not exist in the schema.
+ *
+ * Only fires for FullyValidatable config objects where the schema is complete,
+ * guaranteeing that any key not listed is a genuine error.
+ *
+ * @implements Rule<Node\Expr\MethodCall>
+ */
+final class ConfigGetUnknownKeyRule implements Rule
+{
+
+    public function __construct(
+        private ConfigSchemaData $configSchemaData,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier || $node->name->name !== 'get') {
+            return [];
+        }
+
+        // Verify the receiver is Config or a subclass (e.g. ImmutableConfig).
+        $receiverType = $scope->getType($node->var);
+        $configType = new ObjectType(Config::class);
+        if (!$configType->isSuperTypeOf($receiverType)->yes()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) !== 1) {
+            return [];
+        }
+
+        $configName = $this->resolveConfigName($node, $scope);
+        if ($configName === null) {
+            return [];
+        }
+
+        if (!$this->configSchemaData->isFullyValidatable($configName)) {
+            return [];
+        }
+
+        $keyType = $scope->getType($args[0]->value);
+        $errors = [];
+        foreach ($keyType->getConstantStrings() as $constantString) {
+            $key = $constantString->getValue();
+            if (!$this->configSchemaData->keyExistsInSchema($configName, $key)) {
+                $errors[] = RuleErrorBuilder::message(
+                    sprintf(
+                        'Config key "%s" does not exist in the schema for "%s".',
+                        $key,
+                        $configName
+                    )
+                )
+                    ->identifier('drupal.configGetUnknownKey')
+                    ->build();
+            }
+        }
+
+        return $errors;
+    }
+
+    private function resolveConfigName(MethodCall $methodCall, Scope $scope): ?string
+    {
+        $var = $methodCall->var;
+
+        if (!$var instanceof MethodCall && !$var instanceof StaticCall) {
+            return null;
+        }
+
+        $methodName = $var instanceof MethodCall
+            ? ($var->name instanceof Identifier ? $var->name->name : null)
+            : ($var->name instanceof Identifier ? $var->name->name : null);
+
+        if ($methodName === null) {
+            return null;
+        }
+
+        // Pattern 1: \Drupal::config('name')
+        if ($var instanceof StaticCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
+        if ($var instanceof MethodCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 3: $configFactory->get('name')
+        if ($var instanceof MethodCall && $methodName === 'get') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        // Pattern 4: $configFactory->getEditable('name')
+        if ($var instanceof MethodCall && $methodName === 'getEditable') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $args
+     */
+    private function extractFirstStringArg(array $args): ?string
+    {
+        if (count($args) === 0) {
+            return null;
+        }
+
+        $argValue = $args[0]->value;
+        if ($argValue instanceof String_) {
+            return $argValue->value;
+        }
+
+        return null;
+    }
+}

--- a/src/Type/ConfigGetDynamicReturnTypeExtension.php
+++ b/src/Type/ConfigGetDynamicReturnTypeExtension.php
@@ -10,7 +10,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
 use function count;
 
 class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -62,19 +62,14 @@ class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
         foreach ($constantStrings as $constantString) {
             $key = $constantString->getValue();
             $type = $this->configSchemaData->getTypeForKey($configName, $key);
-            if ($type !== null) {
-                $types[] = $type;
+            if ($type === null) {
+                // One unresolvable key poisons the union: narrowing to only
+                // the resolved branches would drop the mixed branch.
+                return null;
             }
+            $types[] = $type;
         }
 
-        if (count($types) === 0) {
-            return null;
-        }
-
-        if (count($types) === 1) {
-            return $types[0];
-        }
-
-        return new UnionType($types);
+        return TypeCombinator::union(...$types);
     }
 }

--- a/src/Type/ConfigGetDynamicReturnTypeExtension.php
+++ b/src/Type/ConfigGetDynamicReturnTypeExtension.php
@@ -3,25 +3,23 @@
 namespace mglaman\PHPStanDrupal\Type;
 
 use Drupal\Core\Config\Config;
-use Drupal\Core\Config\ConfigFactoryInterface;
+use mglaman\PHPStanDrupal\Drupal\ConfigNameResolverTrait;
 use mglaman\PHPStanDrupal\Drupal\ConfigSchemaData;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use PHPStan\Type\UnionType;
 use function count;
 
 class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+    use ConfigNameResolverTrait;
 
     public function __construct(
         private ConfigSchemaData $configSchemaData,
+        private bool $configGetReturnType = false,
     ) {
     }
 
@@ -40,6 +38,10 @@ class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
         MethodCall $methodCall,
         Scope $scope
     ): ?Type {
+        if (!$this->configGetReturnType) {
+            return null;
+        }
+
         $args = $methodCall->getArgs();
         if (count($args) !== 1) {
             return null;
@@ -74,73 +76,5 @@ class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
         }
 
         return new UnionType($types);
-    }
-
-    private function resolveConfigName(MethodCall $methodCall, Scope $scope): ?string
-    {
-        $var = $methodCall->var;
-
-        // The var should be a method call that returns Config/ImmutableConfig.
-        // We need to find what config name was passed.
-        if (!$var instanceof MethodCall && !$var instanceof StaticCall) {
-            return null;
-        }
-
-        $methodName = $var instanceof MethodCall
-            ? ($var->name instanceof Identifier ? $var->name->name : null)
-            : ($var->name instanceof Identifier ? $var->name->name : null);
-
-        if ($methodName === null) {
-            return null;
-        }
-
-        // Pattern 1: \Drupal::config('name')
-        if ($var instanceof StaticCall && $methodName === 'config') {
-            return $this->extractFirstStringArg($var->getArgs());
-        }
-
-        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
-        if ($var instanceof MethodCall && $methodName === 'config') {
-            return $this->extractFirstStringArg($var->getArgs());
-        }
-
-        // Pattern 3: $configFactory->get('name') — verify the receiver is ConfigFactoryInterface
-        if ($var instanceof MethodCall && $methodName === 'get') {
-            $receiverType = $scope->getType($var->var);
-            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
-            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
-                return $this->extractFirstStringArg($var->getArgs());
-            }
-            return null;
-        }
-
-        // Pattern 4: $configFactory->getEditable('name') returns Config (mutable)
-        if ($var instanceof MethodCall && $methodName === 'getEditable') {
-            $receiverType = $scope->getType($var->var);
-            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
-            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
-                return $this->extractFirstStringArg($var->getArgs());
-            }
-            return null;
-        }
-
-        return null;
-    }
-
-    /**
-     * @param \PhpParser\Node\Arg[] $args
-     */
-    private function extractFirstStringArg(array $args): ?string
-    {
-        if (count($args) === 0) {
-            return null;
-        }
-
-        $argValue = $args[0]->value;
-        if ($argValue instanceof String_) {
-            return $argValue->value;
-        }
-
-        return null;
     }
 }

--- a/src/Type/ConfigGetDynamicReturnTypeExtension.php
+++ b/src/Type/ConfigGetDynamicReturnTypeExtension.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Type;
+
+use Drupal\Core\Config\Config;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use mglaman\PHPStanDrupal\Drupal\ConfigSchemaData;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use function count;
+
+class ConfigGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+    public function __construct(
+        private ConfigSchemaData $configSchemaData,
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return Config::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $args = $methodCall->getArgs();
+        if (count($args) !== 1) {
+            return null;
+        }
+
+        $configName = $this->resolveConfigName($methodCall, $scope);
+        if ($configName === null) {
+            return null;
+        }
+
+        $keyType = $scope->getType($args[0]->value);
+        $constantStrings = $keyType->getConstantStrings();
+        if (count($constantStrings) === 0) {
+            return null;
+        }
+
+        $types = [];
+        foreach ($constantStrings as $constantString) {
+            $key = $constantString->getValue();
+            $type = $this->configSchemaData->getTypeForKey($configName, $key);
+            if ($type !== null) {
+                $types[] = $type;
+            }
+        }
+
+        if (count($types) === 0) {
+            return null;
+        }
+
+        if (count($types) === 1) {
+            return $types[0];
+        }
+
+        return new UnionType($types);
+    }
+
+    private function resolveConfigName(MethodCall $methodCall, Scope $scope): ?string
+    {
+        $var = $methodCall->var;
+
+        // The var should be a method call that returns Config/ImmutableConfig.
+        // We need to find what config name was passed.
+        if (!$var instanceof MethodCall && !$var instanceof StaticCall) {
+            return null;
+        }
+
+        $methodName = $var instanceof MethodCall
+            ? ($var->name instanceof Identifier ? $var->name->name : null)
+            : ($var->name instanceof Identifier ? $var->name->name : null);
+
+        if ($methodName === null) {
+            return null;
+        }
+
+        // Pattern 1: \Drupal::config('name')
+        if ($var instanceof StaticCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 2: $this->config('name') from ConfigFormBaseTrait
+        if ($var instanceof MethodCall && $methodName === 'config') {
+            return $this->extractFirstStringArg($var->getArgs());
+        }
+
+        // Pattern 3: $configFactory->get('name') — verify the receiver is ConfigFactoryInterface
+        if ($var instanceof MethodCall && $methodName === 'get') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        // Pattern 4: $configFactory->getEditable('name') returns Config (mutable)
+        if ($var instanceof MethodCall && $methodName === 'getEditable') {
+            $receiverType = $scope->getType($var->var);
+            $configFactoryType = new ObjectType(ConfigFactoryInterface::class);
+            if ($configFactoryType->isSuperTypeOf($receiverType)->yes()) {
+                return $this->extractFirstStringArg($var->getArgs());
+            }
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param \PhpParser\Node\Arg[] $args
+     */
+    private function extractFirstStringArg(array $args): ?string
+    {
+        if (count($args) === 0) {
+            return null;
+        }
+
+        $argValue = $args[0]->value;
+        if ($argValue instanceof String_) {
+            return $argValue->value;
+        }
+
+        return null;
+    }
+}

--- a/tests/fixtures/config/phpunit-drupal-phpstan-config-get-return-type.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan-config-get-return-type.neon
@@ -1,0 +1,5 @@
+includes:
+	- phpunit-drupal-phpstan.neon
+parameters:
+	drupal:
+		configGetReturnType: true

--- a/tests/fixtures/config/phpunit-drupal-phpstan-config-get-unknown-key.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan-config-get-unknown-key.neon
@@ -1,0 +1,4 @@
+parameters:
+	drupal:
+		rules:
+			configGetUnknownKeyRule: true

--- a/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
+++ b/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\ConfigGetUnknownKeyRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+
+final class ConfigGetUnknownKeyRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): \PHPStan\Rules\Rule
+    {
+        return $this->getContainer()->getByType(ConfigGetUnknownKeyRule::class);
+    }
+
+    /**
+     * @dataProvider resultData
+     *
+     * @param list<array{0: string, 1: int, 2?: string|null}> $errorMessages
+     */
+    public function testRule(string $path, array $errorMessages): void
+    {
+        $this->analyse([$path], $errorMessages);
+    }
+
+    public static function resultData(): \Generator
+    {
+        yield 'unknown keys on FullyValidatable configs' => [
+            __DIR__ . '/data/config-get-unknown-key.php',
+            [
+                [
+                    'Config key "nonexistent_key" does not exist in the schema for "system.maintenance".',
+                    14,
+                ],
+                [
+                    'Config key "threshold.unknown_key" does not exist in the schema for "system.cron".',
+                    20,
+                ],
+                [
+                    'Config key "totally_wrong" does not exist in the schema for "system.cron".',
+                    23,
+                ],
+                [
+                    'Config key "bad_key" does not exist in the schema for "system.maintenance".',
+                    31,
+                ],
+                [
+                    'Config key "bad_editable_key" does not exist in the schema for "system.maintenance".',
+                    37,
+                ],
+                [
+                    'Config key "unknown_via_trait" does not exist in the schema for "system.maintenance".',
+                    64,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
+++ b/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
@@ -50,7 +50,7 @@ final class ConfigGetUnknownKeyRuleTest extends DrupalRuleTestCase
                 ],
                 [
                     'Config key "unknown_via_trait" does not exist in the schema for "system.maintenance".',
-                    64,
+                    72,
                 ],
             ],
         ];

--- a/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
+++ b/tests/src/Rules/ConfigGetUnknownKeyRuleTest.php
@@ -8,6 +8,13 @@ use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
 final class ConfigGetUnknownKeyRuleTest extends DrupalRuleTestCase
 {
 
+    public static function getAdditionalConfigFiles(): array
+    {
+        return array_merge(parent::getAdditionalConfigFiles(), [
+            __DIR__ . '/../../fixtures/config/phpunit-drupal-phpstan-config-get-unknown-key.neon',
+        ]);
+    }
+
     protected function getRule(): \PHPStan\Rules\Rule
     {
         return $this->getContainer()->getByType(ConfigGetUnknownKeyRule::class);
@@ -50,7 +57,7 @@ final class ConfigGetUnknownKeyRuleTest extends DrupalRuleTestCase
                 ],
                 [
                     'Config key "unknown_via_trait" does not exist in the schema for "system.maintenance".',
-                    72,
+                    106,
                 ],
             ],
         ];

--- a/tests/src/Rules/data/config-get-unknown-key.php
+++ b/tests/src/Rules/data/config-get-unknown-key.php
@@ -37,6 +37,14 @@ function testUnknownKeysViaConfigFactory(ConfigFactoryInterface $configFactory):
     $configFactory->getEditable('system.maintenance')->get('bad_editable_key');
 }
 
+// --- Sequence traversal: keys under a sequence should not be reported ---
+
+function testSequenceTraversal(): void {
+    // system.mail.interface is a sequence of strings; 'default' is a dynamic
+    // element key — should NOT be reported as unknown.
+    \Drupal::config('system.mail')->get('interface.default');
+}
+
 // --- Non-FullyValidatable configs: no errors regardless of key ---
 
 function testNonFullyValidatable(): void {

--- a/tests/src/Rules/data/config-get-unknown-key.php
+++ b/tests/src/Rules/data/config-get-unknown-key.php
@@ -1,0 +1,68 @@
+<?php
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+// --- FullyValidatable configs: unknown keys should be reported ---
+
+function testUnknownKeysOnFullyValidatable(): void {
+    // Valid key — no error expected.
+    \Drupal::config('system.maintenance')->get('message');
+
+    // Unknown key on FullyValidatable config — error expected.
+    \Drupal::config('system.maintenance')->get('nonexistent_key');
+
+    // Valid nested key — no error.
+    \Drupal::config('system.cron')->get('threshold.requirements_warning');
+
+    // Unknown nested key — error expected.
+    \Drupal::config('system.cron')->get('threshold.unknown_key');
+
+    // Top-level key that does not exist — error expected.
+    \Drupal::config('system.cron')->get('totally_wrong');
+}
+
+function testUnknownKeysViaConfigFactory(ConfigFactoryInterface $configFactory): void {
+    // Valid key — no error.
+    $configFactory->get('system.maintenance')->get('message');
+
+    // Unknown key — error expected.
+    $configFactory->get('system.maintenance')->get('bad_key');
+
+    // getEditable — valid key, no error.
+    $configFactory->getEditable('system.maintenance')->get('message');
+
+    // getEditable — unknown key, error expected.
+    $configFactory->getEditable('system.maintenance')->get('bad_editable_key');
+}
+
+// --- Non-FullyValidatable configs: no errors regardless of key ---
+
+function testNonFullyValidatable(): void {
+    // system.theme is NOT FullyValidatable — no error even for unknown keys.
+    \Drupal::config('system.theme')->get('completely_made_up');
+
+    // Unknown config name — no error.
+    \Drupal::config('nonexistent.config')->get('any_key');
+}
+
+class TestFormWithUnknownKey extends ConfigFormBase {
+    protected function getEditableConfigNames() {
+        return ['system.maintenance'];
+    }
+
+    public function getFormId() {
+        return 'test_form_unknown_key';
+    }
+
+    public function buildForm(array $form, FormStateInterface $form_state) {
+        // Valid key — no error.
+        $this->config('system.maintenance')->get('message');
+
+        // Unknown key via ConfigFormBaseTrait — error expected.
+        $this->config('system.maintenance')->get('unknown_via_trait');
+
+        return $form;
+    }
+}

--- a/tests/src/Rules/data/config-get-unknown-key.php
+++ b/tests/src/Rules/data/config-get-unknown-key.php
@@ -55,6 +55,40 @@ function testNonFullyValidatable(): void {
     \Drupal::config('nonexistent.config')->get('any_key');
 }
 
+// --- Dynamic type references: keys beneath them are unverifiable ---
+
+function testDynamicTypeReference(): void {
+    // system.mail is FullyValidatable, but mailer_dsn.options uses the dynamic
+    // type `mailer_dsn.options.[%parent.scheme]` — keys beneath it must not be
+    // reported.
+    \Drupal::config('system.mail')->get('mailer_dsn.options.verify_peer');
+}
+
+// --- Receiver verification: same-named methods on other classes ---
+
+class NotDrupal {
+    public static function config(string $name): \Drupal\Core\Config\Config {
+        return \Drupal::getContainer()->get('config.factory')->getEditable('some.other_config');
+    }
+}
+
+class HasConfigHelper {
+    public function config(string $name): \Drupal\Core\Config\Config {
+        return \Drupal::getContainer()->get('config.factory')->getEditable('mymodule.' . $name);
+    }
+
+    public function run(): void {
+        // Not ConfigFormBaseTrait; the helper prefixes the name, so the key
+        // belongs to a different config — no error.
+        $this->config('system.maintenance')->get('anything_at_all');
+    }
+}
+
+function testStaticCallOnOtherClass(): void {
+    // Static ::config() on a class other than \Drupal — no error.
+    NotDrupal::config('system.maintenance')->get('legit_key_of_other_config');
+}
+
 class TestFormWithUnknownKey extends ConfigFormBase {
     protected function getEditableConfigNames() {
         return ['system.maintenance'];

--- a/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
+++ b/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Tests\Type;
 
-use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
 use PHPStan\Testing\TypeInferenceTestCase;
 
 final class ConfigGetReturnTypeExtensionTest extends TypeInferenceTestCase
 {
-    use AdditionalConfigFilesTrait;
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return array_merge(parent::getAdditionalConfigFiles(), [
+            __DIR__ . '/../../fixtures/config/phpunit-drupal-phpstan-config-get-return-type.neon',
+        ]);
+    }
 
     public static function dataFileAsserts(): iterable
     {

--- a/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
+++ b/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace mglaman\PHPStanDrupal\Tests\Type;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use Symfony\Component\Yaml\Yaml;
+use function array_key_exists;
+use function file_exists;
 
 final class ConfigGetReturnTypeExtensionTest extends TypeInferenceTestCase
 {
@@ -19,6 +22,25 @@ final class ConfigGetReturnTypeExtensionTest extends TypeInferenceTestCase
     public static function dataFileAsserts(): iterable
     {
         yield from self::gatherAssertTypes(__DIR__ . '/data/config-get.php');
+        if (self::systemMailIsFullyValidatable()) {
+            yield from self::gatherAssertTypes(__DIR__ . '/data/config-get-system-mail.php');
+        }
+    }
+
+    /**
+     * system.mail is only FullyValidatable in newer Drupal core versions, so
+     * gate the asserts that depend on it on the actual schema content.
+     */
+    private static function systemMailIsFullyValidatable(): bool
+    {
+        $schemaFile = __DIR__ . '/../../fixtures/drupal/core/modules/system/config/schema/system.schema.yml';
+        if (!file_exists($schemaFile)) {
+            return false;
+        }
+        $schema = Yaml::parseFile($schemaFile);
+        // The constraint's value is null (`FullyValidatable: ~`), so isset()
+        // would report false — use array_key_exists().
+        return array_key_exists('FullyValidatable', $schema['system.mail']['constraints'] ?? []);
     }
 
     /**

--- a/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
+++ b/tests/src/Type/ConfigGetReturnTypeExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Type;
+
+use mglaman\PHPStanDrupal\Tests\AdditionalConfigFilesTrait;
+use PHPStan\Testing\TypeInferenceTestCase;
+
+final class ConfigGetReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    use AdditionalConfigFilesTrait;
+
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/data/config-get.php');
+    }
+
+    /**
+     * @dataProvider dataFileAsserts
+     * @param string $assertType
+     * @param string $file
+     * @param mixed ...$args
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/src/Type/data/config-get-system-mail.php
+++ b/tests/src/Type/data/config-get-system-mail.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ConfigGetReturnTypeSystemMail;
+
+use function PHPStan\Testing\assertType;
+
+// These asserts require system.mail to be FullyValidatable, which is not the
+// case in every supported Drupal core version. The test gates this file on
+// the actual schema content.
+
+function testSystemMail(): void {
+    // system.mail has a sequence of strings
+    assertType('array<string>|null', \Drupal::config('system.mail')->get('interface'));
+
+    // system.mail.interface is a sequence; 'default' is a dynamic element key -> string|null
+    assertType('string|null', \Drupal::config('system.mail')->get('interface.default'));
+}
+
+function testDynamicTypeReference(): void {
+    // mailer_dsn.scheme is a static string in the schema.
+    assertType('string|null', \Drupal::config('system.mail')->get('mailer_dsn.scheme'));
+
+    // mailer_dsn.options uses the dynamic type
+    // `mailer_dsn.options.[%parent.scheme]` — no narrowing possible.
+    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options'));
+    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options.verify_peer'));
+}

--- a/tests/src/Type/data/config-get.php
+++ b/tests/src/Type/data/config-get.php
@@ -46,6 +46,49 @@ function testConfigFactory(ConfigFactoryInterface $configFactory): void {
     assertType('string|null', $configFactory->getEditable('system.maintenance')->get('message'));
 }
 
+function testDynamicTypeReference(): void {
+    // mailer_dsn.scheme is a static string in the schema.
+    assertType('string|null', \Drupal::config('system.mail')->get('mailer_dsn.scheme'));
+
+    // mailer_dsn.options uses the dynamic type
+    // `mailer_dsn.options.[%parent.scheme]` — no narrowing possible.
+    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options'));
+    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options.verify_peer'));
+}
+
+function testPartiallyResolvableUnion(bool $flag): void {
+    // One branch resolves, the other does not: narrowing must not drop the
+    // unresolvable branch.
+    $key = $flag ? 'message' : 'unknown_key_xyz';
+    assertType('mixed', \Drupal::config('system.maintenance')->get($key));
+
+    // Both branches resolve: union of both types.
+    $key = $flag ? 'message' : 'langcode';
+    assertType('string|null', \Drupal::config('system.maintenance')->get($key));
+}
+
+class NotDrupal {
+    public static function config(string $name): ImmutableConfig {
+        return \Drupal::config('some.other_config');
+    }
+}
+
+class HasConfigHelper {
+    public function config(string $name): ImmutableConfig {
+        return \Drupal::config('mymodule.' . $name);
+    }
+
+    public function run(): void {
+        // Not ConfigFormBaseTrait — no narrowing.
+        assertType('mixed', $this->config('system.maintenance')->get('message'));
+    }
+}
+
+function testStaticCallOnOtherClass(): void {
+    // Static ::config() on a class other than \Drupal — no narrowing.
+    assertType('mixed', NotDrupal::config('system.maintenance')->get('message'));
+}
+
 function testImmutableConfig(ImmutableConfig $config): void {
     // ImmutableConfig extends Config, so the extension applies.
     // Without knowing the config name at call site this falls back to mixed.

--- a/tests/src/Type/data/config-get.php
+++ b/tests/src/Type/data/config-get.php
@@ -30,6 +30,9 @@ function testDrupalConfig(): void {
     // system.mail has a sequence of strings
     assertType('array<string>|null', \Drupal::config('system.mail')->get('interface'));
 
+    // system.mail.interface is a sequence; 'default' is a dynamic element key -> string|null
+    assertType('string|null', \Drupal::config('system.mail')->get('interface.default'));
+
     // system.feature_flags is FullyValidatable with a boolean
     assertType('bool|null', \Drupal::config('system.feature_flags')->get('linkset_endpoint'));
 }

--- a/tests/src/Type/data/config-get.php
+++ b/tests/src/Type/data/config-get.php
@@ -27,12 +27,6 @@ function testDrupalConfig(): void {
     // Unknown config should return mixed
     assertType('mixed', \Drupal::config('nonexistent.config')->get('key'));
 
-    // system.mail has a sequence of strings
-    assertType('array<string>|null', \Drupal::config('system.mail')->get('interface'));
-
-    // system.mail.interface is a sequence; 'default' is a dynamic element key -> string|null
-    assertType('string|null', \Drupal::config('system.mail')->get('interface.default'));
-
     // system.feature_flags is FullyValidatable with a boolean
     assertType('bool|null', \Drupal::config('system.feature_flags')->get('linkset_endpoint'));
 }
@@ -44,16 +38,6 @@ function testConfigFactory(ConfigFactoryInterface $configFactory): void {
 
     // getEditable() returns Config (mutable)
     assertType('string|null', $configFactory->getEditable('system.maintenance')->get('message'));
-}
-
-function testDynamicTypeReference(): void {
-    // mailer_dsn.scheme is a static string in the schema.
-    assertType('string|null', \Drupal::config('system.mail')->get('mailer_dsn.scheme'));
-
-    // mailer_dsn.options uses the dynamic type
-    // `mailer_dsn.options.[%parent.scheme]` — no narrowing possible.
-    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options'));
-    assertType('mixed', \Drupal::config('system.mail')->get('mailer_dsn.options.verify_peer'));
 }
 
 function testPartiallyResolvableUnion(bool $flag): void {

--- a/tests/src/Type/data/config-get.php
+++ b/tests/src/Type/data/config-get.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace ConfigGetReturnType;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use function PHPStan\Testing\assertType;
+
+function testDrupalConfig(): void {
+    // system.maintenance is FullyValidatable, message is type: text -> string|null
+    assertType('string|null', \Drupal::config('system.maintenance')->get('message'));
+
+    // system.cron is FullyValidatable
+    assertType('bool|null', \Drupal::config('system.cron')->get('logging'));
+
+    // Nested key: system.cron threshold.requirements_warning is integer
+    assertType('int|null', \Drupal::config('system.cron')->get('threshold.requirements_warning'));
+
+    // Both requirements keys exist in the schema
+    assertType('int|null', \Drupal::config('system.cron')->get('threshold.requirements_error'));
+
+    // system.theme is NOT FullyValidatable, so should return mixed
+    assertType('mixed', \Drupal::config('system.theme')->get('default'));
+
+    // Unknown config should return mixed
+    assertType('mixed', \Drupal::config('nonexistent.config')->get('key'));
+
+    // system.mail has a sequence of strings
+    assertType('array<string>|null', \Drupal::config('system.mail')->get('interface'));
+
+    // system.feature_flags is FullyValidatable with a boolean
+    assertType('bool|null', \Drupal::config('system.feature_flags')->get('linkset_endpoint'));
+}
+
+function testConfigFactory(ConfigFactoryInterface $configFactory): void {
+    // ConfigFactory::get() returns ImmutableConfig (extends Config), so narrowing applies
+    assertType('string|null', $configFactory->get('system.maintenance')->get('message'));
+    assertType('int|null', $configFactory->get('system.cron')->get('threshold.requirements_error'));
+
+    // getEditable() returns Config (mutable)
+    assertType('string|null', $configFactory->getEditable('system.maintenance')->get('message'));
+}
+
+function testImmutableConfig(ImmutableConfig $config): void {
+    // ImmutableConfig extends Config, so the extension applies.
+    // Without knowing the config name at call site this falls back to mixed.
+    assertType('mixed', $config->get('message'));
+}
+
+class TestConfigForm extends ConfigFormBase {
+    protected function getEditableConfigNames() {
+        return ['system.maintenance'];
+    }
+
+    public function getFormId() {
+        return 'test_config_form';
+    }
+
+    public function buildForm(array $form, FormStateInterface $form_state) {
+        // $this->config() from ConfigFormBaseTrait
+        assertType('string|null', $this->config('system.maintenance')->get('message'));
+        return $form;
+    }
+}


### PR DESCRIPTION
I vibe-coded a solution to #753. Please accept my apologies, as I don't have enough experience with this repo to verify if this is a good approach, so please only review as a proof of concept.

The TL;DR is:

- Narrows `Config::get()` return types using Drupal's config schema files, so calls like `\Drupal::config('system.cron')->get('logging')` resolve to `bool|null` instead of mixed. Only applies to configs with the `FullyValidatable` constraint, which guarantees the schema is complete. Types are always nullable since any key can be absent at runtime, but maybe we should assume they are not?
- Also adds an opt-in rule (`configGetUnknownKeyRule`) that reports calls to `->get()` with a key that doesn't exist in the  schema. This catches typos at analysis time rather than runtime.

I've attached a more verbose explanation, but fair warning about the use of the LLM here.

[config-get-return-type-extension.md](https://github.com/user-attachments/files/28938876/config-get-return-type-extension.md)