### PR TITLE
feat: add stubs for Markup classes for type hinting

### DIFF
--- a/stubs/Drupal/Component/Render/FormattableMarkup.stub
+++ b/stubs/Drupal/Component/Render/FormattableMarkup.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Component\Render;
+
+class FormattableMarkup implements MarkupInterface, \Countable {
+
+    /**
+     * @param string $string
+     * @param array<string, string|\Stringable> $arguments
+     */
+    public function __construct($string, array $arguments) {}
+
+}

--- a/stubs/Drupal/Core/StringTranslation/TranslatableMarkup.stub
+++ b/stubs/Drupal/Core/StringTranslation/TranslatableMarkup.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Core\StringTranslation;
+
+use Drupal\Component\Render\FormattableMarkup;
+
+class TranslatableMarkup extends FormattableMarkup {
+
+  /**
+   * @param string $string
+   * @param array<string, string|\Stringable> $arguments
+   * @param array<string, mixed> $options
+   */
+  public function __construct($string, array $arguments = [], array $options = [], ?TranslationInterface $string_translation = NULL) {}
+
+}

--- a/stubs/Drupal/Core/StringTranslation/TranslationInterface.stub
+++ b/stubs/Drupal/Core/StringTranslation/TranslationInterface.stub
@@ -1,0 +1,6 @@
+<?php
+
+namespace Drupal\Core\StringTranslation;
+
+interface TranslationInterface {
+}


### PR DESCRIPTION
Fixes #1019

add type hinting so you prevent Type errors on HTML::escape (null is not a string)