### PR TITLE
Harden include-loading rules against masked failures

### DIFF
--- a/src/Rules/Drupal/LoadIncludeBase.php
+++ b/src/Rules/Drupal/LoadIncludeBase.php
@@ -35,6 +35,11 @@ abstract class LoadIncludeBase implements Rule
         return null;
     }
 
+    /**
+     * @return array{string, string}|array{false, false}
+     *   The module name and file name, or [false, false] when either could
+     *   not be resolved to a constant string.
+     */
     protected function parseLoadIncludeArgs(Node\Arg $module, Node\Arg $type, ?Node\Arg $name, Scope $scope): array
     {
         $moduleName = $this->getStringArgValue($module->value, $scope);

--- a/src/Rules/Drupal/LoadIncludes.php
+++ b/src/Rules/Drupal/LoadIncludes.php
@@ -42,54 +42,59 @@ class LoadIncludes extends LoadIncludeBase
             return [];
         }
 
-        try {
-            // Try to invoke it similarly as the module handler itself.
-            [$moduleName, $filename] = $this->parseLoadIncludeArgs($args[0], $args[1], $args[2] ?? null, $scope);
-            if (!$moduleName && !$filename) {
-                // Couldn't determine module- nor file-name, most probably
-                // because it's a variable. Nothing to load, bail now.
-                return [];
-            }
-            $module = $this->extensionMap->getModule($moduleName);
-            if ($module === null) {
-                return [
-                    RuleErrorBuilder::message(sprintf(
-                        'File %s could not be loaded from %s::loadInclude because %s module is not found.',
-                        $filename,
-                        ModuleHandlerInterface::class,
-                        $moduleName
-                    ))
-                    ->line($node->getStartLine())
-                    ->identifier('loadIncludes.moduleNotFound')
-                    ->build()
-                ];
-            }
-
-            $file = $module->getAbsolutePath() . DIRECTORY_SEPARATOR . $filename;
-            if (is_file($file)) {
-                require_once $file;
-                return [];
-            }
+        // Try to invoke it similarly as the module handler itself.
+        [$moduleName, $filename] = $this->parseLoadIncludeArgs($args[0], $args[1], $args[2] ?? null, $scope);
+        if ($moduleName === false || $filename === false) {
+            // Couldn't determine module- nor file-name, most probably
+            // because it's a variable. Nothing to load, bail now.
+            return [];
+        }
+        $module = $this->extensionMap->getModule($moduleName);
+        if ($module === null) {
             return [
                 RuleErrorBuilder::message(sprintf(
-                    'File %s could not be loaded from %s::loadInclude',
-                    $module->getPath() . '/' . $filename,
-                    ModuleHandlerInterface::class
+                    'File %s could not be loaded from %s::loadInclude because %s module is not found.',
+                    $filename,
+                    ModuleHandlerInterface::class,
+                    $moduleName
                 ))
                 ->line($node->getStartLine())
-                ->identifier('loadIncludes.fileNotLoadable')
-                ->build()
-            ];
-        } catch (Throwable $e) {
-            return [
-                RuleErrorBuilder::message(sprintf(
-                    'A file could not be loaded from %s::loadInclude',
-                    ModuleHandlerInterface::class
-                ))
-                ->line($node->getStartLine())
-                ->identifier('loadIncludes.fileNotLoadable')
+                ->identifier('loadIncludes.moduleNotFound')
                 ->build()
             ];
         }
+
+        $file = $module->getAbsolutePath() . DIRECTORY_SEPARATOR . $filename;
+        if (is_file($file)) {
+            try {
+                // Load the include so its symbols are available for the rest
+                // of the analysis, mirroring what loadInclude() does at
+                // runtime. Only the require itself is guarded: a broken
+                // include must not crash the analysis, but PHPStan's own
+                // exceptions elsewhere must propagate.
+                require_once $file;
+            } catch (Throwable $e) {
+                return [
+                    RuleErrorBuilder::message(sprintf(
+                        'A file could not be loaded from %s::loadInclude',
+                        ModuleHandlerInterface::class
+                    ))
+                    ->line($node->getStartLine())
+                    ->identifier('loadIncludes.fileNotLoadable')
+                    ->build()
+                ];
+            }
+            return [];
+        }
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'File %s could not be loaded from %s::loadInclude',
+                $module->getPath() . '/' . $filename,
+                ModuleHandlerInterface::class
+            ))
+            ->line($node->getStartLine())
+            ->identifier('loadIncludes.fileNotLoadable')
+            ->build()
+        ];
     }
 }

