### PR TITLE
Keep ExtensionDiscovery::sort() consistent for extensions under unknown profile directories

### DIFF
--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -299,6 +299,11 @@ class ExtensionDiscovery
                         continue 2;
                     }
                 }
+                // The extension lives under a profiles directory that is not
+                // a known profile directory. Every key must be present in
+                // both arrays or array_multisort() fails on unequal sizes.
+                $origins[$key] = self::ORIGIN_PROFILE;
+                $profiles[$key] = null;
             }
         }
         // Now sort the extensions by origin and installation profile(s).

--- a/tests/src/Drupal/ExtensionDiscoveryTest.php
+++ b/tests/src/Drupal/ExtensionDiscoveryTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace mglaman\PHPStanDrupal\Tests\Drupal;
+
+use mglaman\PHPStanDrupal\Drupal\Extension;
+use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
+use PHPUnit\Framework\TestCase;
+
+final class ExtensionDiscoveryTest extends TestCase
+{
+
+    /**
+     * Extensions under an unknown profiles directory must still sort.
+     *
+     * scan() filters these out before sorting, but sort() is protected and
+     * must not leave holes in the arrays it hands to array_multisort().
+     */
+    public function testSortHandlesExtensionsUnderUnknownProfileDirectory(): void
+    {
+        $root = __DIR__ . '/../../fixtures/drupal';
+        $discovery = new class($root) extends ExtensionDiscovery {
+            /**
+             * @param \mglaman\PHPStanDrupal\Drupal\Extension[] $files
+             * @param array<string, int> $weights
+             *
+             * @return \mglaman\PHPStanDrupal\Drupal\Extension[]
+             */
+            public function sortForTest(array $files, array $weights): array
+            {
+                return $this->sort($files, $weights);
+            }
+        };
+        $discovery->setProfileDirectories(['core/profiles/standard']);
+
+        $core = new Extension($root, 'module', 'core/modules/node/node.info.yml');
+        $core->subpath = 'modules/node';
+        $core->origin = 'core';
+
+        $orphan = new Extension($root, 'module', 'profiles/not_a_profile/modules/orphan/orphan.info.yml');
+        $orphan->subpath = 'profiles/not_a_profile/modules/orphan';
+        $orphan->origin = '';
+
+        $custom = new Extension($root, 'module', 'modules/custom/custom.info.yml');
+        $custom->subpath = 'modules/custom';
+        $custom->origin = '';
+
+        $sorted = $discovery->sortForTest(
+            ['custom' => $custom, 'orphan' => $orphan, 'node' => $core],
+            ['core' => 0, '' => 3]
+        );
+
+        self::assertSame(['node', 'orphan', 'custom'], array_keys($sorted));
+    }
+}


### PR DESCRIPTION
Part 4 of 10 in the legacy-code audit stack (on top of #1034). Hardening in `ExtensionDiscovery::sort()`, split out of the original latent-fixes PR so it can be reviewed on its own. The remaining dead-code cleanups moved to the next PR in the stack.

## What changed

An extension under a `profiles/` directory that does not match any known profile directory fell through the `else` branch in `sort()` without a matching entry in the `$origins` and `$profiles` arrays. `array_multisort()` then threw `ValueError: Array sizes are inconsistent`. The extension now gets `ORIGIN_PROFILE` with no profile weight, so every key is present in both arrays.

## Is this reachable?

Not through `scan()` today. `filterByProfileDirectories()` runs first and drops the same extensions using the same predicate, so users cannot hit this in practice. `sort()` is protected on a non-final class, though, and it should not depend on a sibling method having already filtered its input. Reviewed as hardening, not as a user-visible crash fix. No release note needed.

## Testing

New `ExtensionDiscoveryTest` calls `sort()` through a subclass with an extension under an unknown profile directory. It fails on `main` with the `ValueError` and passes with this change. Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
