### PR TITLE
Ignore environment-dependent instanceof.alwaysTrue in getChildren()

### DIFF
--- a/src/Drupal/RecursiveExtensionFilterIterator.php
+++ b/src/Drupal/RecursiveExtensionFilterIterator.php
@@ -83,6 +83,13 @@ class RecursiveExtensionFilterIterator extends RecursiveFilterIterator
     public function getChildren(): RecursiveFilterIterator
     {
         $filter = parent::getChildren();
+        // Depending on the PHP version PHPStan runs under, the SPL stub
+        // types getChildren() as static (making this check always true) or
+        // as the base RecursiveFilterIterator (making it a real narrowing).
+        // Keep the check for the latter and ignore the always-true report
+        // of the former; reportUnmatchedIgnoredErrors is disabled, so the
+        // ignore is inert where the report does not occur.
+        // @phpstan-ignore instanceof.alwaysTrue
         if ($filter instanceof self) {
             // Pass on the blacklist.
             $filter->blacklist = $this->blacklist;


### PR DESCRIPTION
Part 1 of 9 in the legacy-code audit stack. Fixes the lint failure currently breaking CI on main, so every layer above starts green.

## What changed

CI's lint job reports the `instanceof self` check in `RecursiveExtensionFilterIterator::getChildren()` as always true because its SPL stub types `parent::getChildren()` as `static`, while other environments (including local runs on the same PHPStan 2.2.5) type it as the base `RecursiveFilterIterator`, where the check is a real narrowing. The check must stay for the latter interpretation, so the always-true report is suppressed with a documented inline ignore. `reportUnmatchedIgnoredErrors: false` keeps the ignore inert where the report does not occur.

## Testing

`phpstan analyze` passes both locally (where the report never fired) and in CI (where it did). This same failure was breaking main's lint — merging this fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)