### PR TITLE
Populate service map when bootstrap is skipped (e.g. under Rector)

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -263,6 +263,9 @@ services:
 	-
 		class: mglaman\PHPStanDrupal\Drupal\ServiceMap
 	-
+		class: mglaman\PHPStanDrupal\Drupal\RectorServiceMapInitializer
+		tags: [phpstan.broker.dynamicStaticMethodReturnTypeExtension]
+	-
 		class: mglaman\PHPStanDrupal\Drupal\ExtensionMap
 	-
 		class: mglaman\PHPStanDrupal\Drupal\EntityDataRepository

--- a/src/Drupal/RectorServiceMapInitializer.php
+++ b/src/Drupal/RectorServiceMapInitializer.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Drupal;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+/**
+ * Populates the Drupal service map when the bootstrap file is not executed.
+ *
+ * The service map is built by {@see DrupalAutoloader::register()}, which runs as
+ * a `bootstrapFiles` entry (drupal-autoloader.php). PHPStan executes those through
+ * CommandHelper::executeBootstrapFile(). Tools that build the PHPStan container
+ * directly never call CommandHelper, so the bootstrap is skipped and the map stays
+ * empty — most notably Rector, whose PHPStanServicesFactory calls
+ * ContainerFactory::create() and stops there. The result is that \Drupal::service()
+ * resolves to `object` under Rector instead of the concrete service class.
+ *
+ * This service is registered as a no-op dynamic return type extension purely so
+ * PHPStan instantiates it eagerly when the broker is built. If the map is still
+ * empty at that point, it runs the autoloader against the live container. The
+ * empty-map guard keeps a normal PHPStan run a no-op, since the bootstrap already
+ * populated the map there.
+ *
+ * @see https://github.com/mglaman/phpstan-drupal/issues/995
+ */
+final class RectorServiceMapInitializer implements DynamicStaticMethodReturnTypeExtension
+{
+    public function __construct(Container $container, ServiceMap $serviceMap)
+    {
+        if ($serviceMap->getServices() === []) {
+            (new DrupalAutoloader())->register($container);
+        }
+    }
+
+    public function getClass(): string
+    {
+        return 'Drupal';
+    }
+
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return false;
+    }
+
+    public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): ?Type
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #995.

The service map is built by `DrupalAutoloader::register()`, which runs as a `bootstrapFiles` entry. PHPStan executes those through `CommandHelper::executeBootstrapFile()`. Tools that build the PHPStan container directly never call `CommandHelper`, so the bootstrap is skipped and the map stays empty. Rector is the case — its `PHPStanServicesFactory` calls `ContainerFactory::create()` and stops there — so `\Drupal::service('renderer')` resolves to `object` instead of `Drupal\Core\Render\Renderer`, and type-aware Rector rules silently skip those nodes.

This registers `RectorServiceMapInitializer`, a no-op `DynamicStaticMethodReturnTypeExtension` that PHPStan instantiates eagerly when the broker builds. If the service map is still empty at that point, it runs the autoloader against the live container. The empty-map guard keeps a normal `phpstan analyse` run a no-op, since the bootstrap already populated the map there.

I went with reusing `DrupalAutoloader::register()` wholesale rather than refactoring the scan out of it, to keep the change small. Lazy population inside `ServiceMap` would be cleaner as the real shape if you'd prefer that — happy to rework.

Tested against Drupal 11 with Rector 2.4 across a full install (webform, photoswipe): `\Drupal::service('renderer')` resolves to `Renderer` and `\Drupal::service('entity_type.manager')` to `EntityTypeManager`, Rector processes both modules without errors, and standalone `phpstan analyse` behaves exactly as before.

---

*Claude was used for research and development of this issue and fix.*
