### PR TITLE
Add PathItem field type stub (2.0.x)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [main]
+    branches: [main, 2.0.x]
   pull_request:
-    branches: [main]
+    branches: [main, 2.0.x]
   schedule:
     - cron: 0 0 * * *
 

--- a/stubs/Drupal/path/Plugin/Field/FieldType/PathItem.stub
+++ b/stubs/Drupal/path/Plugin/Field/FieldType/PathItem.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\path\Plugin\Field\FieldType;
+
+use Drupal\Core\Field\FieldItemBase;
+
+/**
+ * @property ?string $alias
+ * @property ?int $pid
+ * @property ?string $langcode
+ */
+class PathItem extends FieldItemBase {
+
+}

--- a/tests/src/Type/data/field-types.php
+++ b/tests/src/Type/data/field-types.php
@@ -25,6 +25,7 @@ use Drupal\file\Plugin\Field\FieldType\FileItem;
 use Drupal\file\Plugin\Field\FieldType\FileUriItem;
 use Drupal\link\Plugin\Field\FieldType\LinkItem;
 use Drupal\node\Entity\Node;
+use Drupal\path\Plugin\Field\FieldType\PathItem;
 use Drupal\text\Plugin\Field\FieldType\TextItem;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
 use Drupal\text\Plugin\Field\FieldType\TextWithSummaryItem;
@@ -179,6 +180,14 @@ $file_uri_field = $node->get('field_file')->first();
 assert($file_uri_field instanceof FileUriItem);
 assertType(FileUriItem::class, $file_uri_field);
 assertType('string', $file_uri_field->url);
+
+// PathItem.
+$path_field = $node->get('path')->first();
+assert($path_field instanceof PathItem);
+assertType(PathItem::class, $path_field);
+assertType('string|null', $path_field->alias);
+assertType('int|null', $path_field->pid);
+assertType('string|null', $path_field->langcode);
 
 // TextITem.
 $text_field = $node->get('field_text')->first();


### PR DESCRIPTION
Cherry-pick of #1007 (e41d454) to the 2.0.x maintenance branch.

Adds a stub for the path module's `PathItem` field type and covers `alias`, `pid`, and `langcode` inference in the shared field-type fixture.

Also cherry-picks #1002 (3cc6987) so CI runs on the 2.0.x branch — the workflow on 2.0.x still only triggered on `main`, so no checks were running for this PR.

Verified locally: `FieldTypesTest` passes on this branch (77/77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)