### PR TITLE
Do not fatal when a shorthand service class cannot be loaded

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -237,7 +237,7 @@ class DrupalAutoloader
                 //     tags:
                 //       - { name: foo_bar }
                 // @endcode
-                if (!isset($serviceDefinition['class']) && class_exists($serviceId)) {
+                if (!isset($serviceDefinition['class']) && $this->classExists($serviceId)) {
                     $serviceDefinition['class'] = $serviceId;
                 }
                 // @todo sanitize "calls" and "configurator" and "factory"
@@ -418,5 +418,17 @@ class DrupalAutoloader
     protected function camelize(string $id): string
     {
         return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
+    }
+
+    private function classExists(string $className): bool
+    {
+        try {
+            return class_exists($className);
+        } catch (Throwable) {
+            // Loading the class can fail when it depends on a class from an
+            // extension that is not available, such as a decorator for an
+            // optional module registered with decoration_on_invalid: ignore.
+            return false;
+        }
     }
 }

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -37,7 +37,7 @@ class ServiceMap
             }
 
             if (isset($serviceDefinition['decorates'])) {
-                $decorators[$serviceDefinition['decorates']][] = $serviceId;
+                $decorators[$serviceDefinition['decorates']][$serviceId] = $serviceDefinition['decoration_on_invalid'] ?? 'exception';
             }
 
             // @todo support factories
