### PR TITLE
EntityRepositoryReturnTypeExtension: Handle non-constant strings (fixes #1040)

### DIFF
--- a/src/Type/EntityRepositoryReturnTypeExtension.php
+++ b/src/Type/EntityRepositoryReturnTypeExtension.php
@@ -77,7 +77,12 @@ final class EntityRepositoryReturnTypeExtension implements DynamicMethodReturnTy
 
         $entityObjectTypes = [];
         $entityIdArg = $scope->getType($methodArgs[0]->value);
-        foreach ($entityIdArg->getConstantStrings() as $constantStringType) {
+
+        $constantStrings = $entityIdArg->getConstantStrings();
+        if (count($constantStrings) === 0) {
+            return $returnType;
+        }
+        foreach ($constantStrings as $constantStringType) {
             $entityObjectTypes[] = $this->entityDataRepository->get($constantStringType->getValue())->getClassType() ?? $returnType;
         }
         $entityTypes = TypeCombinator::union(...$entityObjectTypes);

--- a/src/Type/EntityRepositoryReturnTypeExtension.php
+++ b/src/Type/EntityRepositoryReturnTypeExtension.php
@@ -75,31 +75,38 @@ final class EntityRepositoryReturnTypeExtension implements DynamicMethodReturnTy
             return $scope->getType($methodArgs[0]->value);
         }
 
-        $entityObjectTypes = [];
         $entityIdArg = $scope->getType($methodArgs[0]->value);
+        $returnsArray = $returnType->isArray()->yes();
 
-        $constantStrings = $entityIdArg->getConstantStrings();
-        if (count($constantStrings) === 0) {
+        $resolvedTypes = [];
+        foreach ($entityIdArg->getConstantStrings() as $constantStringType) {
+            $classType = $this->entityDataRepository->get($constantStringType->getValue())->getClassType();
+            if ($classType === null) {
+                // The entity type ID is unknown, so nothing can be narrowed.
+                return $returnType;
+            }
+            $resolvedTypes[] = $returnsArray ? new ArrayType($this->getKeyType($classType), $classType) : $classType;
+        }
+        if ($resolvedTypes === []) {
             return $returnType;
         }
-        foreach ($constantStrings as $constantStringType) {
-            $entityObjectTypes[] = $this->entityDataRepository->get($constantStringType->getValue())->getClassType() ?? $returnType;
-        }
-        $entityTypes = TypeCombinator::union(...$entityObjectTypes);
 
-        if ($returnType->isArray()->no()) {
-            if ($returnType->isNull()->maybe()) {
-                $entityTypes = TypeCombinator::addNull($entityTypes);
-            }
-            return $entityTypes;
+        $resolvedType = TypeCombinator::union(...$resolvedTypes);
+        if ($returnType->isNull()->maybe()) {
+            $resolvedType = TypeCombinator::addNull($resolvedType);
         }
+        return $resolvedType;
+    }
 
-        if ((new ObjectType(ConfigEntityInterface::class))->isSuperTypeOf($entityTypes)->yes()) {
-            $keyType = new StringType();
-        } else {
-            $keyType = new IntegerType();
+    /**
+     * Config entities are keyed by their string ID, content entities by their
+     * integer ID.
+     */
+    private function getKeyType(Type $classType): Type
+    {
+        if ((new ObjectType(ConfigEntityInterface::class))->isSuperTypeOf($classType)->yes()) {
+            return new StringType();
         }
-
-        return new ArrayType($keyType, $entityTypes);
+        return new IntegerType();
     }
 }

--- a/tests/src/Type/data/entity-repository.php
+++ b/tests/src/Type/data/entity-repository.php
@@ -7,6 +7,9 @@ use function PHPStan\Testing\assertType;
 
 $entityRepository = \Drupal::service('entity.repository');
 
+/** @phpstan-var string $someEntityType */
+/** @phpstan-var string|int $someEntityId */
+
 assertType(
     'Drupal\node\Entity\Node|null',
     $entityRepository->loadEntityByUuid('node', '3f205175-04f7-4f57-b48b-9799299252c3')
@@ -15,6 +18,10 @@ assertType(
 assertType(
     'Drupal\Core\Entity\Entity\EntityViewMode|null',
     $entityRepository->loadEntityByConfigTarget('entity_view_mode', 'media.default')
+);
+assertType(
+    'Drupal\Core\Entity\EntityInterface|null',
+    $entityRepository->loadEntityByConfigTarget($nonConstantString, 'media.default')
 );
 
 assertType(
@@ -25,6 +32,10 @@ assertType(
 assertType(
     'Drupal\node\Entity\Node|null',
     $entityRepository->getActive('node', 5)
+);
+assertType(
+    'Drupal\Core\Entity\EntityInterface|null',
+    $entityRepository->getActive($someEntityType, 5)
 );
 
 assertType(
@@ -37,11 +48,24 @@ assertType(
 );
 
 assertType(
+    'array<Drupal\Core\Entity\EntityInterface>',
+    $entityRepository->getActiveMultiple($someEntityType, [$someEntityId])
+);
+
+assertType(
     'Drupal\node\Entity\Node|null',
     $entityRepository->getCanonical('node', 5)
+);
+assertType(
+    'Drupal\Core\Entity\EntityInterface|null',
+    $entityRepository->getCanonical($someEntityType, $someEntityId)
 );
 
 assertType(
     'array<int, Drupal\node\Entity\Node>',
     $entityRepository->getCanonicalMultiple('node', [5])
+);
+assertType(
+    'array<Drupal\Core\Entity\EntityInterface>',
+    $entityRepository->getCanonicalMultiple($someEntityType, [$someEntityId])
 );

--- a/tests/src/Type/data/entity-repository.php
+++ b/tests/src/Type/data/entity-repository.php
@@ -7,8 +7,8 @@ use function PHPStan\Testing\assertType;
 
 $entityRepository = \Drupal::service('entity.repository');
 
-/** @phpstan-var string $someEntityType */
-/** @phpstan-var string|int $someEntityId */
+/** @var string $someEntityType */
+/** @var 'node'|'block' $nodeOrBlock */
 
 assertType(
     'Drupal\node\Entity\Node|null',
@@ -21,7 +21,7 @@ assertType(
 );
 assertType(
     'Drupal\Core\Entity\EntityInterface|null',
-    $entityRepository->loadEntityByConfigTarget($nonConstantString, 'media.default')
+    $entityRepository->loadEntityByConfigTarget($someEntityType, 'media.default')
 );
 
 assertType(
@@ -37,6 +37,14 @@ assertType(
     'Drupal\Core\Entity\EntityInterface|null',
     $entityRepository->getActive($someEntityType, 5)
 );
+assertType(
+    'Drupal\Core\Entity\EntityInterface|null',
+    $entityRepository->getActive('not_an_entity_type', 5)
+);
+assertType(
+    'Drupal\block\Entity\Block|Drupal\node\Entity\Node|null',
+    $entityRepository->getActive($nodeOrBlock, 5)
+);
 
 assertType(
     'array<int, Drupal\node\Entity\Node>',
@@ -49,7 +57,15 @@ assertType(
 
 assertType(
     'array<Drupal\Core\Entity\EntityInterface>',
-    $entityRepository->getActiveMultiple($someEntityType, [$someEntityId])
+    $entityRepository->getActiveMultiple($someEntityType, [5])
+);
+assertType(
+    'array<Drupal\Core\Entity\EntityInterface>',
+    $entityRepository->getActiveMultiple('not_an_entity_type', [5])
+);
+assertType(
+    'array<int|string, Drupal\block\Entity\Block|Drupal\node\Entity\Node>',
+    $entityRepository->getActiveMultiple($nodeOrBlock, [5])
 );
 
 assertType(
@@ -58,7 +74,7 @@ assertType(
 );
 assertType(
     'Drupal\Core\Entity\EntityInterface|null',
-    $entityRepository->getCanonical($someEntityType, $someEntityId)
+    $entityRepository->getCanonical($someEntityType, 5)
 );
 
 assertType(
@@ -67,5 +83,5 @@ assertType(
 );
 assertType(
     'array<Drupal\Core\Entity\EntityInterface>',
-    $entityRepository->getCanonicalMultiple($someEntityType, [$someEntityId])
+    $entityRepository->getCanonicalMultiple($someEntityType, [5])
 );


### PR DESCRIPTION
As noted in mglaman/phpstan-drupal#1040, when `EntityRepositoryInterface::getActive` and friends were passed a non-constant string as the `$entity_type_id` parameter, the involved entity type was inferred as *NEVER*.

This PR fixes the issue by introducing a new guard clause, explicitly checking for no guard clauses being involved, and falling back to a generic return type for the function. It also introduces additional tests, checking that the issue does not reoccur.

Fixes mglaman/phpstan-drupal#1040.