### PR TITLE
Widen drupal-finder constraint and drop stale baseline entries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "symfony/finder": "^6.2 || ^7.0 || ^8.0",
         "symfony/yaml": "^6.2 || ^7.0 || ^8.0",
-        "webflo/drupal-finder": "^1.3.1"
+        "webflo/drupal-finder": "^1.3.1 || ^2.0"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,36 +1,3 @@
 parameters:
-	ignoreErrors:
-		-
-			message: """
-				#^Call to deprecated method locateRoot\\(\\) of class DrupalFinder\\\\DrupalFinder\\:
-				Will be removed in v2\\. Future usage should instantiate
-				  a new DrupalFinder object by passing the starting path to its
-				  constructor\\.$#
-			"""
-			count: 1
-			path: src/Drupal/DrupalAutoloader.php
-
-		-
-			message: """
-				#^Instantiation of deprecated class DrupalFinder\\\\DrupalFinder\\:
-				in drupal\\-finder\\:1\\.3\\.0 and is removed from drupal\\-finder\\:2\\.0\\.0\\.
-				  Use \\\\DrupalFinder\\\\DrupalFinderComposerRuntime instead\\.$#
-			"""
-			count: 1
-			path: src/Drupal/DrupalAutoloader.php
-
-		-
-			message: "#^Parameter \\#1 \\$root of class mglaman\\\\PHPStanDrupal\\\\Drupal\\\\ExtensionDiscovery constructor expects string, bool\\|string given\\.$#"
-			count: 1
-			path: src/Drupal/DrupalAutoloader.php
-
-		-
-			message: "#^Parameter \\#1 \\$start_path of method DrupalFinder\\\\DrupalFinder\\:\\:locateRoot\\(\\) expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Drupal/DrupalAutoloader.php
-
-		-
-			message: "#^Property mglaman\\\\PHPStanDrupal\\\\Drupal\\\\DrupalAutoloader\\:\\:\\$drupalRoot \\(string\\) does not accept bool\\|string\\.$#"
-			count: 1
-			path: src/Drupal/DrupalAutoloader.php
+	ignoreErrors: []
 


### PR DESCRIPTION
## Summary
- Widen `webflo/drupal-finder` constraint to `^1.3.1 || ^2.0` — `DrupalAutoloader` already uses `DrupalFinderComposerRuntime`, which is available and non-deprecated in both major versions.
- Remove 5 stale `ignoreErrors` entries in `phpstan-baseline.neon` referencing `DrupalFinder::locateRoot()`/`DrupalFinder` instantiation — dead code paths, the migration to `DrupalFinderComposerRuntime` already happened in #790.

Closes #962

## Test plan
- [x] `php vendor/bin/phpstan analyze` — no errors (confirms the baseline entries were genuinely dead)
- [x] `php vendor/bin/phpunit` — full suite green (one pre-existing unrelated failure in `InspectorTypeExtensionTest`, confirmed present on `main` too)
- [x] `php vendor/bin/phpcs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)