@@ -68,8 +68,17 @@ class ServiceMap
         }
 
         foreach ($decorators as $decorated_service_id => $services) {
-            foreach ($services as $decorating_service_id) {
-                if (!isset(self::$services[$decorated_service_id], self::$services[$decorating_service_id])) {
+            foreach ($services as $decorating_service_id => $decoration_on_invalid) {
+                if (!isset(self::$services[$decorated_service_id])) {
+                    // Symfony removes the decorating service from the
+                    // container when the decorated service does not exist and
+                    // decoration_on_invalid is set to ignore.
+                    if ($decoration_on_invalid === 'ignore') {
+                        unset(self::$services[$decorating_service_id]);
+                    }
+                    continue;
+                }
+                if (!isset(self::$services[$decorating_service_id])) {
                     continue;
                 }
                 self::$services[$decorated_service_id]->addDecorator(self::$services[$decorating_service_id]);

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
+use Throwable;
 use function class_exists;
 
 class ServiceMap
@@ -41,7 +42,7 @@ class ServiceMap
 
             // @todo support factories
             if (!isset($serviceDefinition['class'])) {
-                if (class_exists($serviceId)) {
+                if (self::classExists($serviceId)) {
                     $serviceDefinition['class'] = $serviceId;
                 } else {
                     continue;
@@ -67,12 +68,24 @@ class ServiceMap
         }
 
         foreach ($decorators as $decorated_service_id => $services) {
-            foreach ($services as $dcorating_service_id) {
-                if (!isset(self::$services[$decorated_service_id])) {
+            foreach ($services as $decorating_service_id) {
+                if (!isset(self::$services[$decorated_service_id], self::$services[$decorating_service_id])) {
                     continue;
                 }
-                self::$services[$decorated_service_id]->addDecorator(self::$services[$dcorating_service_id]);
+                self::$services[$decorated_service_id]->addDecorator(self::$services[$decorating_service_id]);
             }
+        }
+    }
+
+    private static function classExists(string $className): bool
+    {
+        try {
+            return class_exists($className);
+        } catch (Throwable) {
+            // Loading the class can fail when it depends on a class from an
+            // extension that is not available, such as a decorator for an
+            // optional module registered with decoration_on_invalid: ignore.
+            return false;
         }
     }
 

--- a/tests/fixtures/drupal/modules/service_map_broken/service_map_broken.info.yml
+++ b/tests/fixtures/drupal/modules/service_map_broken/service_map_broken.info.yml
@@ -1,0 +1,3 @@
+name: service_map_broken
+type: module
+core_version_requirement: ^8 || ^9

--- a/tests/fixtures/drupal/modules/service_map_broken/service_map_broken.services.yml
+++ b/tests/fixtures/drupal/modules/service_map_broken/service_map_broken.services.yml
@@ -1,0 +1,4 @@
+services:
+  Drupal\service_map_broken\ExtendsMissingClass:
+    decorates: missing_module.render_converter
+    decoration_on_invalid: ignore

--- a/tests/fixtures/drupal/modules/service_map_broken/src/ExtendsMissingClass.php
+++ b/tests/fixtures/drupal/modules/service_map_broken/src/ExtendsMissingClass.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\service_map_broken;
+
+use Drupal\missing_module\RenderConverter;
+
+// The parent class belongs to a module that is not available. Declaring this
+// class throws an Error, which the service map must survive.
+final class ExtendsMissingClass extends RenderConverter
+{
+
+}

--- a/tests/src/ServiceMapFactoryTest.php
+++ b/tests/src/ServiceMapFactoryTest.php
@@ -112,6 +112,11 @@ final class ServiceMapFactoryTest extends TestCase
                 'decorates' => 'unknown',
                 'class' => 'Drupal\service_map\Override',
             ],
+            'ignored_decorator_of_unknown_service' => [
+                'decorates' => 'unknown',
+                'decoration_on_invalid' => 'ignore',
+                'class' => 'Drupal\service_map\Override',
+            ],
         ]);
         $validator($service->getService($id));
     }
@@ -262,6 +267,18 @@ final class ServiceMapFactoryTest extends TestCase
             function (DrupalServiceDefinition $service): void {
                 self::assertEquals(LoggerChannel::class, $service->getClass());
             }
+        ];
+        yield [
+            'decorating_an_unknown_service',
+            function (?DrupalServiceDefinition $service): void {
+                self::assertNotNull($service, 'decorating_an_unknown_service');
+            },
+        ];
+        yield [
+            'ignored_decorator_of_unknown_service',
+            function (?DrupalServiceDefinition $service): void {
+                self::assertNull($service, 'ignored_decorator_of_unknown_service');
+            },
         ];
         yield [
             'service_map.base_to_be_decorated',

--- a/tests/src/ServiceMapFactoryTest.php
+++ b/tests/src/ServiceMapFactoryTest.php
@@ -116,6 +116,39 @@ final class ServiceMapFactoryTest extends TestCase
         $validator($service->getService($id));
     }
 
+    /**
+     * @covers \mglaman\PHPStanDrupal\Drupal\ServiceMap::setDrupalServices
+     * @covers \mglaman\PHPStanDrupal\Drupal\ServiceMap::getService
+     * @covers \mglaman\PHPStanDrupal\Drupal\ServiceMap::classExists
+     */
+    public function testShorthandServiceWithUnloadableClass(): void
+    {
+        $autoloader = static function (string $class): void {
+            if ($class === 'Drupal\service_map_broken\ExtendsMissingClass') {
+                require __DIR__ . '/../fixtures/drupal/modules/service_map_broken/src/ExtendsMissingClass.php';
+            }
+        };
+        spl_autoload_register($autoloader);
+        try {
+            $service = new ServiceMap();
+            $service->setDrupalServices([
+                'decorated_service' => [
+                    'class' => 'Drupal\service_map\Base',
+                ],
+                'Drupal\service_map_broken\ExtendsMissingClass' => [
+                    'decorates' => 'decorated_service',
+                    'decoration_on_invalid' => 'ignore',
+                ],
+            ]);
+        } finally {
+            spl_autoload_unregister($autoloader);
+        }
+        self::assertNull($service->getService('Drupal\service_map_broken\ExtendsMissingClass'));
+        $decorated = $service->getService('decorated_service');
+        self::assertNotNull($decorated);
+        self::assertCount(0, $decorated->getDecorators());
+    }
+
     public static function getServiceProvider(): \Iterator
     {
         yield [


### PR DESCRIPTION
## Problem

Service map generation calls `class_exists()` on shorthand service IDs (added in #817). `class_exists()` autoloads the class, and PHP resolves parent classes at declaration time. A service class extending a class from an unavailable module throws an `Error` that kills the bootstrap before PHPStan analyzes a single file:

```
Error thrown in modules/canvas_headless/src/RenderConverter/JsComponentCanvasRenderConverter.php
on line 15 while loading bootstrap file vendor/mglaman/phpstan-drupal/drupal-autoloader.php:
Class "Drupal\custom_elements\RenderConverter\CanvasRenderConverter" not found
```

Canvas hit this: `canvas_headless` registers a decorator for a `custom_elements` service with `decoration_on_invalid: ignore`, and `drupal/custom_elements` sits in `require-dev`. Symfony ignores the decorator at runtime. phpstan-drupal fataled anyway, because the crash happens during class load, not container compilation. See https://git.drupalcode.org/project/canvas/-/merge_requests/1460, which works around it with an explicit `class:` key.

## Fix

Catch `Throwable` around both shorthand `class_exists()` calls (`DrupalAutoloader`, `ServiceMap`) and skip the service when its class cannot load. `ServiceMap::setDrupalServices()` also skips decorator registration when the decorating service was dropped — previously an undefined array key.

## Tests

- New fixture module `service_map_broken` with a shorthand service whose class extends a class from a missing module. Every bootstrap-dependent test now exercises the failure path; without the fix, `DrupalContainerDynamicReturnTypeTest` fatals with the exact error above.
- `ServiceMapFactoryTest::testShorthandServiceWithUnloadableClass` covers `ServiceMap` directly: the broken service is skipped and the decorated service survives with zero decorators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)