### PR TITLE
Run CI on 2.0.x maintenance branch

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
## What changed?

The Tests workflow now triggers on pushes and pull requests targeting the `2.0.x` maintenance branch, in addition to `main`.

## Why?

`2.0.x` was cut from the 2.0.17 tag so `main` can track 2.1.0. Without this change, any patch backported to `2.0.x` runs zero CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)