### PR TITLE
Fix never type for dynamic container service IDs

### DIFF
--- a/src/Type/ContainerDynamicReturnTypeExtension.php
+++ b/src/Type/ContainerDynamicReturnTypeExtension.php
@@ -67,6 +67,12 @@ class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
                 }
             }
 
+            // A dynamic service ID has no constant strings; unioning zero
+            // types would produce `never`.
+            if ($types === []) {
+                return $returnType;
+            }
+
             return TypeCombinator::union(...$types);
         } elseif ($methodName === 'get') {
             $args = $methodCall->getArgs();
@@ -89,10 +95,18 @@ class ContainerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExte
 
             $argType = $scope->getType($args[0]->value);
 
-            foreach ($argType->getConstantStrings() as $constantStringType) {
+            $constantStrings = $argType->getConstantStrings();
+            foreach ($constantStrings as $constantStringType) {
                 $serviceId = $constantStringType->getValue();
                 $service = $this->serviceMap->getService($serviceId);
                 $types[] = $service !== null ? $service->getType() : $returnType;
+            }
+
+            // A dynamic service ID has no constant strings; fall back to the
+            // declared return type so the union cannot collapse to `never`,
+            // while keeping any null added for NULL_ON_INVALID_REFERENCE.
+            if ($constantStrings === []) {
+                $types[] = $returnType;
             }
 
             return TypeCombinator::union(...$types);

--- a/tests/src/Rules/EntityStoragePropertyAssignmentRuleTest.php
+++ b/tests/src/Rules/EntityStoragePropertyAssignmentRuleTest.php
@@ -44,4 +44,9 @@ final class EntityStoragePropertyAssignmentRuleTest extends DrupalRuleTestCase
             ]
         );
     }
+
+    public function testBug1012(): void
+    {
+        $this->analyse([__DIR__ . '/data/bug-1012-proxy.php'], []);
+    }
 }

--- a/tests/src/Rules/data/bug-1012-proxy.php
+++ b/tests/src/Rules/data/bug-1012-proxy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules\data;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+// No error: core-generated proxy classes fetch the decorated service with a
+// dynamic service ID (issue #1012).
+class GeneratedProxyLazyLoadingService
+{
+    protected ContainerInterface $container;
+
+    protected string $drupalProxyOriginalServiceId;
+
+    protected object $service;
+
+    public function __construct(ContainerInterface $container, string $drupal_proxy_original_service_id)
+    {
+        $this->container = $container;
+        $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+    }
+
+    protected function lazyLoadItself(): object
+    {
+        if (!isset($this->service)) {
+            $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+        }
+
+        return $this->service;
+    }
+}

--- a/tests/src/Type/DrupalContainerDynamicReturnTypeTest.php
+++ b/tests/src/Type/DrupalContainerDynamicReturnTypeTest.php
@@ -17,6 +17,7 @@ final class DrupalContainerDynamicReturnTypeTest extends TypeInferenceTestCase
         yield from self::gatherAssertTypes(__DIR__ . '/data/drupal-service-static.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/drupal-class-resolver.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/bug-563.php');
+        yield from self::gatherAssertTypes(__DIR__ . '/data/bug-1012.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/container-optional.php');
         yield from self::gatherAssertTypes(__DIR__ . '/data/synthetic.php');
     }

--- a/tests/src/Type/data/bug-1012.php
+++ b/tests/src/Type/data/bug-1012.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Bug1012;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use function PHPStan\Testing\assertType;
+
+function foo(string $service_id): void {
+    $container = \Drupal::getContainer();
+    assert($container !== null);
+
+    assertType('object', $container->get($service_id));
+    assertType('object|null', $container->get($service_id, ContainerInterface::NULL_ON_INVALID_REFERENCE));
+    assertType('bool', $container->has($service_id));
+}


### PR DESCRIPTION
## What changed

`$container->get()` and `$container->has()` no longer resolve to `never` when called with a variable service ID. `get()` falls back to its declared return type (keeping the `null` added for `NULL_ON_INVALID_REFERENCE`), and `has()` falls back to `bool`.

## Why

Fixes #1012. `ContainerDynamicReturnTypeExtension` unions the types resolved from each constant string in the argument. A variable service ID has no constant strings, so `TypeCombinator::union()` received zero types and produced `never`. Since `never` is a subtype of everything, `EntityStoragePropertyAssignmentRule` flagged the assignment — hitting every core-generated proxy class, which fetches its decorated service via `$this->container->get($this->drupalProxyOriginalServiceId)`.

Same mechanism as #983, but fixed in the extension this time so every consumer of the type benefits, not just one rule.

## Testing notes

- `tests/src/Type/data/bug-1012.php` asserts `get($var)` is `object`, `get($var, NULL_ON_INVALID_REFERENCE)` is `object|null`, and `has($var)` is `bool`.
- `tests/src/Rules/data/bug-1012-proxy.php` mirrors the generated proxy `lazyLoadItself()` pattern and expects no errors.
- Full suite, phpcs, and phpstan all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)