### PR TITLE
Fix module sort comparator and drop Drupal 8/9 dead code in autoloader

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -25,8 +25,8 @@ use function in_array;
 use function is_array;
 use function is_dir;
 use function is_string;
+use function str_contains;
 use function str_replace;
-use function strpos;
 use function strtr;
 use function trigger_error;
 use function ucwords;
@@ -121,12 +121,13 @@ class DrupalAutoloader
         $extensionDiscovery->setProfileDirectories($profile_directories);
 
         $this->moduleData = array_merge($extensionDiscovery->scan('module'), $profiles);
-        // Sort test extensions after regular ones so that their namespaces
-        // and services do not take precedence during registration.
+        // Load test extensions after regular ones. Test modules stub functions
+        // from their parent module behind function_exists() guards, so if the
+        // test module's .module file loads first the parent's unconditional
+        // declaration is a compile error that loadAndCatchErrors() cannot
+        // intercept.
         usort($this->moduleData, static function (Extension $a, Extension $b): int {
-            $aIsTest = strpos($a->getName(), '_test') !== false ? 1 : 0;
-            $bIsTest = strpos($b->getName(), '_test') !== false ? 1 : 0;
-            return $aIsTest <=> $bIsTest;
+            return str_contains($a->getName(), '_test') <=> str_contains($b->getName(), '_test');
         });
         $this->themeData = $extensionDiscovery->scan('theme');
         $this->addCoreTestNamespaces();

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -6,11 +6,9 @@ use Composer\Autoload\ClassLoader;
 use Drupal\Component\DependencyInjection\Container as DrupalContainer;
 use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
 use Drupal\Core\DrupalKernelInterface;
-use Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter;
 use DrupalFinder\DrupalFinderComposerRuntime;
 use Drush\Drush;
 use PHPStan\DependencyInjection\Container;
-use PHPUnit\Framework\Test;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -24,7 +22,6 @@ use function class_exists;
 use function dirname;
 use function file_exists;
 use function in_array;
-use function interface_exists;
 use function is_array;
 use function is_dir;
 use function is_string;
@@ -124,8 +121,12 @@ class DrupalAutoloader
         $extensionDiscovery->setProfileDirectories($profile_directories);
 
         $this->moduleData = array_merge($extensionDiscovery->scan('module'), $profiles);
-        usort($this->moduleData, static function (Extension $a, Extension $b) {
-            return strpos($a->getName(), '_test') !== false ? 10 : 0;
+        // Sort test extensions after regular ones so that their namespaces
+        // and services do not take precedence during registration.
+        usort($this->moduleData, static function (Extension $a, Extension $b): int {
+            $aIsTest = strpos($a->getName(), '_test') !== false ? 1 : 0;
+            $bIsTest = strpos($b->getName(), '_test') !== false ? 1 : 0;
+            return $aIsTest <=> $bIsTest;
         });
         $this->themeData = $extensionDiscovery->scan('theme');
         $this->addCoreTestNamespaces();
@@ -193,11 +194,7 @@ class DrupalAutoloader
         if (class_exists(Drush::class)) {
             $reflect = new ReflectionClass(Drush::class);
             if ($reflect->getFileName() !== false) {
-                $levels = 2;
-                if (Drush::getMajorVersion() < 9) {
-                    $levels = 3;
-                }
-                $drushDir = dirname($reflect->getFileName(), $levels);
+                $drushDir = dirname($reflect->getFileName(), 2);
                 foreach (Finder::create()->files()->name('*.inc')->in($drushDir . '/includes') as $file) {
                     require_once $file->getPathname();
                 }
@@ -258,11 +255,6 @@ class DrupalAutoloader
 
         $service_map = $container->getByType(ServiceMap::class);
         $service_map->setDrupalServices($this->serviceMap);
-
-        if (interface_exists(Test::class)
-            && class_exists('Drupal\TestTools\PhpUnitCompatibility\PhpUnit8\ClassWriter')) {
-            ClassWriter::mutateTestBase($this->autoloader);
-        }
 
         $extension_map = $container->getByType(ExtensionMap::class);
         $extension_map->setExtensions($this->moduleData, $this->themeData, $profiles);


### PR DESCRIPTION
Part 5 of 9 in the legacy-code audit stack (on top of #1042).

## What changed

- **Module sort comparator fixed.** The `usort` callback in `DrupalAutoloader` returned 10 or 0 and ignored its second operand, so it was not a valid comparator and the order of test modules was implementation-defined. On PHP 8 it did not sort test modules last at all. Replaced with a valid comparator that reliably loads `_test` extensions after regular ones.
- **Why the sort exists.** Test modules stub functions from their parent module behind `function_exists()` guards. If the test module's `.module` file loads first, the parent's unconditional declaration is a compile error that `loadAndCatchErrors()` cannot intercept. This was the original blazy_test fix from 2019. The comment now says so.
- Removed the Drupal 8/9-only `PhpUnit8\ClassWriter` shim (the class was removed in Drupal 10) and the Drush 8 directory-depth branch (composer requires drush ^11 || ^12 || ^13).

## Known consequence

Service definitions are last-writer-wins by ID. With the ordering now deterministic, a test module that redefines a production service ID always wins in the service map, where before the winner depended on filesystem order. Core's own collisions are against `core.services.yml`, which is processed first regardless, and the pattern is rare in contrib. Tracked as a follow-up together with a path-based test-module check, since `_test` in the name misses test extensions under `tests/` directories and catches real modules like `ab_tests`.

## Testing

Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
