### PR TITLE
Add ResultCacheMetaExtension so the result cache tracks the Drupal site

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -316,6 +316,10 @@ services:
 	-
 		class: mglaman\PHPStanDrupal\Drupal\ConfigSchemaData
 	-
+		class: mglaman\PHPStanDrupal\Drupal\BootstrapResultCacheMetaExtension
+		tags:
+			- phpstan.resultCacheMetaExtension
+	-
 		class: mglaman\PHPStanDrupal\Drupal\EntityDataRepository
 		arguments:
 			entityMapping: %drupal.entityMapping%

--- a/src/Drupal/BootstrapResultCacheMetaExtension.php
+++ b/src/Drupal/BootstrapResultCacheMetaExtension.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Drupal;
+
+use Drupal;
+use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
+use function class_exists;
+use function glob;
+use function hash;
+use function hash_file;
+use function ksort;
+use function serialize;
+use function sort;
+
+/**
+ * Invalidates PHPStan's result cache when the analyzed Drupal site changes.
+ *
+ * PHPStan hashes its bootstrap files, but not the Drupal extensions and
+ * services.yml files the bootstrap discovers. Without this extension,
+ * enabling a module, editing a services.yml, or upgrading core would reuse
+ * stale analysis results from the cache.
+ */
+final class BootstrapResultCacheMetaExtension implements ResultCacheMetaExtension
+{
+
+    public function __construct(
+        private readonly ServiceMap $serviceMap,
+        private readonly ExtensionMap $extensionMap,
+        private readonly ConfigSchemaData $configSchemaData
+    ) {
+    }
+
+    public function getKey(): string
+    {
+        return 'phpstan-drupal';
+    }
+
+    public function getHash(): string
+    {
+        $extensions = [];
+        $groups = [
+            'module' => $this->extensionMap->getModules(),
+            'theme' => $this->extensionMap->getThemes(),
+            'profile' => $this->extensionMap->getProfiles(),
+        ];
+        foreach ($groups as $type => $group) {
+            ksort($group);
+            foreach ($group as $name => $extension) {
+                $infoPath = $extension->getAbsolutePath() . DIRECTORY_SEPARATOR . $extension->getFilename();
+                $extensions[$type][$name] = [$infoPath, $this->hashFile($infoPath)];
+            }
+        }
+
+        $services = [];
+        $serviceYamlPaths = $this->serviceMap->getServiceYamlPaths();
+        ksort($serviceYamlPaths);
+        foreach ($serviceYamlPaths as $path) {
+            $services[$path] = $this->hashFile($path);
+        }
+
+        $schemas = [];
+        $schemaDirectories = $this->configSchemaData->getSchemaDirectories();
+        sort($schemaDirectories);
+        foreach ($schemaDirectories as $directory) {
+            $files = glob($directory . '/*.schema.yml');
+            if ($files === false) {
+                continue;
+            }
+            foreach ($files as $file) {
+                $schemas[$file] = $this->hashFile($file);
+            }
+        }
+
+        return hash('sha256', serialize([
+            'drupal' => class_exists(Drupal::class) ? Drupal::VERSION : 'unknown',
+            'extensions' => $extensions,
+            'services' => $services,
+            'schemas' => $schemas,
+        ]));
+    }
+
+    private function hashFile(string $path): string
+    {
+        $hash = @hash_file('sha256', $path);
+        // A file that disappeared after discovery must still change the hash.
+        return $hash === false ? 'missing' : $hash;
+    }
+}

--- a/src/Drupal/ConfigSchemaData.php
+++ b/src/Drupal/ConfigSchemaData.php
@@ -59,6 +59,14 @@ class ConfigSchemaData
     private static array $fullyValidatable = [];
 
     /**
+     * @return list<string>
+     */
+    public function getSchemaDirectories(): array
+    {
+        return self::$schemaDirectories;
+    }
+
+    /**
      * @param list<string> $schemaDirectories
      */
     public function setSchemaDirectories(array $schemaDirectories): void

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -254,7 +254,7 @@ class DrupalAutoloader
         $this->loadConfigSchemas($container);
 
         $service_map = $container->getByType(ServiceMap::class);
