### PR TITLE
Fix readonly false positive in DependencySerializationTraitPropertyRule

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,6 +41,7 @@ jobs:
         experimental: [false]
         php-version:
           - "8.3"
+          - "8.4"
         drupal:
           - "~11.2.0"
           - "~11.3.0"

--- a/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
+++ b/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
@@ -8,6 +8,8 @@ use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -17,6 +19,11 @@ use PHPStan\Rules\RuleErrorBuilder;
 final class DependencySerializationTraitPropertyRule implements Rule
 {
 
+    public function __construct(
+        private readonly PhpVersion $phpVersion
+    ) {
+    }
+
     public function getNodeType(): string
     {
         return ClassPropertyNode::class;
@@ -24,7 +31,8 @@ final class DependencySerializationTraitPropertyRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->getClassReflection()->hasTraitUse(DependencySerializationTrait::class)) {
+        $classReflection = $node->getClassReflection();
+        if (!$classReflection->hasTraitUse(DependencySerializationTrait::class)) {
             return [];
         }
 
@@ -39,16 +47,49 @@ final class DependencySerializationTraitPropertyRule implements Rule
             ->identifier('dependencySerializationTraitProperty.unsupportedPrivateProperty')
             ->build();
         }
-        if ($node->isReadOnly()) {
+        if ($node->isReadOnly() && $this->isReadOnlyPropertyBroken($node, $classReflection)) {
             $errors[] = RuleErrorBuilder::message(
                 sprintf(
-                    'Read-only properties are incompatible with %s.',
+                    'Read-only properties are incompatible with %s when the trait is used by a parent class on PHP < 8.4.',
                     DependencySerializationTrait::class
                 )
-            )->tip('See https://www.drupal.org/node/3110266')
+            )->tip(sprintf(
+                '%s::__wakeup() cannot initialize a read-only property declared in a child class. Use the trait in this class directly, or remove the readonly modifier.',
+                DependencySerializationTrait::class
+            ))
             ->identifier('dependencySerializationTraitProperty.unsupportedReadOnlyProperty')
             ->build();
         }
         return $errors;
+    }
+
+    private function isReadOnlyPropertyBroken(ClassPropertyNode $node, ClassReflection $classReflection): bool
+    {
+        // PHP 8.4 allows initializing a read-only property from a parent
+        // class scope, which makes __wakeup() work in all cases.
+        if ($this->phpVersion->getVersionId() >= 80400) {
+            return false;
+        }
+
+        // The trait's __sleep() skips non-object values, so properties that
+        // can never hold an object are serialized as-is and never touched.
+        $nativeType = $node->getNativeType();
+        if ($nativeType !== null && $nativeType->isObject()->no()) {
+            return false;
+        }
+
+        // When the declaring class composes the trait itself, __wakeup() runs
+        // in the declaring scope and may initialize the read-only property.
+        return !$this->classComposesTrait($classReflection);
+    }
+
+    private function classComposesTrait(ClassReflection $classReflection): bool
+    {
+        foreach ($classReflection->getTraits() as $trait) {
+            if ($trait->getName() === DependencySerializationTrait::class || $this->classComposesTrait($trait)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
+++ b/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
@@ -4,14 +4,17 @@ namespace mglaman\PHPStanDrupal\Tests\Rules;
 
 use mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 
 final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestCase
 {
 
+    private int $phpVersionId = 80300;
+
     protected function getRule(): Rule
     {
-        return new DependencySerializationTraitPropertyRule();
+        return new DependencySerializationTraitPropertyRule(new PhpVersion($this->phpVersionId));
     }
 
     public function testRule(): void
@@ -30,13 +33,33 @@ final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestC
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
-                    22,
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    32,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
-                    28,
+                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait when the trait is used by a parent class on PHP < 8.4.',
+                    37,
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait::__wakeup() cannot initialize a read-only property declared in a child class. Use the trait in this class directly, or remove the readonly modifier.',
+                ],
+            ]
+        );
+    }
+
+    public function testReadOnlyPropertiesAllowedOnPhp84(): void
+    {
+        $this->phpVersionId = 80400;
+        $this->analyse(
+            [__DIR__.'/data/dependency-serialization-trait.php'],
+            [
+                [
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    16,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    22,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [

--- a/tests/src/Rules/data/dependency-serialization-trait.php
+++ b/tests/src/Rules/data/dependency-serialization-trait.php
@@ -31,3 +31,18 @@ class Qux {
 class FooForm extends FormBase {
     private EntityTypeManagerInterface $entityTypeManager;
 }
+
+class ReadonlyChildForm extends FormBase {
+    public function __construct(
+        protected readonly EntityTypeManagerInterface $entityTypeManager,
+        protected readonly string $formName,
+    ) {}
+}
+
+class ReadonlyDirectUse {
+    use DependencySerializationTrait;
+
+    public function __construct(
+        protected readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+}


### PR DESCRIPTION
## What changed

`dependencySerializationTraitProperty.unsupportedReadOnlyProperty` no longer fires for every readonly property on a class using `DependencySerializationTrait`. It now reports only the case that actually breaks at runtime: an object-typed readonly property declared in a class that inherits the trait from a parent, analyzed on PHP < 8.4.

Fixes #1009.
Fixes #889.

## Why

`DependencySerializationTrait::__sleep()` never mutates properties — it only removes service properties from the list of names handed to `serialize()`. `__wakeup()` then performs the first write to the excluded property on the freshly unserialized object. When the declaring class composes the trait itself, that write happens in the declaring scope, which PHP's readonly semantics allow. Scalar and array properties are never touched by the trait at all.

The one real failure mode, verified against PHP 8.3 and 8.4:

```
PHP 8.3.32
DirectUse: OK, db=restored
Child: ERROR: Cannot initialize readonly property Child::$db from scope ParentUses
PHP 8.4.23
DirectUse: OK, db=restored
Child: OK, db=restored
```

A readonly property declared in a child class (a form extending `FormBase`, for example) cannot be initialized by `__wakeup()`, whose scope is the parent class that uses the trait. PHP 8.4 relaxed readonly initialization scope, so the error is skipped entirely when `phpVersion` is 8.4+.

## How

The rule now takes PHPStan's `PhpVersion` (autowired) and reports readonly only when all three hold:

1. `phpVersion` < 8.4
2. The property's native type can hold an object (`__sleep()` skips non-objects)
3. The declaring class does not compose the trait itself, directly or through another trait

The error message and tip now describe the parent-class condition and how to resolve it. The identifier is unchanged, so existing ignores keep working.

## Testing notes

- New fixture cases: readonly promoted service property in a `FormBase` child (reported on PHP 8.3, not on 8.4), readonly scalar in the same class (never reported), and readonly service property with direct trait use (never reported).
- Existing direct-use readonly expectations (`Baz`, `Qux`) removed — those were the false positives.
- Full suite: 815 tests pass. `phpcs` and self-analysis clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
