### PR TITLE
Align legacy rules and reflections with current PHPStan API conventions

### DIFF
--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -60,11 +60,17 @@ class EntityFieldReflection implements PropertyReflection
 
     private function isContentEntityType(): bool
     {
+        if (!$this->reflectionProvider->hasClass(ContentEntityInterface::class)) {
+            return false;
+        }
         return $this->declaringClass->isSubclassOfClass($this->reflectionProvider->getClass(ContentEntityInterface::class));
     }
 
     private function isConfigEntityType(): bool
     {
+        if (!$this->reflectionProvider->hasClass(ConfigEntityInterface::class)) {
+            return false;
+        }
         return $this->declaringClass->isSubclassOfClass($this->reflectionProvider->getClass(ConfigEntityInterface::class));
     }
 

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -7,8 +7,6 @@ use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\IsSuperTypeOfResult;
-use PHPStan\Type\ObjectType;
 use function array_key_exists;
 
 /**
@@ -52,7 +50,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if (self::classObjectIsSuperOfInterface($classReflection->getName(), self::getFieldItemListInterfaceObject())->yes()) {
+        if ($classReflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -64,20 +62,10 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($classReflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName, $this->reflectionProvider);
         }
-        if (self::classObjectIsSuperOfInterface($classReflection->getName(), self::getFieldItemListInterfaceObject())->yes()) {
+        if ($classReflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
         throw new ShouldNotHappenException($classReflection->getName() . "::$propertyName should be handled earlier.");
-    }
-
-    public static function classObjectIsSuperOfInterface(string $name, ObjectType $interfaceObject) : IsSuperTypeOfResult
-    {
-        return $interfaceObject->isSuperTypeOf(new ObjectType($name));
-    }
-
-    protected static function getFieldItemListInterfaceObject() : ObjectType
-    {
-        return new ObjectType('Drupal\Core\Field\FieldItemListInterface');
     }
 }

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
+use Drupal\Core\Field\FieldItemListInterface;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
@@ -50,7 +51,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             // Content entities have magical __get... so it is kind of true.
             return true;
         }
-        if ($classReflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if ($classReflection->is(FieldItemListInterface::class)) {
             return FieldItemListPropertyReflection::canHandleProperty($classReflection, $propertyName);
         }
 
@@ -62,7 +63,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         if ($classReflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
             return new EntityFieldReflection($classReflection, $propertyName, $this->reflectionProvider);
         }
-        if ($classReflection->implementsInterface('Drupal\Core\Field\FieldItemListInterface')) {
+        if ($classReflection->is(FieldItemListInterface::class)) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -6,11 +6,10 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\MixedType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
 
 /**
  * Allows field access via magic methods
@@ -42,7 +41,7 @@ class FieldItemListPropertyReflection implements PropertyReflection
     public function getReadableType(): Type
     {
         if ($this->propertyName === 'entity') {
-            return new UnionType([new ObjectType('Drupal\Core\Entity\EntityInterface'), new NullType()]);
+            return TypeCombinator::addNull(new ObjectType('Drupal\Core\Entity\EntityInterface'));
         }
         if ($this->propertyName === 'target_id') {
             // @todo needs to be union type.
@@ -60,7 +59,7 @@ class FieldItemListPropertyReflection implements PropertyReflection
     public function getWritableType(): Type
     {
         if ($this->propertyName === 'entity') {
-            return new UnionType([new ObjectType('Drupal\Core\Entity\EntityInterface'), new NullType()]);
+            return TypeCombinator::addNull(new ObjectType('Drupal\Core\Entity\EntityInterface'));
         }
         if ($this->propertyName === 'target_id') {
             return new StringType();

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -7,53 +7,49 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 use PhpParser\Node;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\ObjectType;
 use function sprintf;
+use function str_contains;
+use function strtolower;
 
 /**
- * @implements \PHPStan\Rules\Rule<\PhpParser\Node\Stmt\Class_>
+ * @implements Rule<InClassNode>
  */
 class PluginManagerInspectionRule implements Rule
 {
-    /** @var ReflectionProvider */
-    private $reflectionProvider;
-    public function __construct(ReflectionProvider $reflectionProvider)
-    {
-        $this->reflectionProvider = $reflectionProvider;
-    }
-
     public function getNodeType(): string
     {
-        return Node\Stmt\Class_::class;
+        return InClassNode::class;
     }
 
     public function processNode(Node $node, Scope $scope): array
     {
-        if ($node->namespacedName === null) {
-            // anonymous class
+        $classReflection = $node->getClassReflection();
+        if ($classReflection->isAnonymous()) {
             return [];
         }
-        if ($node->extends === null) {
+        $originalNode = $node->getOriginalNode();
+        if (!$originalNode instanceof Node\Stmt\Class_) {
             return [];
         }
-        if (str_contains($node->namespacedName->toLowerString(), 'test')) {
+        if ($originalNode->extends === null) {
             return [];
         }
-
-        $pluginManagerType = $scope->resolveTypeByName($node->namespacedName);
-        $pluginManagerInterfaceType = new ObjectType(PluginManagerInterface::class);
-        if (!$pluginManagerInterfaceType->isSuperTypeOf($pluginManagerType)->yes()) {
-            return [];
-        }
-        $defaultPluginManager = new ObjectType(DefaultPluginManager::class);
-        if ($defaultPluginManager->equals($pluginManagerType)) {
+        if (str_contains(strtolower($classReflection->getName()), 'test')) {
             return [];
         }
 
-        $constructorMethodNode = (new NodeFinder())->findFirst($node->stmts, static function (Node $node) {
+        if (!$classReflection->is(PluginManagerInterface::class)) {
+            return [];
+        }
+        if ($classReflection->getName() === DefaultPluginManager::class) {
+            return [];
+        }
+
+        $constructorMethodNode = (new NodeFinder())->findFirst($originalNode->stmts, static function (Node $node) {
             return $node instanceof Node\Stmt\ClassMethod && $node->name->toString() === '__construct';
         });
         if (!$constructorMethodNode instanceof Node\Stmt\ClassMethod) {
@@ -61,8 +57,8 @@ class PluginManagerInspectionRule implements Rule
         }
 
         $errors = [];
-        if ($this->isYamlDiscovery($node)) {
-            $errors = $this->inspectYamlPluginManager($node, $constructorMethodNode);
+        if ($this->isYamlDiscovery($originalNode)) {
+            $errors = $this->inspectYamlPluginManager($classReflection, $constructorMethodNode);
         } else {
             // @todo inspect annotated plugin managers.
         }
@@ -79,7 +75,6 @@ class PluginManagerInspectionRule implements Rule
                 'Plugin managers should call alterInfo to allow plugin definitions to be altered.'
             )
                 ->tip('For example, to invoke hook_mymodule_data_alter() call alterInfo with "mymodule_data".')
-                ->line($node->getStartLine())
                 ->identifier('pluginManagerInspection.alterInfoMissing')
                 ->build();
         }
@@ -113,13 +108,12 @@ class PluginManagerInspectionRule implements Rule
     /**
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */
-    private function inspectYamlPluginManager(Node\Stmt\Class_ $class, Node\Stmt\ClassMethod $constructorMethodNode): array
+    private function inspectYamlPluginManager(ClassReflection $classReflection, Node\Stmt\ClassMethod $constructorMethodNode): array
     {
         $errors = [];
 
-        $fqn = (string) $class->namespacedName;
-        $reflection = $this->reflectionProvider->getClass($fqn);
-        $constructor = $reflection->getConstructor();
+        $fqn = $classReflection->getName();
+        $constructor = $classReflection->getConstructor();
 
         if ($constructor->getDeclaringClass()->getName() !== $fqn) {
             $errors[] = RuleErrorBuilder::message(

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -49,10 +49,10 @@ class PluginManagerInspectionRule implements Rule
             return [];
         }
 
-        $constructorMethodNode = (new NodeFinder())->findFirst($originalNode->stmts, static function (Node $node) {
-            return $node instanceof Node\Stmt\ClassMethod && $node->name->toString() === '__construct';
-        });
-        if (!$constructorMethodNode instanceof Node\Stmt\ClassMethod) {
+        // Only look at the class's own methods. A recursive search would also
+        // match a constructor declared by an anonymous class nested in a method.
+        $constructorMethodNode = $originalNode->getMethod('__construct');
+        if ($constructorMethodNode === null) {
             return [];
         }
 
@@ -113,6 +113,9 @@ class PluginManagerInspectionRule implements Rule
         $errors = [];
 
         $fqn = $classReflection->getName();
+        if (!$classReflection->hasConstructor()) {
+            return $errors;
+        }
         $constructor = $classReflection->getConstructor();
 
         if ($constructor->getDeclaringClass()->getName() !== $fqn) {

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -4,7 +4,7 @@ namespace mglaman\PHPStanDrupal\Rules\Drupal;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\MethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -21,7 +21,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // Only check static calls to \Drupal
-        if (!($node->class instanceof Node\Name\FullyQualified) || (string) $node->class !== 'Drupal') {
+        if (!$node->class instanceof Node\Name || $scope->resolveName($node->class) !== 'Drupal') {
             return [];
         }
         // Do not raise if called inside a trait.
@@ -61,7 +61,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
         if ($scopeFunction === null) {
             return [];
         }
-        if (!$scopeFunction instanceof ExtendedMethodReflection) {
+        if (!$scopeFunction instanceof MethodReflection) {
             return [];
         }
         if ($scopeFunction->isStatic()) {

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -58,7 +58,6 @@ class LoadIncludes extends LoadIncludeBase
                     ModuleHandlerInterface::class,
                     $moduleName
                 ))
-                ->line($node->getStartLine())
                 ->identifier('loadIncludes.moduleNotFound')
                 ->build()
             ];
@@ -79,7 +78,6 @@ class LoadIncludes extends LoadIncludeBase
                         'A file could not be loaded from %s::loadInclude',
                         ModuleHandlerInterface::class
                     ))
-                    ->line($node->getStartLine())
                     ->identifier('loadIncludes.fileNotLoadable')
                     ->build()
                 ];
@@ -92,7 +90,6 @@ class LoadIncludes extends LoadIncludeBase
                 $module->getPath() . '/' . $filename,
                 ModuleHandlerInterface::class
             ))
-            ->line($node->getStartLine())
             ->identifier('loadIncludes.fileNotLoadable')
             ->build()
         ];

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -56,7 +56,6 @@ class ModuleLoadInclude extends LoadIncludeBase
                     $filename,
                     $moduleName
                 ))
-                ->line($node->getStartLine())
                 ->identifier('moduleLoadInclude.moduleNotFound')
                 ->build()
             ];
@@ -73,7 +72,6 @@ class ModuleLoadInclude extends LoadIncludeBase
             } catch (Throwable $e) {
                 return [
                     RuleErrorBuilder::message('A file could not be loaded from module_load_include')
-                    ->line($node->getStartLine())
                     ->identifier('moduleLoadInclude.moduleNotLoadable')
                     ->build()
                 ];
@@ -85,7 +83,6 @@ class ModuleLoadInclude extends LoadIncludeBase
                 'File %s could not be loaded from module_load_include.',
                 $module->getPath() . '/' . $filename
             ))