--- a/src/Rules/Drupal/ModuleLoadInclude.php
+++ b/src/Rules/Drupal/ModuleLoadInclude.php
@@ -41,43 +41,53 @@ class ModuleLoadInclude extends LoadIncludeBase
             return [];
         }
 
-        try {
-            // Try to invoke it similarly as the module handler itself.
-            [$moduleName, $filename] = $this->parseLoadIncludeArgs($args[1], $args[0], $args[2] ?? null, $scope);
-            $module = $this->extensionMap->getModule($moduleName);
-            if ($module === null) {
-                return [
-                    RuleErrorBuilder::message(sprintf(
-                        'File %s could not be loaded from module_load_include because %s module is not found.',
-                        $filename,
-                        $moduleName
-                    ))
-                    ->line($node->getStartLine())
-                    ->identifier('moduleLoadInclude.moduleNotFound')
-                    ->build()
-                ];
-            }
-            $file = $module->getAbsolutePath() . DIRECTORY_SEPARATOR . $filename;
-            if (is_file($file)) {
-                require_once $file;
-                return [];
-            }
+        // Try to invoke it similarly as the module handler itself.
+        [$moduleName, $filename] = $this->parseLoadIncludeArgs($args[1], $args[0], $args[2] ?? null, $scope);
+        if ($moduleName === false || $filename === false) {
+            // Couldn't determine module- nor file-name, most probably
+            // because it's a variable. Nothing to load, bail now.
+            return [];
+        }
+        $module = $this->extensionMap->getModule($moduleName);
+        if ($module === null) {
             return [
                 RuleErrorBuilder::message(sprintf(
-                    'File %s could not be loaded from module_load_include.',
-                    $module->getPath() . '/' . $filename
+                    'File %s could not be loaded from module_load_include because %s module is not found.',
+                    $filename,
+                    $moduleName
                 ))
                 ->line($node->getStartLine())
-                ->identifier('moduleLoadInclude.moduleNotLoadable')
-                ->build()
-            ];
-        } catch (Throwable $e) {
-            return [
-                RuleErrorBuilder::message('A file could not be loaded from module_load_include')
-                ->line($node->getStartLine())
-                ->identifier('moduleLoadInclude.moduleNotLoadable')
+                ->identifier('moduleLoadInclude.moduleNotFound')
                 ->build()
             ];
         }
+        $file = $module->getAbsolutePath() . DIRECTORY_SEPARATOR . $filename;
+        if (is_file($file)) {
+            try {
+                // Load the include so its symbols are available for the rest
+                // of the analysis, mirroring what module_load_include() does
+                // at runtime. Only the require itself is guarded: a broken
+                // include must not crash the analysis, but PHPStan's own
+                // exceptions elsewhere must propagate.
+                require_once $file;
+            } catch (Throwable $e) {
+                return [
+                    RuleErrorBuilder::message('A file could not be loaded from module_load_include')
+                    ->line($node->getStartLine())
+                    ->identifier('moduleLoadInclude.moduleNotLoadable')
+                    ->build()
+                ];
+            }
+            return [];
+        }
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'File %s could not be loaded from module_load_include.',
+                $module->getPath() . '/' . $filename
+            ))
+            ->line($node->getStartLine())
+            ->identifier('moduleLoadInclude.moduleNotLoadable')
+            ->build()
+        ];
     }
 }


### PR DESCRIPTION
Part 3 of 9 in the legacy-code audit stack (on top of #1026).

## What changed

`LoadIncludes` and `ModuleLoadInclude` wrapped their entire rule body in `catch (Throwable)`, so PHPStan's own internal exceptions were swallowed and reported to users as "file could not be loaded". The catch now wraps only the `require_once` itself, and the intentional load-the-include side effect is documented in place.

`ModuleLoadInclude` was also missing the non-constant-args guard that `LoadIncludes` has, so a non-literal module name interpolated `false` into its error message. The shared `parseLoadIncludeArgs()` sentinel return shape is now documented on the base class — the missing annotation is what let the two rules diverge unnoticed.

## Testing

Existing LoadIncludes/ModuleLoadInclude rule tests cover the reported messages; full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)