### PR TITLE
[2.0.x] Drop EOL Drupal 11.2 from CI matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -42,7 +42,6 @@ jobs:
         php-version:
           - "8.3"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
         include:
           - php-version: "8.1"
@@ -87,7 +86,6 @@ jobs:
         php-version:
           - "8.3"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
         include:
           - php-version: "8.1"
@@ -163,7 +161,6 @@ jobs:
         php-version:
           - "8.3"
         drupal:
-          - "~11.2.0"
           - "~11.3.0"
         include:
           - php-version: "8.1"


### PR DESCRIPTION
## What changed

Removes the `~11.2.0` leg from all three CI matrix blocks (Tests, Build Integration, and the core-analysis job) on 2.0.x.

## Why

Drupal 11.2 is EOL with unfixed security advisories (SA-CORE-2026-010, -011, -012). The Drupal project template's composer advisory policy blocks installing affected core versions, so every Build Integration run against 2.0.x now fails at composer install — before any phpstan-drupal code runs. This is what's failing CI on #1016 and #1017. Main hit the same breakage and fixed it in #1011.

Minimal fix only: no new matrix legs (11.4 / PHP 8.5 modernization stays a main-branch concern).

## Testing notes

CI on this PR is the test — Build Integration legs should get past composer install again. #1016 and #1017 need a rerun after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)