### PR TITLE
Modernize legacy code for PHP 8.1 and repo conventions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="phpstan-drupal">
-	<config name="php_version" value="70400"/>
+	<config name="php_version" value="80100"/>
 	<arg name="colors"/>
 	<arg name="extensions" value="php"/>
 	<arg name="encoding" value="utf-8"/>

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -32,52 +32,51 @@ use function trigger_error;
 use function ucwords;
 use function usort;
 
+/**
+ * Bootstraps a Drupal site for analysis from PHPStan's bootstrap file.
+ *
+ * @internal
+ */
 class DrupalAutoloader
 {
 
-    /**
-     * @var \Composer\Autoload\ClassLoader
-     */
-    private $autoloader;
+    private ClassLoader $autoloader;
 
-    /**
-     * @var string
-     */
-    private $drupalRoot;
+    private string $drupalRoot;
 
     /**
      * List of available modules.
      *
      * @var Extension[]
      */
-    protected $moduleData = [];
+    protected array $moduleData = [];
 
     /**
      * List of available themes.
      *
      * @var Extension[]
      */
-    protected $themeData = [];
+    protected array $themeData = [];
 
     /**
      * @var array<array<string, string>>
      */
-    private $serviceMap = [];
+    private array $serviceMap = [];
 
     /**
      * @var array<string, string>
      */
-    private $serviceYamls = [];
+    private array $serviceYamls = [];
 
     /**
      * @var array<string, string>
      */
-    private $serviceClassProviders = [];
+    private array $serviceClassProviders = [];
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
-    private $namespaces = [];
+    private array $namespaces = [];
 
     public function register(Container $container): void
     {

--- a/src/Drupal/DrupalServiceDefinition.php
+++ b/src/Drupal/DrupalServiceDefinition.php
@@ -11,52 +11,23 @@ use function str_replace;
 class DrupalServiceDefinition
 {
 
-    /**
-     * @var string
-     */
-    private $id;
+    private const DEFAULT_DEPRECATION_TEMPLATE = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
 
-    /**
-     * @var string|null
-     */
-    private $class;
+    private bool $deprecated = false;
 
-    /**
-     * @var bool
-     */
-    private $public;
-
-    /**
-     * @var bool
-     */
-    private $deprecated = false;
-
-    /**
-     * @var string|null
-     */
-    private $deprecationTemplate;
-
-    /**
-     * @var string
-     */
-    private static $defaultDeprecationTemplate = 'The "%service_id%" service is deprecated. You should stop using it, as it will soon be removed.';
-
-    /**
-     * @var string|null
-     */
-    private $alias;
+    private ?string $deprecationTemplate = null;
 
     /**
      * @var array<string, \mglaman\PHPStanDrupal\Drupal\DrupalServiceDefinition>
      */
-    private $decorators = [];
+    private array $decorators = [];
 
-    public function __construct(string $id, ?string $class, bool $public = true, ?string $alias = null)
-    {
-        $this->id = $id;
-        $this->class = $class;
-        $this->public = $public;
-        $this->alias = $alias;
+    public function __construct(
+        private readonly string $id,
+        private readonly ?string $class,
+        private readonly bool $public = true,
+        private readonly ?string $alias = null
+    ) {
     }
 
     public function setDeprecated(bool $status = true, ?string $template = null): void
@@ -65,33 +36,21 @@ class DrupalServiceDefinition
         $this->deprecationTemplate = $template;
     }
 
-    /**
-     * @return string
-     */
     public function getId(): string
     {
         return $this->id;
     }
 
-    /**
-     * @return string|null
-     */
     public function getClass(): ?string
     {
         return $this->class;
     }
 
-    /**
-     * @return bool
-     */
     public function isPublic(): bool
     {
         return $this->public;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAlias(): ?string
     {
         return $this->alias;
@@ -104,7 +63,7 @@ class DrupalServiceDefinition
 
     public function getDeprecatedDescription(): string
     {
-        return str_replace('%service_id%', $this->id, $this->deprecationTemplate ?? self::$defaultDeprecationTemplate);
+        return str_replace('%service_id%', $this->id, $this->deprecationTemplate ?? self::DEFAULT_DEPRECATION_TEMPLATE);
     }
 
     public function getType(): Type

--- a/src/Drupal/Extension.php
+++ b/src/Drupal/Extension.php
@@ -8,74 +8,38 @@ use function explode;
 use function file_get_contents;
 use function is_array;
 use function sprintf;
-use function strpos;
+use function str_contains;
 use function trim;
 
 /**
  * Defines an extension (file) object.
  *
  * Bundled version of \Drupal\Core\Extension\Extension.
+ *
+ * @internal
  */
 class Extension
 {
 
     /**
-     * The type of the extension (e.g., 'module').
-     *
-     * @var string
+     * The subpath of the extension below the search path it was found in.
      */
-    protected $type;
+    public string $subpath = '';
 
     /**
-     * The relative pathname of the extension (e.g.,
-     * 'core/modules/node/node.info.yml').
-     *
-     * @var string
+     * The originating search path directory (e.g., 'core').
      */
-    protected $pathname;
+    public string $origin = '';
 
     /**
-     * The filename of the main extension file (e.g., 'node.module').
-     *
-     * @var string|null
+     * @var array<mixed>|null
      */
-    protected $filename;
-
-    /**
-     * An SplFileInfo instance for the extension's info file.
-     *
-     * Note that SplFileInfo is a PHP resource and resources cannot be serialized.
-     *
-     * @var ?\SplFileInfo
-     */
-    protected $splFileInfo;
-
-    /**
-     * The app root.
-     *
-     * @var string
-     */
-    protected $root;
-
-    /**
-     * @var string
-     */
-    public $subpath = '';
-
-    /**
-     * @var string
-     */
-    public $origin = '';
-
-    /**
-     * @var array|null
-     */
-    private $info;
+    private ?array $info = null;
 
     /**
      * @var string[]|null
      */
-    private $dependencies;
+    private ?array $dependencies = null;
 
     /**
      * Constructs a new Extension object.
@@ -87,15 +51,15 @@ class Extension
      * @param string $pathname
      *   The relative path and filename of the extension's info file; e.g.,
      *   'core/modules/node/node.info.yml'.
-     * @param string $filename
+     * @param string|null $filename
      *   (optional) The filename of the main extension file; e.g., 'node.module'.
      */
-    public function __construct($root, $type, $pathname, $filename = null)
-    {
-        $this->root = $root;
-        $this->type = $type;
-        $this->pathname = $pathname;
-        $this->filename = $filename;
+    public function __construct(
+        protected string $root,
+        protected string $type,
+        protected string $pathname,
+        protected ?string $filename = null
+    ) {
     }
 
     /**
@@ -212,7 +176,7 @@ class Extension
 
         // @see \Drupal\Core\Extension\Dependency::createFromString().
         foreach ($dependencies as $dependency) {
-            if (strpos($dependency, ':') !== false) {
+            if (str_contains($dependency, ':')) {
                 [, $dependency] = explode(':', $dependency);
             }
 
@@ -234,6 +198,11 @@ class Extension
             throw new RuntimeException(sprintf('Cannot read "%s"', $this->getPathname()));
         }
 
-        return $this->info = Yaml::parse($infoContent);
+        $parsed = Yaml::parse($infoContent);
+        if (!is_array($parsed)) {
+            throw new RuntimeException(sprintf('Malformed info file "%s"', $this->getPathname()));
+        }
+
+        return $this->info = $parsed;
     }
 }

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -3,7 +3,6 @@
 namespace mglaman\PHPStanDrupal\Drupal;
 
 use FilesystemIterator;
-use mglaman\PHPStanDrupal\Drupal\Extension;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Symfony\Component\Finder\Finder;
@@ -14,8 +13,15 @@ use function dirname;
 use function file_exists;
 use function is_dir;
 use function preg_match;
-use function strpos;
+use function str_starts_with;
 
+/**
+ * Discovers extensions in a Drupal site.
+ *
+ * Bundled version of \Drupal\Core\Extension\ExtensionDiscovery.
+ *
+ * @internal
+ */
 class ExtensionDiscovery
 {
 
@@ -61,23 +67,21 @@ class ExtensionDiscovery
     /**
      * List of installation profile directories to additionally scan.
      *
-     * @var array
+     * @var array<int, string>
      */
-    protected $profileDirectories;
+    protected array $profileDirectories;
 
     /**
      * The app root for the current operation.
-     *
-     * @var string
      */
-    protected $root;
+    protected string $root;
 
     /**
      * The site paths.
      *
      * @var string[]
      */
-    protected $sitePaths;
+    protected array $sitePaths;
 
     /**
      * Constructs a new ExtensionDiscovery object.
@@ -85,7 +89,7 @@ class ExtensionDiscovery
      * @param string $root
      *   The app root.
      */
-    public function __construct($root)
+    public function __construct(string $root)
     {
         $this->root = $root;
         $this->profileDirectories = [
@@ -247,13 +251,13 @@ class ExtensionDiscovery
         }
 
         return array_filter($all_files, function (Extension $file) : bool {
-            if (strpos($file->subpath, 'profiles') !== 0) {
+            if (!str_starts_with($file->subpath, 'profiles')) {
                 // This extension doesn't belong to a profile, ignore it.
                 return true;
             }
 
             foreach ($this->profileDirectories as $weight => $profile_path) {
-                if (strpos($file->getPath(), $profile_path) === 0) {
+                if (str_starts_with($file->getPath(), $profile_path)) {
                     // Parent profile found.
                     return true;
                 }
@@ -281,7 +285,7 @@ class ExtensionDiscovery
         foreach ($all_files as $key => $file) {
             // If the extension does not belong to a profile, just apply the weight
             // of the originating directory.
-            if (strpos($file->subpath, 'profiles') !== 0) {
+            if (!str_starts_with($file->subpath, 'profiles')) {
                 $origins[$key] = $weights[$file->origin];
                 $profiles[$key] = null;
             } elseif ($this->profileDirectories === []) {
@@ -293,7 +297,7 @@ class ExtensionDiscovery
             } else {
                 // Apply the weight of the originating profile directory.
                 foreach ($this->profileDirectories as $weight => $profile_path) {
-                    if (strpos($file->getPath(), $profile_path) === 0) {
+                    if (str_starts_with($file->getPath(), $profile_path)) {
                         $origins[$key] = self::ORIGIN_PROFILE;
                         $profiles[$key] = $weight;
                         continue 2;

--- a/src/Drupal/RecursiveExtensionFilterIterator.php
+++ b/src/Drupal/RecursiveExtensionFilterIterator.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Drupal;
 
@@ -6,14 +6,14 @@ use RecursiveFilterIterator;
 use RecursiveIterator;
 use function array_merge;
 use function in_array;
-use function substr;
+use function str_ends_with;
 
 /**
  * Filters a RecursiveDirectoryIterator to discover extensions.
  *
  * Locally bundled version of \Drupal\Core\Extension\Discovery\RecursiveExtensionFilterIterator.
  *
- * @method bool isDir()
+ * @internal
  */
 class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
 {
@@ -24,9 +24,9 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
      * Only these directory names are considered when starting a filesystem
      * recursion in a search path.
      *
-     * @var array
+     * @var list<string>
      */
-    protected $whitelist = [
+    protected array $whitelist = [
         'profiles',
         'modules',
         'themes',
@@ -39,9 +39,9 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
      * i.e., extensions (of all types) are not able to use any of these names,
      * because their directory names will be skipped.
      *
-     * @var array
+     * @var list<string>
      */
-    protected $blacklist = [
+    protected array $blacklist = [
         // Object-oriented code subdirectories.
         'src',
         'lib',
@@ -67,7 +67,7 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
      *
      * @param \RecursiveIterator $iterator
      *   The iterator to filter.
-     * @param array $blacklist
+     * @param list<string> $blacklist
      *   (optional) Add to the blacklist of directories that should be filtered
      *   out during the iteration.
      */
@@ -108,7 +108,7 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
         if ($name[0] === '.') {
             return false;
         }
-        if ($this->isDir()) {
+        if ($this->current()->isDir()) {
             // If this is a subdirectory of a base search path, only recurse into the
             // fixed list of expected extension type directory names. Required for
             // scanning the top-level/root directory; without this condition, we would
@@ -126,13 +126,13 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
             // config module to be overridden/replaced in a profile/site directory
             // (whereas it must be located directly in a modules directory).
             if ($name === 'config') {
-                return substr($this->current()->getPathname(), -14) === 'modules/config';
+                return str_ends_with($this->current()->getPathname(), 'modules/config');
             }
             // Accept the directory unless the name is blacklisted.
             return !in_array($name, $this->blacklist, true);
         }
 
         // Only accept extension info files.
-        return substr($name, -9) === '.info.yml';
+        return str_ends_with($name, '.info.yml');
     }
 }

--- a/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldMethodsViaMagicReflectionExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Reflection;
 

--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
@@ -22,19 +22,11 @@ use PHPStan\Type\Type;
 class EntityFieldReflection implements PropertyReflection
 {
 
-  /** @var ClassReflection */
-    private $declaringClass;
-
-  /** @var string */
-    private $propertyName;
-
-    private ReflectionProvider $reflectionProvider;
-
-    public function __construct(ClassReflection $declaringClass, string $propertyName, ReflectionProvider $reflectionProvider)
-    {
-        $this->declaringClass = $declaringClass;
-        $this->propertyName = $propertyName;
-        $this->reflectionProvider = $reflectionProvider;
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly string $propertyName,
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
     }
 
     public function getReadableType(): Type

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
@@ -20,11 +20,9 @@ use function array_key_exists;
 class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflectionExtension
 {
 
-    private ReflectionProvider $reflectionProvider;
-
-    public function __construct(ReflectionProvider $reflectionProvider)
-    {
-        $this->reflectionProvider = $reflectionProvider;
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider
+    ) {
     }
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
@@ -32,11 +30,12 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         // @todo Have this run after PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
         // We should not have to check for the property tags if we could get this to run after PHPStan's
         // existing annotation property reflection.
-        if ($classReflection->hasNativeProperty($propertyName) || array_key_exists($propertyName, $classReflection->getPropertyTags())) {
+        if ($classReflection->hasNativeProperty($propertyName)) {
             // Let other parts of PHPStan handle this.
             return false;
         }
 
+        // A class is its own ancestor, so this also covers the class itself.
         foreach ($classReflection->getAncestors() as $ancestor) {
             if (array_key_exists($propertyName, $ancestor->getPropertyTags())) {
                 return false;

--- a/src/Reflection/FieldItemListMethodReflection.php
+++ b/src/Reflection/FieldItemListMethodReflection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Reflection;
 

--- a/src/Reflection/FieldItemListPropertyReflection.php
+++ b/src/Reflection/FieldItemListPropertyReflection.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
@@ -19,16 +19,10 @@ use PHPStan\Type\TypeCombinator;
 class FieldItemListPropertyReflection implements PropertyReflection
 {
 
-    /** @var ClassReflection */
-    private $declaringClass;
-
-    /** @var string */
-    private $propertyName;
-
-    public function __construct(ClassReflection $declaringClass, string $propertyName)
-    {
-        $this->declaringClass = $declaringClass;
-        $this->propertyName = $propertyName;
+    public function __construct(
+        private readonly ClassReflection $declaringClass,
+        private readonly string $propertyName
+    ) {
     }
 
     public static function canHandleProperty(ClassReflection $classReflection, string $propertyName): bool

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -18,7 +18,7 @@ use function strtolower;
 /**
  * @implements Rule<InClassNode>
  */
-class PluginManagerInspectionRule implements Rule
+final class PluginManagerInspectionRule implements Rule
 {
     public function getNodeType(): string
     {

--- a/src/Rules/Deprecations/DeprecatedHookImplementation.php
+++ b/src/Rules/Deprecations/DeprecatedHookImplementation.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace mglaman\PHPStanDrupal\Rules\Deprecations;
 

--- a/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
+++ b/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
@@ -16,8 +16,32 @@ use function strtolower;
  *
  * @implements Rule<FuncCall>
  */
-class DiscouragedFunctionsRule implements Rule
+final class DiscouragedFunctionsRule implements Rule
 {
+    private const DISCOURAGED_FUNCTIONS = [
+        // Devel module debugging functions.
+        'dargs',
+        'dcp',
+        'dd',
+        'dfb',
+        'dfbt',
+        'dpm',
+        'dpq',
+        'dpr',
+        'dprint_r',
+        'drupal_debug',
+        'dsm',
+        'dvm',
+        'dvr',
+        'kdevel_print_object',
+        'kpr',
+        'kprint_r',
+        'sdpm',
+        // Functions which are not available on all
+        // PHP builds.
+        'fnmatch',
+    ];
+
     public function getNodeType(): string
     {
         return FuncCall::class;
@@ -30,31 +54,7 @@ class DiscouragedFunctionsRule implements Rule
         }
         $name = strtolower((string)$node->name);
 
-        $discouragedFunctions = [
-            // Devel module debugging functions.
-            'dargs',
-            'dcp',
-            'dd',
-            'dfb',
-            'dfbt',
-            'dpm',
-            'dpq',
-            'dpr',
-            'dprint_r',
-            'drupal_debug',
-            'dsm',
-            'dvm',
-            'dvr',
-            'kdevel_print_object',
-            'kpr',
-            'kprint_r',
-            'sdpm',
-            // Functions which are not available on all
-            // PHP builds.
-            'fnmatch',
-        ];
-
-        if (in_array($name, $discouragedFunctions, true)) {
+        if (in_array($name, self::DISCOURAGED_FUNCTIONS, true)) {
             return [
                 RuleErrorBuilder::message(
                     sprintf('Calls to function %s should not exist.', $name)

--- a/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
+++ b/src/Rules/Drupal/GlobalDrupalDependencyInjectionRule.php
@@ -11,8 +11,27 @@ use PHPStan\Rules\RuleErrorBuilder;
 /**
  * @implements Rule<Node\Expr\StaticCall>
  */
-class GlobalDrupalDependencyInjectionRule implements Rule
+final class GlobalDrupalDependencyInjectionRule implements Rule
 {
+    /**
+     * Interfaces whose implementations cannot use dependency injection.
+     */
+    private const ALLOWED_INTERFACES = [
+        // Ignore tests.
+        'PHPUnit\Framework\Test',
+        // Typed data objects cannot use dependency injection.
+        'Drupal\Core\TypedData\TypedDataInterface',
+        // Entities don't use services for now
+        // @see https://www.drupal.org/project/drupal/issues/2913224
+        'Drupal\Core\Entity\EntityInterface',
+        // Stream wrappers are only registered as a service for their tags
+        // and cannot use dependency injection. Function calls like
+        // file_exists, stat, etc. will construct the class directly.
+        'Drupal\Core\StreamWrapper\StreamWrapperInterface',
+        // Ignore Nightwatch test setup classes.
+        'Drupal\TestSite\TestSetupInterface',
+    ];
+
     public function getNodeType(): string
     {
         return Node\Expr\StaticCall::class;
@@ -35,23 +54,7 @@ class GlobalDrupalDependencyInjectionRule implements Rule
             return [];
         }
 
-        $allowed_list = [
-            // Ignore tests.
-            'PHPUnit\Framework\Test',
-            // Typed data objects cannot use dependency injection.
-            'Drupal\Core\TypedData\TypedDataInterface',
-            // Entities don't use services for now
-            // @see https://www.drupal.org/project/drupal/issues/2913224
-            'Drupal\Core\Entity\EntityInterface',
-            // Stream wrappers are only registered as a service for their tags
-            // and cannot use dependency injection. Function calls like
-            // file_exists, stat, etc. will construct the class directly.
-            'Drupal\Core\StreamWrapper\StreamWrapperInterface',
-            // Ignore Nightwatch test setup classes.
-            'Drupal\TestSite\TestSetupInterface',
-        ];
-
-        foreach ($allowed_list as $item) {
+        foreach (self::ALLOWED_INTERFACES as $item) {
             if ($scopeClassReflection->implementsInterface($item)) {
                 return [];
             }

--- a/src/Rules/Drupal/LoadIncludeBase.php
+++ b/src/Rules/Drupal/LoadIncludeBase.php
@@ -15,14 +15,9 @@ use function count;
 abstract class LoadIncludeBase implements Rule
 {
 
-    /**
-     * @var \mglaman\PHPStanDrupal\Drupal\ExtensionMap
-     */
-    protected $extensionMap;
-
-    public function __construct(ExtensionMap $extensionMap)
-    {
-        $this->extensionMap = $extensionMap;
+    public function __construct(
+        protected readonly ExtensionMap $extensionMap
+    ) {
     }
 
     private function getStringArgValue(Node\Expr $expr, Scope $scope): ?string

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -15,7 +15,7 @@ use function sprintf;
 /**
  * @extends LoadIncludeBase<Node\Expr\MethodCall>
  */
-class LoadIncludes extends LoadIncludeBase
+final class LoadIncludes extends LoadIncludeBase
 {
 
     public function getNodeType(): string

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -19,7 +19,7 @@ use function sprintf;
  *
  * @extends LoadIncludeBase<Node\Expr\FuncCall>
  */
-class ModuleLoadInclude extends LoadIncludeBase
+final class ModuleLoadInclude extends LoadIncludeBase
 {
 
     public function getNodeType(): string

--- a/src/Rules/Drupal/PluginManager/AbstractPluginManagerRule.php
+++ b/src/Rules/Drupal/PluginManager/AbstractPluginManagerRule.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Rules\Drupal\PluginManager;
 
+use Drupal\Component\Plugin\PluginManagerInterface;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 
@@ -17,6 +18,6 @@ abstract class AbstractPluginManagerRule implements Rule
         return
             !$classReflection->isInterface() &&
             !$classReflection->isAnonymous() &&
-            $classReflection->implementsInterface('Drupal\Component\Plugin\PluginManagerInterface');
+            $classReflection->implementsInterface(PluginManagerInterface::class);
     }
 }

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -11,7 +11,7 @@ use function count;
 /**
  * @extends AbstractPluginManagerRule<ClassMethod>
  */
-class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
+final class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
 {
     public function getNodeType(): string
     {

--- a/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
@@ -2,6 +2,7 @@
 
 namespace mglaman\PHPStanDrupal\Type;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
 use mglaman\PHPStanDrupal\Type\EntityStorage\EntityStorageType;
 use PhpParser\Node\Expr\BinaryOp\Concat;
@@ -15,24 +16,14 @@ use PHPStan\Type\Type;
 class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
-    /**
-     * @var EntityDataRepository
-     */
-    private $entityDataRepository;
-
-    /**
-     * EntityTypeManagerGetStorageDynamicReturnTypeExtension constructor.
-     *
-     * @param EntityDataRepository $entityDataRepository
-     */
-    public function __construct(EntityDataRepository $entityDataRepository)
-    {
-        $this->entityDataRepository = $entityDataRepository;
+    public function __construct(
+        private readonly EntityDataRepository $entityDataRepository
+    ) {
     }
 
     public function getClass(): string
     {
-        return 'Drupal\Core\Entity\EntityTypeManagerInterface';
+        return EntityTypeManagerInterface::class;
     }
 
     public function isMethodSupported(MethodReflection $methodReflection): bool


### PR DESCRIPTION
Part 7 of 9 in the legacy-code audit stack. Mechanical modernization with no behavior change.

## What changed

- `declare(strict_types=1)` in the remaining `src/` files (the Reflection classes, `RecursiveExtensionFilterIterator`, `DeprecatedHookImplementation`).
- The four bundled Drupal-core forks in `src/Drupal/` are marked `@internal` — they are bootstrap implementation details, not extension points.
- The six audited concrete rules are `final`, matching the newer rules.
- Promoted `readonly` constructors and typed properties across the audited classes; the dead `splFileInfo` property is gone.
- The per-node rebuilt arrays in `DiscouragedFunctionsRule` and `GlobalDrupalDependencyInjectionRule` are class constants now.
- `::class` over string FQCNs, `str_contains`/`str_starts_with`/`str_ends_with` over `strpos`/`substr`, and the `@method isDir()` docblock shim replaced with an explicit `$this->current()->isDir()`.
- `Extension::parseInfo()` validates that `Yaml::parse()` returned an array.
- `phpcs.xml` raises `php_version` from 7.4 to 8.1 to match `composer.json`, so PHPCS actually checks against the supported platform.

## Upgrade note

Six rule classes are now `final`: `DiscouragedFunctionsRule`, `GlobalDrupalDependencyInjectionRule`, `LoadIncludes`, `ModuleLoadInclude`, `PluginManagerInspectionRule`, and `PluginManagerSetsCacheBackendRule`. The rules never carried an API promise, but a project that subclassed one of them will need to copy the rule instead.

## Testing

Full suite, self-analysis, and phpcs (with the raised php_version) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


