### PR TITLE
Do not crash on first-class callables or missing args in getStorage()

### DIFF
--- a/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
@@ -6,11 +6,9 @@ use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
 use mglaman\PHPStanDrupal\Type\EntityStorage\EntityStorageType;
 use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\VariadicPlaceholder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
-use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 
@@ -52,16 +50,17 @@ class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMe
             $methodCall->getArgs(),
             $methodReflection->getVariants()
         )->getReturnType();
-        if (!isset($methodCall->args[0])) {
-            // Parameter is required.
-            throw new ShouldNotHappenException();
+        if ($methodCall->isFirstClassCallable()) {
+            return $returnType;
+        }
+        $args = $methodCall->getArgs();
+        if (count($args) === 0) {
+            // Calling getStorage() without arguments is invalid, but PHPStan
+            // reports that itself; do not crash the analysis.
+            return $returnType;
         }
 
-        $arg1 = $methodCall->args[0];
-        if ($arg1 instanceof VariadicPlaceholder) {
-            throw new ShouldNotHappenException();
-        }
-        $arg1 = $arg1->value;
+        $arg1 = $args[0]->value;
 
         // @todo handle where the first param is EntityTypeInterface::id()
         if ($arg1 instanceof MethodCall) {


### PR DESCRIPTION
Part 2 of 9 in the legacy-code audit stack (on top of #1033).

## What changed

`$entityTypeManager->getStorage(...)` (first-class callable syntax) crashed the whole analysis with a `ShouldNotHappenException`, and a zero-argument `getStorage()` did the same. Both now fall back to the declared return type: a wrong-arity call is the user's error and PHPStan reports it elsewhere — crashing the analysis is never right.

## Testing

Covered by a new first-class-callable fixture added with the `?Type` migration later in the stack (#1027); the full suite, self-analysis, and phpcs are green on this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)