### PR TITLE
Test against Drupal 11.4 and PHP 8.5, drop EOL 11.2

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - "8.3"
           - "8.4"
+          - "8.5"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v7"
@@ -41,9 +42,11 @@ jobs:
         experimental: [false]
         php-version:
           - "8.3"
+          - "8.4"
+          - "8.5"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
+          - "~11.4.0"
         include:
           - php-version: "8.1"
             drupal: "^10.4"
@@ -87,8 +90,8 @@ jobs:
         php-version:
           - "8.3"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
+          - "~11.4.0"
         include:
           - php-version: "8.1"
             drupal: "^10.4"
@@ -163,8 +166,8 @@ jobs:
         php-version:
           - "8.3"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
+          - "~11.4.0"
         include:
           - php-version: "8.1"
             drupal: "^10.4"


### PR DESCRIPTION
## What changed

The CI matrix now tests the two supported Drupal minors, ~11.3.0 and ~11.4.0, replacing end-of-life ~11.2.0. The tests job runs PHP 8.3, 8.4, and 8.5; linting adds PHP 8.5.

## Why

`Build Integration | PHP 8.3 | Drupal ~11.2.0` fails on main (including last night's scheduled run): composer's security advisory policy in the Drupal project template refuses to install `drupal/core 11.2.14` because SA-CORE-2026-010 through SA-CORE-2026-012 are unfixed on the EOL 11.2 branch. Testing a supported minor beats ignoring the advisories.

PHP 8.5 was previously exercised only by the core HEAD baseline job. The full test suite passes on PHP 8.5.8 locally.

## Notes

- Overlaps with #1010, which adds PHP 8.4 to the tests matrix on its branch. The added line is identical, so whichever merges second auto-merges cleanly.
- The `Drupal core HEAD baseline check` failure on main is baseline drift against core HEAD; it is `continue-on-error` and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)