-        $service_map->setDrupalServices($this->serviceMap);
+        $service_map->setDrupalServices($this->serviceMap, $this->serviceYamls);
 
         $extension_map = $container->getByType(ExtensionMap::class);
         $extension_map->setExtensions($this->moduleData, $this->themeData, $profiles);

--- a/src/Drupal/ServiceMap.php
+++ b/src/Drupal/ServiceMap.php
@@ -10,6 +10,9 @@ class ServiceMap
     /** @var DrupalServiceDefinition[] */
     private static $services = [];
 
+    /** @var array<string, string> */
+    private static array $serviceYamlPaths = [];
+
     public function getService(string $id): ?DrupalServiceDefinition
     {
         return self::$services[$id] ?? null;
@@ -23,9 +26,26 @@ class ServiceMap
         return self::$services;
     }
 
-    public function setDrupalServices(array $drupalServices): void
+    /**
+     * Absolute paths of the services.yml files the map was built from.
+     *
+     * @return array<string, string>
+     *   Paths keyed by the providing extension name.
+     */
+    public function getServiceYamlPaths(): array
+    {
+        return self::$serviceYamlPaths;
+    }
+
+    /**
+     * @param array<string, string> $serviceYamlPaths
+     *   Absolute paths of the consumed services.yml files, keyed by the
+     *   providing extension name.
+     */
+    public function setDrupalServices(array $drupalServices, array $serviceYamlPaths = []): void
     {
         self::$services = [];
+        self::$serviceYamlPaths = $serviceYamlPaths;
         $decorators = [];
 
         foreach ($drupalServices as $serviceId => $serviceDefinition) {

--- a/tests/src/BootstrapResultCacheMetaExtensionTest.php
+++ b/tests/src/BootstrapResultCacheMetaExtensionTest.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests;
+
+use mglaman\PHPStanDrupal\Drupal\BootstrapResultCacheMetaExtension;
+use mglaman\PHPStanDrupal\Drupal\ConfigSchemaData;
+use mglaman\PHPStanDrupal\Drupal\Extension;
+use mglaman\PHPStanDrupal\Drupal\ExtensionMap;
+use mglaman\PHPStanDrupal\Drupal\ServiceMap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The seeded ServiceMap, ExtensionMap, and ConfigSchemaData state is static,
+ * so each test runs in its own process to avoid clobbering the
+ * bootstrap-populated state other test classes depend on.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class BootstrapResultCacheMetaExtensionTest extends TestCase
+{
+
+    private string $fixtureRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $fixtureRoot = \realpath(__DIR__ . '/../fixtures/drupal');
+        self::assertNotFalse($fixtureRoot);
+        $this->fixtureRoot = $fixtureRoot;
+    }
+
+    private function createExtension(): BootstrapResultCacheMetaExtension
+    {
+        return new BootstrapResultCacheMetaExtension(
+            new ServiceMap(),
+            new ExtensionMap(),
+            new ConfigSchemaData()
+        );
+    }
+
+    /**
+     * The ServiceMap, ExtensionMap, and ConfigSchemaData state is static, so
+     * every test must seed all of it to be independent of test order.
+     *
+     * @param array<int, Extension> $modules
+     * @param array<string, string> $serviceYamlPaths
+     * @param list<string> $schemaDirectories
+     */
+    private function seed(array $modules = [], array $serviceYamlPaths = [], array $schemaDirectories = []): void
+    {
+        (new ServiceMap())->setDrupalServices([], $serviceYamlPaths);
+        (new ExtensionMap())->setExtensions($modules, [], []);
+        (new ConfigSchemaData())->setSchemaDirectories($schemaDirectories);
+    }
+
+    private function createModule(string $name): Extension
+    {
+        return new Extension(
+            $this->fixtureRoot,
+            'module',
+            "modules/$name/$name.info.yml",
+            "$name.module"
+        );
+    }
+
+    public function testKey(): void
+    {
+        self::assertSame('phpstan-drupal', $this->createExtension()->getKey());
+    }
+
+    public function testHashIsDeterministic(): void
+    {
+        $this->seed([$this->createModule('phpstan_fixtures')]);
+        $extension = $this->createExtension();
+        self::assertSame($extension->getHash(), $extension->getHash());
+    }
+
+    public function testExtensionListChangesHash(): void
+    {
+        $this->seed([$this->createModule('phpstan_fixtures')]);
+        $hashBefore = $this->createExtension()->getHash();
+
+        $this->seed([
+            $this->createModule('phpstan_fixtures'),
+            $this->createModule('module_with_dependencies'),
+        ]);
+        $hashAfter = $this->createExtension()->getHash();
+
+        self::assertNotSame($hashBefore, $hashAfter);
+    }
+
+    public function testServicesYmlContentChangesHash(): void
+    {
+        $servicesYml = \tempnam(\sys_get_temp_dir(), 'phpstan_drupal_test');
+        self::assertNotFalse($servicesYml);
+        \file_put_contents($servicesYml, "services:\n  foo.bar:\n    class: Drupal\Foo\Bar\n");
+
+        $this->seed([], ['test_module' => $servicesYml]);
+        $hashBefore = $this->createExtension()->getHash();
+
+        \file_put_contents($servicesYml, "services:\n  foo.baz:\n    class: Drupal\Foo\Baz\n", FILE_APPEND);
+        $hashAfter = $this->createExtension()->getHash();
+        \unlink($servicesYml);
+
+        self::assertNotSame($hashBefore, $hashAfter);
+    }
+
+    public function testMissingFileStillProducesDeterministicHash(): void
+    {
+        $this->seed([], ['test_module' => '/nonexistent/test_module.services.yml']);
+        $extension = $this->createExtension();
+        $hashWithMissingFile = $extension->getHash();
+        self::assertSame($hashWithMissingFile, $extension->getHash());
+
+        $this->seed([], []);
+        self::assertNotSame($hashWithMissingFile, $this->createExtension()->getHash());
+    }
+
+    public function testSchemaDirectoryChangesHash(): void
+    {
+        $schemaDir = \sys_get_temp_dir() . '/phpstan_drupal_schema_' . \uniqid();
+        \mkdir($schemaDir);
+        \file_put_contents($schemaDir . '/test.schema.yml', "test.settings:\n  type: config_object\n");
+
+        $this->seed([], [], []);
+        $hashBefore = $this->createExtension()->getHash();
+
+        $this->seed([], [], [$schemaDir]);
+        $hashAfter = $this->createExtension()->getHash();
+
+        \unlink($schemaDir . '/test.schema.yml');
+        \rmdir($schemaDir);
+
+        self::assertNotSame($hashBefore, $hashAfter);
+    }
+}


### PR DESCRIPTION
Part 9 of 9 in the legacy-code audit stack. The highest-impact finding from the audit: PHPStan's result cache never invalidated when the analyzed Drupal site changed.

## Why

PHPStan hashes its bootstrap files, but knows nothing about the Drupal extensions, `services.yml` files, and config schemas our bootstrap discovers. Enabling a module, editing a `services.yml`, or upgrading core silently reused stale analysis results until the user ran `--no-result-cache` or the cache expired.

## What changed

`BootstrapResultCacheMetaExtension` implements PHPStan's `ResultCacheMetaExtension` (`phpstan.resultCacheMetaExtension` tag). Its hash covers:

- the discovered extension inventory — info-file path and content per module/theme/profile,
- every consumed `services.yml` (path and content),
- all `*.schema.yml` files in the collected schema directories,
- `\Drupal::VERSION`, which catches tarball core upgrades (composer-managed upgrades are already covered by PHPStan's own composer.lock hashing).

Any change invalidates the whole result cache. The hashing runs once per analysis over a few hundred small YAML files — well under 50ms. Discovered PHP files are deliberately not hashed; PHPStan hashes analyzed files itself.

To feed the extension, `ServiceMap::setDrupalServices()` gains an optional second parameter recording the consumed yml paths (backwards compatible), and `ConfigSchemaData` exposes its schema directories.

## Testing

New unit tests assert the hash is deterministic, and changes when the extension list, a services.yml's content, or a schema directory changes. The tests run in separate processes because the underlying state is static. Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


