### PR TITLE
Make the five always-on legacy rules configurable and fix a wrong error identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,34 @@ parameters:
 > [!NOTE]
 > `hookRules` was renamed to `hookFormAlterRule` in 2.1.0 — update your configuration if you referenced it explicitly.
 
+#### Legacy rules made configurable in 2.2.0
+
+The following rules were previously always on. They remain enabled by default, but can now be disabled individually:
+
+```neon
+parameters:
+    drupal:
+        rules:
+            # Flags calls to discouraged functions such as Devel's debugging
+            # functions (dpm, dsm, kint, ...) and fnmatch.
+            discouragedFunctionsRule: false
+
+            # Flags \Drupal static calls inside classes that should use
+            # dependency injection instead.
+            globalDrupalDependencyInjectionRule: false
+
+            # Flags plugin managers that do not set a cache backend.
+            pluginManagerSetsCacheBackendRule: false
+
+            # Validates module_load_include() calls and loads the include for
+            # the rest of the analysis.
+            moduleLoadInclude: false
+
+            # Validates ModuleHandlerInterface::loadInclude() calls and loads
+            # the include for the rest of the analysis.
+            loadIncludes: false
+```
+
 #### Disabling checks for extending `@internal` classes
 
 You can disable the `ClassExtendsInternalClassRule` rule by adding the following to your `phpstan.neon`:

--- a/extension.neon
+++ b/extension.neon
@@ -31,6 +31,11 @@ parameters:
 		configGetReturnType: false
 		classResolverReturnType: true
 		rules:
+			discouragedFunctionsRule: true
+			globalDrupalDependencyInjectionRule: true
+			pluginManagerSetsCacheBackendRule: true
+			moduleLoadInclude: true
+			loadIncludes: true
 			testClassSuffixNameRule: true
 			dependencySerializationTraitPropertyRule: true
 			accessResultConditionRule: true
@@ -275,6 +280,11 @@ parametersSchema:
 		configGetReturnType: boolean()
 		classResolverReturnType: boolean()
 		rules: structure([
+			discouragedFunctionsRule: boolean()
+			globalDrupalDependencyInjectionRule: boolean()
+			pluginManagerSetsCacheBackendRule: boolean()
+			moduleLoadInclude: boolean()
+			loadIncludes: boolean()
 			testClassSuffixNameRule: boolean()
 			dependencySerializationTraitPropertyRule: boolean()
 			accessResultConditionRule: boolean()

--- a/rules.neon
+++ b/rules.neon
@@ -1,19 +1,24 @@
 rules:
-	- mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\RenderCallbackRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\StaticServiceDeprecatedServiceRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\GetDeprecatedServiceRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\Tests\BrowserTestBaseDefaultThemeRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\ConfigEntityConfigExportRule
 	- mglaman\PHPStanDrupal\Rules\Deprecations\PluginAnnotationContextDefinitionsRule
-	- mglaman\PHPStanDrupal\Rules\Drupal\ModuleLoadInclude
-	- mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes
 	- mglaman\PHPStanDrupal\Rules\Drupal\EntityQuery\EntityQueryHasAccessCheckRule
 	- mglaman\PHPStanDrupal\Rules\Drupal\TestClassesProtectedPropertyModulesRule
 
 conditionalTags:
+	mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule:
+		phpstan.rules.rule: %drupal.rules.discouragedFunctionsRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule:
+		phpstan.rules.rule: %drupal.rules.globalDrupalDependencyInjectionRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule:
+		phpstan.rules.rule: %drupal.rules.pluginManagerSetsCacheBackendRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\ModuleLoadInclude:
+		phpstan.rules.rule: %drupal.rules.moduleLoadInclude%
+	mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes:
+		phpstan.rules.rule: %drupal.rules.loadIncludes%
 	mglaman\PHPStanDrupal\Rules\Drupal\ConfigGetUnknownKeyRule:
 		phpstan.rules.rule: %drupal.rules.configGetUnknownKeyRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\HookFormAlterRule:
@@ -46,6 +51,16 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.entityOperationsCacheabilityRule%
 
 services:
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\Coder\DiscouragedFunctionsRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\GlobalDrupalDependencyInjectionRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\PluginManager\PluginManagerSetsCacheBackendRule
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\ModuleLoadInclude
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\LoadIncludes
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\ConfigGetUnknownKeyRule
 	-

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -122,7 +122,7 @@ final class PluginManagerInspectionRule implements Rule
             $errors[] = RuleErrorBuilder::message(
                 sprintf('%s must override __construct if using YAML plugins.', $fqn)
             )
-                ->identifier('pluginManagerInspection.callAlterInfo')
+                ->identifier('pluginManagerInspection.constructorOverrideMissing')
                 ->build();
         } else {
             foreach ($constructorMethodNode->stmts ?? [] as $constructorStmt) {


### PR DESCRIPTION
Part 8 of 9 in the legacy-code audit stack. One change that deserves release-note visibility and one small correctness fix.

## What changed

**Five always-on rules become configurable.** `DiscouragedFunctionsRule`, `GlobalDrupalDependencyInjectionRule`, `PluginManagerSetsCacheBackendRule`, `ModuleLoadInclude`, and `LoadIncludes` move from the flat `rules:` block to the `conditionalTags` registration every newer rule uses, gated on new `drupal.rules.*` parameters. They default to **true**, so nothing changes for existing users — they gain a per-rule opt-out, documented in the README.

**Wrong error identifier fixed.** The "`%s must override __construct if using YAML plugins.`" message in `PluginManagerInspectionRule` was reported under `pluginManagerInspection.callAlterInfo`, which belongs to a different check. It is now `pluginManagerInspection.constructorOverrideMissing`. No upgrade step is needed: since #1027 the rule only inspects classes that declare their own constructor, so this message cannot currently be reported and nobody has an `ignoreErrors` entry for it. Removing the unreachable branch is a separate follow-up.

## Testing

Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


