### PR TITLE
Test for DependencySerializationTrait with non-service private properties.

### DIFF
--- a/tests/src/Rules/data/dependency-serialization-trait.php
+++ b/tests/src/Rules/data/dependency-serialization-trait.php
@@ -46,3 +46,9 @@ class ReadonlyDirectUse {
         protected readonly EntityTypeManagerInterface $entityTypeManager,
     ) {}
 }
+
+class NonServiceProperty {
+    use DependencySerializationTrait;
+
+    private bool $foo;
+}


### PR DESCRIPTION
This tests for private property usage where the properties are not services. These are irrelevant to DependencySerializationTrait, since it's only concerned with values that are objects and registered services.