-            ->line($node->getStartLine())
             ->identifier('moduleLoadInclude.moduleNotLoadable')
             ->build()
         ];

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -84,6 +84,18 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
             'value',
             false,
         ];
+        // Values typed as the interface itself, such as $node->uid, are the
+        // common case and must be handled like the concrete class.
+        yield 'field item list interface: entity' => [
+            \Drupal\Core\Field\FieldItemListInterface::class,
+            'entity',
+            true,
+        ];
+        yield 'field item list interface: target_id' => [
+            \Drupal\Core\Field\FieldItemListInterface::class,
+            'target_id',
+            true,
+        ];
         yield 'field item list: format' => [
             \Drupal\Core\Field\FieldItemList::class,
             'format',
@@ -125,6 +137,15 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
         $readableType = $propertyReflection->getReadableType();
         self::assertInstanceOf(MixedType::class, $readableType);
     }
-    
+
+    public function testGetPropertyFieldItemListInterface(): void
+    {
+        $classReflection = $this->createReflectionProvider()->getClass(FieldItemListInterface::class);
+        $propertyReflection = $this->extension->getProperty($classReflection, 'entity');
+        $readableType = $propertyReflection->getReadableType();
+        self::assertSame('Drupal\Core\Entity\EntityInterface|null', $readableType->describe(VerbosityLevel::typeOnly()));
+        $propertyReflection = $this->extension->getProperty($classReflection, 'target_id');
+        self::assertInstanceOf(StringType::class, $propertyReflection->getReadableType());
+    }
 
 }

