### PR TITLE
Deny uses of AccessResult in boolean context.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -34,6 +34,7 @@ parameters:
 			testClassSuffixNameRule: true
 			dependencySerializationTraitPropertyRule: true
 			accessResultConditionRule: true
+			accessResultBooleanContextRule: true
 			classExtendsInternalClassRule: true
 			pluginManagerInspectionRule: false
 			cacheableDependencyRule: true
@@ -278,6 +279,7 @@ parametersSchema:
 			testClassSuffixNameRule: boolean()
 			dependencySerializationTraitPropertyRule: boolean()
 			accessResultConditionRule: boolean()
+			accessResultBooleanContextRule: boolean()
 			classExtendsInternalClassRule: boolean()
 			pluginManagerInspectionRule: boolean()
 			cacheableDependencyRule: boolean()

--- a/rules.neon
+++ b/rules.neon
@@ -24,6 +24,8 @@ conditionalTags:
 		phpstan.rules.rule: %drupal.rules.dependencySerializationTraitPropertyRule%
 	mglaman\PHPStanDrupal\Rules\Drupal\AccessResultConditionRule:
 		phpstan.rules.rule: %drupal.rules.accessResultConditionRule%
+	mglaman\PHPStanDrupal\Rules\Drupal\AccessResultBooleanContextRule:
+		phpstan.rules.rule: %drupal.rules.accessResultBooleanContextRule%
 	mglaman\PHPStanDrupal\Rules\Classes\ClassExtendsInternalClassRule:
 		phpstan.rules.rule: %drupal.rules.classExtendsInternalClassRule%
 	mglaman\PHPStanDrupal\Rules\Classes\PluginManagerInspectionRule:
@@ -56,6 +58,10 @@ services:
 		class: mglaman\PHPStanDrupal\Rules\Drupal\DependencySerializationTraitPropertyRule
 	-
 		class: mglaman\PHPStanDrupal\Rules\Drupal\AccessResultConditionRule
+		arguments:
+			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+	-
+		class: mglaman\PHPStanDrupal\Rules\Drupal\AccessResultBooleanContextRule
 		arguments:
 			treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
 	-

--- a/src/Rules/Drupal/AccessResultBooleanContextRule.php
+++ b/src/Rules/Drupal/AccessResultBooleanContextRule.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Rules\Drupal;
+
+use Drupal\Core\Access\AccessResultInterface;
+use PhpParser\Node;
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
+use PhpParser\Node\Expr\BooleanNot;
+use PhpParser\Node\Expr\Cast\Bool_;
+use PhpParser\Node\Expr\Empty_;
+use PhpParser\Node\Expr\Ternary;
+use PhpParser\Node\Stmt\Do_;
+use PhpParser\Node\Stmt\ElseIf_;
+use PhpParser\Node\Stmt\If_;
+use PhpParser\Node\Stmt\While_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Reports access results that are evaluated in a boolean context.
+ *
+ * An AccessResultInterface object is always truthy, so negating it or using it
+ * as a condition never reflects whether access was granted. The result must be
+ * inspected with ->isAllowed(), ->isForbidden(), or ->isNeutral() instead.
+ *
+ * @implements Rule<Node>
+ */
+final class AccessResultBooleanContextRule implements Rule
+{
+
+    /** @var bool */
+    private $treatPhpDocTypesAsCertain;
+
+    /**
+     * @param bool $treatPhpDocTypesAsCertain
+     */
+    public function __construct($treatPhpDocTypesAsCertain)
+    {
+        $this->treatPhpDocTypesAsCertain = $treatPhpDocTypesAsCertain;
+    }
+
+    public function getNodeType(): string
+    {
+        return Node::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $accessResultType = new ObjectType(AccessResultInterface::class);
+        $errors = [];
+        foreach ($this->getConditionExpressions($node) as $expr) {
+            $type = $this->treatPhpDocTypesAsCertain ? $scope->getType($expr) : $scope->getNativeType($expr);
+            if (!$accessResultType->isSuperTypeOf($type)->yes()) {
+                continue;
+            }
+            $errors[] = RuleErrorBuilder::message(
+                'Access result used in a boolean context. An access result object is always truthy; use ->isAllowed(), ->isForbidden(), or ->isNeutral() to inspect it.'
+            )->identifier('drupal.accessResultBoolean')->line($expr->getStartLine())->build();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Returns the expressions a node evaluates for truthiness.
+     *
+     * @return \PhpParser\Node\Expr[]
+     */
+    private function getConditionExpressions(Node $node): array
+    {
+        switch (true) {
+            case $node instanceof BooleanNot:
+            case $node instanceof Bool_:
+            case $node instanceof Empty_:
+                return [$node->expr];
+            case $node instanceof If_:
+            case $node instanceof ElseIf_:
+            case $node instanceof While_:
+            case $node instanceof Do_:
+            case $node instanceof Ternary:
+                return [$node->cond];
+            case $node instanceof BooleanAnd:
+            case $node instanceof BooleanOr:
+            case $node instanceof LogicalAnd:
+            case $node instanceof LogicalOr:
+                return [$node->left, $node->right];
+            default:
+                return [];
+        }
+    }
+}

--- a/tests/src/Rules/AccessResultBooleanContextRuleTest.php
+++ b/tests/src/Rules/AccessResultBooleanContextRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Rules;
+
+use mglaman\PHPStanDrupal\Rules\Drupal\AccessResultBooleanContextRule;
+use mglaman\PHPStanDrupal\Tests\DrupalRuleTestCase;
+use PHPStan\Rules\Rule;
+
+final class AccessResultBooleanContextRuleTest extends DrupalRuleTestCase
+{
+
+    protected function getRule(): Rule
+    {
+        return new AccessResultBooleanContextRule(true);
+    }
+
+    public function testRule(): void
+    {
+        $message = 'Access result used in a boolean context. An access result object is always truthy; use ->isAllowed(), ->isForbidden(), or ->isNeutral() to inspect it.';
+        $this->analyse(
+            [__DIR__.'/data/access-result-boolean-context.php'],
+            [
+                [$message, 17],
+                [$message, 19],
+                [$message, 21],
+                [$message, 22],
+                [$message, 22],
+                [$message, 23],
+                [$message, 23],
+                [$message, 24],
+                [$message, 25],
+                [$message, 28],
+            ]
+        );
+    }
+}

--- a/tests/src/Rules/data/access-result-boolean-context.php
+++ b/tests/src/Rules/data/access-result-boolean-context.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AccessResultBooleanContext;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+
+function returnsAccessResult(bool $condition): AccessResultInterface
+{
+    return AccessResult::allowedIf($condition);
+}
+
+function test(AccessResultInterface $access): void
+{
+    if (!$access) {
+    }
+    if ($access) {
+    }
+    $cast = (bool) $access;
+    $and = $access && returnsAccessResult(true);
+    $or = returnsAccessResult(false) || $access;
+    $ternary = $access ? 'a' : 'b';
+    while ($access) {
+        break;
+    }
+    if (empty($access)) {
+    }
+    // Valid usages below must not be reported.
+    if (!$access->isAllowed()) {
+    }
+    if ($access->isForbidden()) {
+    }
+    $ok = $access->isAllowed() && $access->isNeutral();
+}


### PR DESCRIPTION
This denies use of AccessResultInterface in boolean context: `if ($result)` is always true. It must be `if ($result->isAllowed()` or the like. Further examples are in tests/src/Rules/data/access-result-boolean-context.php.