### PR TITLE
[2.0.x] Fix readonly false positive in DependencySerializationTraitPropertyRule

### DIFF
--- a/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
+++ b/src/Rules/Drupal/DependencySerializationTraitPropertyRule.php
@@ -8,6 +8,8 @@ use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\ClassPropertyNode;
+use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -17,6 +19,11 @@ use PHPStan\Rules\RuleErrorBuilder;
 final class DependencySerializationTraitPropertyRule implements Rule
 {
 
+    public function __construct(
+        private readonly PhpVersion $phpVersion
+    ) {
+    }
+
     public function getNodeType(): string
     {
         return ClassPropertyNode::class;
@@ -24,7 +31,8 @@ final class DependencySerializationTraitPropertyRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->getClassReflection()->hasTraitUse(DependencySerializationTrait::class)) {
+        $classReflection = $node->getClassReflection();
+        if (!$classReflection->hasTraitUse(DependencySerializationTrait::class)) {
             return [];
         }
 
@@ -39,16 +47,49 @@ final class DependencySerializationTraitPropertyRule implements Rule
             ->identifier('dependencySerializationTraitProperty.unsupportedPrivateProperty')
             ->build();
         }
-        if ($node->isReadOnly()) {
+        if ($node->isReadOnly() && $this->isReadOnlyPropertyBroken($node, $classReflection)) {
             $errors[] = RuleErrorBuilder::message(
                 sprintf(
-                    'Read-only properties are incompatible with %s.',
+                    'Read-only properties are incompatible with %s when the trait is used by a parent class on PHP < 8.4.',
                     DependencySerializationTrait::class
                 )
-            )->tip('See https://www.drupal.org/node/3110266')
+            )->tip(sprintf(
+                '%s::__wakeup() cannot initialize a read-only property declared in a child class. Use the trait in this class directly, or remove the readonly modifier.',
+                DependencySerializationTrait::class
+            ))
             ->identifier('dependencySerializationTraitProperty.unsupportedReadOnlyProperty')
             ->build();
         }
         return $errors;
+    }
+
+    private function isReadOnlyPropertyBroken(ClassPropertyNode $node, ClassReflection $classReflection): bool
+    {
+        // PHP 8.4 allows initializing a read-only property from a parent
+        // class scope, which makes __wakeup() work in all cases.
+        if ($this->phpVersion->getVersionId() >= 80400) {
+            return false;
+        }
+
+        // The trait's __sleep() skips non-object values, so properties that
+        // can never hold an object are serialized as-is and never touched.
+        $nativeType = $node->getNativeType();
+        if ($nativeType !== null && $nativeType->isObject()->no()) {
+            return false;
+        }
+
+        // When the declaring class composes the trait itself, __wakeup() runs
+        // in the declaring scope and may initialize the read-only property.
+        return !$this->classComposesTrait($classReflection);
+    }
+
+    private function classComposesTrait(ClassReflection $classReflection): bool
+    {
+        foreach ($classReflection->getTraits() as $trait) {
+            if ($trait->getName() === DependencySerializationTrait::class || $this->classComposesTrait($trait)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
+++ b/tests/src/Rules/DependencySerializationTraitPropertyRuleTest.php
@@ -4,14 +4,17 @@ namespace mglaman\PHPStanDrupal\Tests\Rules;
 
 use mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule;
 use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Php\PhpVersion;
 use PHPStan\Rules\Rule;
 
 final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestCase
 {
 
+    private int $phpVersionId = 80300;
+
     protected function getRule(): Rule
     {
-        return new DependencySerializationTraitPropertyRule();
+        return new DependencySerializationTraitPropertyRule(new PhpVersion($this->phpVersionId));
     }
 
     public function testRule(): void
@@ -30,13 +33,33 @@ final class DependencySerializationTraitPropertyRuleTest extends DrupalRuleTestC
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
-                    22,
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    32,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [
-                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait.',
-                    28,
+                    'Read-only properties are incompatible with Drupal\Core\DependencyInjection\DependencySerializationTrait when the trait is used by a parent class on PHP < 8.4.',
+                    37,
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait::__wakeup() cannot initialize a read-only property declared in a child class. Use the trait in this class directly, or remove the readonly modifier.',
+                ],
+            ]
+        );
+    }
+
+    public function testReadOnlyPropertiesAllowedOnPhp84(): void
+    {
+        $this->phpVersionId = 80400;
+        $this->analyse(
+            [__DIR__.'/data/dependency-serialization-trait.php'],
+            [
+                [
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    16,
+                    'See https://www.drupal.org/node/3110266',
+                ],
+                [
+                    'Drupal\Core\DependencyInjection\DependencySerializationTrait does not support private properties.',
+                    22,
                     'See https://www.drupal.org/node/3110266',
                 ],
                 [

--- a/tests/src/Rules/data/dependency-serialization-trait.php
+++ b/tests/src/Rules/data/dependency-serialization-trait.php
@@ -31,3 +31,18 @@ class Qux {
 class FooForm extends FormBase {
     private EntityTypeManagerInterface $entityTypeManager;
 }
+
+class ReadonlyChildForm extends FormBase {
+    public function __construct(
+        protected readonly EntityTypeManagerInterface $entityTypeManager,
+        protected readonly string $formName,
+    ) {}
+}
+
+class ReadonlyDirectUse {
+    use DependencySerializationTrait;
+
+    public function __construct(
+        protected readonly EntityTypeManagerInterface $entityTypeManager,
+    ) {}
+}


### PR DESCRIPTION
Cherry-pick of #1010 (28f3f46) to 2.0.x. Fixes #1009 / #889 for the 2.0.x line.

One deviation from the original commit: the `.github/workflows/php.yml` hunk (adding a PHP 8.4 matrix leg) was dropped. The 2.0.x matrix still includes `~11.2.0`, which is no longer installable due to unfixed core security advisories (see #1011), so new 8.4 legs would fail for unrelated reasons. The rule tests construct `PhpVersion` with 8.3 and 8.4 directly, so both analyzed-version code paths are covered on every runtime without the extra CI leg.

Rule + full suite and phpstan pass on 2.0.x.

Note for release notes: the error message/tip text changed, so `ignoreErrors` entries matching on message text will become unmatched (identifier is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)