### PR TITLE
Make containerHasAlwaysTrue false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,18 @@ What it currently enables:
 
 - `checkCoreDeprecatedHooksInApiFiles` — reports hook implementations deprecated in Drupal core `.api.php` files
 - `checkContribDeprecatedHooksInApiFiles` — reports hook implementations deprecated in contrib module `.api.php` files
-- `containerHasAlwaysTrue: false` — `ContainerInterface::has()` returns `bool` instead of always-`true` for known services, preventing false positives that may cause developers to remove legitimate conditional service guards
 
 > [!NOTE]
 > `checkDeprecatedHooksInApiFiles` is deprecated. Use `checkCoreDeprecatedHooksInApiFiles` and `checkContribDeprecatedHooksInApiFiles` instead.
+
+> [!NOTE]
+> `containerHasAlwaysTrue: false` graduated from bleeding edge to the default in 2.1.0. `ContainerInterface::has()` returns `bool` instead of always-`true` for known services, so conditional service guards stay meaningful. Restore the old inference with:
+> ```neon
+> parameters:
+>     drupal:
+>         bleedingEdge:
+>             containerHasAlwaysTrue: true
+> ```
 
 #### Config schema-based checks (experimental)
 

--- a/bleedingEdge.neon
+++ b/bleedingEdge.neon
@@ -4,4 +4,3 @@ parameters:
 			checkDeprecatedHooksInApiFiles: false
 			checkCoreDeprecatedHooksInApiFiles: true
 			checkContribDeprecatedHooksInApiFiles: true
-			containerHasAlwaysTrue: false

--- a/extension.neon
+++ b/extension.neon
@@ -21,7 +21,7 @@ parameters:
 			checkDeprecatedHooksInApiFiles: false
 			checkCoreDeprecatedHooksInApiFiles: false
 			checkContribDeprecatedHooksInApiFiles: false
-			containerHasAlwaysTrue: true
+			containerHasAlwaysTrue: false
 		extensions:
 			entityFieldsViaMagicReflection: true
 			entityFieldMethodsViaMagicReflection: true

--- a/tests/fixtures/config/phpunit-drupal-phpstan-container-has-always-true.neon
+++ b/tests/fixtures/config/phpunit-drupal-phpstan-container-has-always-true.neon
@@ -1,0 +1,6 @@
+includes:
+	- phpunit-drupal-phpstan-no-bleedingedge.neon
+parameters:
+	drupal:
+		bleedingEdge:
+			containerHasAlwaysTrue: true

--- a/tests/src/Type/DrupalContainerDynamicReturnTypeLegacyTest.php
+++ b/tests/src/Type/DrupalContainerDynamicReturnTypeLegacyTest.php
@@ -12,7 +12,7 @@ final class DrupalContainerDynamicReturnTypeLegacyTest extends TypeInferenceTest
     public static function getAdditionalConfigFiles(): array
     {
         return array_merge(parent::getAdditionalConfigFiles(), [
-            __DIR__ . '/../../fixtures/config/phpunit-drupal-phpstan-no-bleedingedge.neon',
+            __DIR__ . '/../../fixtures/config/phpunit-drupal-phpstan-container-has-always-true.neon',
         ]);
     }
 

--- a/tests/src/Type/data/container-legacy-has.php
+++ b/tests/src/Type/data/container-legacy-has.php
@@ -8,6 +8,7 @@ use function PHPStan\Testing\assertType;
 function test(): void {
     $container = \Drupal::getContainer();
 
+    // Legacy behavior restored via containerHasAlwaysTrue: true.
     assertType('true', $container->has('service_map.my_service'));
     assertType('false', $container->has('unknown_service'));
 }


### PR DESCRIPTION
## What changed?

`drupal.bleedingEdge.containerHasAlwaysTrue` now defaults to `false`: `ContainerInterface::has()` returns `bool` instead of always-`true` for services known to the service map. The entry is removed from `bleedingEdge.neon` since it no longer differs from the default.

## Why?

Fixes #1004. Reporting `has()` as always-true pushed developers to delete conditional service guards that do real work at runtime — a module can be uninstalled or a service missing in a different site build. The strict behavior already shipped and soaked in `bleedingEdge.neon`; this graduates it in a minor release, the promotion path the bleeding-edge docs describe.

Restore the old inference with:

```neon
parameters:
    drupal:
        bleedingEdge:
            containerHasAlwaysTrue: true
```

## Testing notes

- `DrupalContainerDynamicReturnTypeTest` (`container.php`) already asserts the strict `bool`/`false` behavior and now exercises the default.
- `DrupalContainerDynamicReturnTypeLegacyTest` repurposed to cover the opt-back path via a config fixture setting `containerHasAlwaysTrue: true` — the always-`true` asserts stay meaningful there.
- README documents the graduation and the opt-back snippet.
- Full suite green apart from the pre-existing `InspectorTypeExtensionTest` failure on `main`; PHPStan self-analysis and PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)