### PR TITLE
Remove dead code and fix exception messages in legacy rules

### DIFF
--- a/src/Drupal/Extension.php
+++ b/src/Drupal/Extension.php
@@ -231,7 +231,7 @@ class Extension
 
         $infoContent = file_get_contents(sprintf('%s/%s', $this->root, $this->getPathname()));
         if (false === $infoContent) {
-            throw new RuntimeException(sprintf('Cannot read "%s', $this->getPathname()));
+            throw new RuntimeException(sprintf('Cannot read "%s"', $this->getPathname()));
         }
 
         return $this->info = Yaml::parse($infoContent);

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -2,11 +2,11 @@
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
-use LogicException;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\ShouldNotHappenException;
 use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\ObjectType;
 use function array_key_exists;
@@ -68,7 +68,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
             return new FieldItemListPropertyReflection($classReflection, $propertyName);
         }
 
-        throw new LogicException($classReflection->getName() . "::$propertyName should be handled earlier.");
+        throw new ShouldNotHappenException($classReflection->getName() . "::$propertyName should be handled earlier.");
     }
 
     public static function classObjectIsSuperOfInterface(string $name, ObjectType $interfaceObject) : IsSuperTypeOfResult

--- a/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
+++ b/src/Rules/Drupal/Coder/DiscouragedFunctionsRule.php
@@ -52,8 +52,6 @@ class DiscouragedFunctionsRule implements Rule
             // Functions which are not available on all
             // PHP builds.
             'fnmatch',
-            // Functions which are a security risk.
-            'eval',
         ];
 
         if (in_array($name, $discouragedFunctions, true)) {

--- a/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
+++ b/src/Rules/Drupal/PluginManager/PluginManagerSetsCacheBackendRule.php
@@ -6,9 +6,6 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\ShouldNotHappenException;
-use PHPStan\Type\Type;
-use function array_map;
 use function count;
 
 /**
@@ -24,7 +21,7 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
     public function processNode(Node $node, Scope $scope): array
     {
         if (!$scope->isInClass()) {
-            throw new ShouldNotHappenException();
+            return [];
         }
 
         if ($scope->isInTrait()) {
@@ -56,15 +53,6 @@ class PluginManagerSetsCacheBackendRule extends AbstractPluginManagerRule
                     continue;
                 }
                 $hasCacheBackendSet = true;
-
-                $cacheKey = array_map(
-                    static fn (Type $type) => $type->getValue(),
-                    $scope->getType($setCacheBackendArgs[1]->value)->getConstantStrings()
-                );
-                if (count($cacheKey) === 0) {
-                    continue;
-                }
-
                 break;
             }
         }


### PR DESCRIPTION
Part 4 of 9 in the legacy-code audit stack (on top of #1034). Dead code and exception-message cleanups surfaced by auditing the oldest code (2018–2019). No user-facing behavior changes and no release note needed.

## What changed

- `Extension::parseInfo()`: add the missing closing quote in the "Cannot read" exception message.
- `EntityFieldsViaMagicReflectionExtension`: throw PHPStan's `ShouldNotHappenException` instead of a bare `LogicException` so the failure surfaces as an internal error with context.
- `PluginManagerSetsCacheBackendRule`: return no errors instead of throwing when outside a class, and delete the `$cacheKey` block. That block computed the constant strings of the cache key argument and then did nothing with them; `$hasCacheBackendSet` was already true before its `continue`, so it was unreachable in effect.
- `DiscouragedFunctionsRule`: drop `'eval'`. It is a language construct, not a function, so it parses as `Expr\Eval_` and never reached this rule's `FuncCall` check.

## Out of scope

- Whether `PluginManagerSetsCacheBackendRule` should require a literal cache key. The dead block looks like an abandoned attempt at that. This PR only removes the unreachable code and does not decide it.
- Flagging `eval` at all. That needs a rule on `Expr\Eval_`, tracked separately if wanted.

## Testing

Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