--- a/tests/src/Rules/PluginManagerInspectionRuleTest.php
+++ b/tests/src/Rules/PluginManagerInspectionRuleTest.php
@@ -11,9 +11,7 @@ final class PluginManagerInspectionRuleTest extends DrupalRuleTestCase
 
     protected function getRule(): Rule
     {
-        return new PluginManagerInspectionRule(
-            self::createReflectionProvider()
-        );
+        return new PluginManagerInspectionRule();
     }
 
     /**

--- a/tests/src/Rules/PluginManagerInspectionRuleTest.php
+++ b/tests/src/Rules/PluginManagerInspectionRuleTest.php
@@ -34,6 +34,10 @@ final class PluginManagerInspectionRuleTest extends DrupalRuleTestCase
             __DIR__ . '/data/plugin-manager-valid.php',
             []
         ];
+        yield 'nested anonymous class constructor does not crash' => [
+            __DIR__ . '/data/plugin-manager-nested-constructor.php',
+            []
+        ];
         yield [
             __DIR__ . '/data/plugin-manager-alter-info.php',
             [

--- a/tests/src/Rules/data/plugin-manager-nested-constructor.php
+++ b/tests/src/Rules/data/plugin-manager-nested-constructor.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PluginManagerNestedConstructor;
+
+use Drupal\Component\Plugin\PluginManagerBase;
+use Drupal\Core\Plugin\Discovery\YamlDiscovery;
+
+/**
+ * A YAML plugin manager with no constructor anywhere in its hierarchy.
+ *
+ * The anonymous class inside getDiscovery() declares a constructor. The rule
+ * must not mistake it for the plugin manager's own constructor.
+ */
+class NoConstructorWithNestedAnonymousClass extends PluginManagerBase {
+
+    protected function getDiscovery() {
+        $this->discovery = new YamlDiscovery('foo', []);
+        return $this->discovery;
+    }
+
+    public function helper(): object {
+        return new class {
+            public function __construct() {}
+        };
+    }
+}


