### PR TITLE
Add PathItem field type stub

### DIFF
--- a/stubs/Drupal/path/Plugin/Field/FieldType/PathItem.stub
+++ b/stubs/Drupal/path/Plugin/Field/FieldType/PathItem.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\path\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * @property ?string $alias
+ * @property ?int $pid
+ * @property ?string $langcode
+ */
+class PathItem extends FieldItemBase {
+
+}

--- a/tests/src/Type/data/field-types.php
+++ b/tests/src/Type/data/field-types.php
@@ -25,6 +25,7 @@ use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\file\Plugin\Field\FieldType\FileUriItem;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
 use Drupal\node\Entity\Node;
+use Drupal\path\Plugin\Field\FieldType\PathItem;
 use Drupal\text\Plugin\Field\FieldType\TextItem;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
 use Drupal\text\Plugin\Field\FieldType\TextWithSummaryItem;
@@ -179,6 +180,14 @@ $file_uri_field = $node->get('field_file')->first();
 assert($file_uri_field instanceof FileUriItem);
 assertType(FileUriItem::class, $file_uri_field);
 assertType('string', $file_uri_field->url);
+
+// PathItem.
+$path_field = $node->get('path')->first();
+assert($path_field instanceof PathItem);
+assertType(PathItem::class, $path_field);
+assertType('string|null', $path_field->alias);
+assertType('int|null', $path_field->pid);
+assertType('string|null', $path_field->langcode);
 
 // TextITem.
 $text_field = $node->get('field_text')->first();


### PR DESCRIPTION
## Summary

- add a stub for the Drupal path module's `PathItem` properties
- cover `alias`, `pid`, and `langcode` inference in the shared field-type fixture

## Testing

- `php vendor/bin/phpunit --no-coverage --filter=FieldTypesTest`
- `php vendor/bin/phpunit --no-coverage`
- `php vendor/bin/phpstan analyze --memory-limit=-1`
- `php vendor/bin/phpcs`
- `composer validate --strict --no-check-publish`
- `php -l stubs/Drupal/path/Plugin/Field/FieldType/PathItem.stub`
- `php -l tests/src/Type/data/field-types.php`
- `git diff --check origin/main...HEAD`

Fixes #365