### PR DESCRIPTION
Part 6 of 9 in the legacy-code audit stack (on top of #1036). Brings the oldest rules and reflection classes in line with current PHPStan 2.x API conventions and the patterns the newer code in this repo already uses.

The `getStorage()` return type extension change that was in this PR moved to #1045. Review found that the union it introduced is not handled by the storage method extensions and collapses when storage classes overlap, so it needs its own tests and a design decision before it lands.

## What changed

- `PluginManagerInspectionRule` migrates from `Node\Stmt\Class_` to `InClassNode`, which provides the `ClassReflection` directly. The `ReflectionProvider` constructor dependency, anonymous-class handling, and manual FQN round-trip all disappear. Behavior is unchanged.
- `GlobalDrupalDependencyInjectionRule` resolves the called class via `$scope->resolveName()` and checks against the `MethodReflection` interface instead of `ExtendedMethodReflection`, which PHPStan marks `@api-do-not-implement`. One observable change: `parent::service()` inside a subclass of the non-final `\Drupal` class is now reported. No such subclass exists in core or this repo.
- `EntityFieldReflection` guards `ReflectionProvider::getClass()` with `hasClass()`; `FieldItemListPropertyReflection` builds nullable types with `TypeCombinator::addNull()`.
- `EntityFieldsViaMagicReflectionExtension` uses `ClassReflection::is()` for the `FieldItemListInterface` check instead of rebuilding an `ObjectType` from the class name on every property lookup. An earlier revision used `implementsInterface()`, which returns false for the interface itself and broke `$node->uid->entity`. Two public static helpers that only served the old check are removed; no callers exist outside vendored copies of this repo.
- Redundant `->line($node->getStartLine())` calls removed — that is already the default.

- `PluginManagerInspectionRule` no longer crashes when a plugin manager without a constructor contains an anonymous class that declares one. The constructor lookup searched the class body recursively and picked up the nested one, then `getConstructor()` threw on the hierarchy. It now uses the class node's own method lookup and guards with `hasConstructor()`. Pre-existing bug, surfaced by review.

## Known but out of scope

- The "must override __construct" branch in `PluginManagerInspectionRule` is unreachable because the rule returns early unless the class body declares its own constructor. Tracked as a follow-up.

## Testing

`EntityFieldsViaMagicReflectionExtensionTest` gains cases for values typed as `FieldItemListInterface` itself, which is what `$node->uid` is. They fail on the `implementsInterface()` revision and pass now. A new `plugin-manager-nested-constructor.php` fixture reproduces the crash. Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
