### PR TITLE
Resolve every constant entity type ID in getStorage() return type

### DIFF
--- a/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityStorage/EntityStorageDynamicReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\UnionType;
 use function in_array;
 
 class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -56,56 +57,58 @@ class EntityStorageDynamicReturnTypeExtension implements DynamicMethodReturnType
         MethodCall $methodCall,
         Scope $scope
     ): Type {
+        $declaredReturnType = ParametersAcceptorSelector::selectFromArgs(
+            $scope,
+            $methodCall->getArgs(),
+            $methodReflection->getVariants()
+        )->getReturnType();
+
         $callerType = $scope->getType($methodCall->var);
         if (!$callerType->isObject()->yes()) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $methodCall->getArgs(),
-                $methodReflection->getVariants()
-            )->getReturnType();
+            return $declaredReturnType;
         }
 
-        if (!$callerType instanceof EntityStorageType) {
-            $resolvedEntityType = $this->entityDataRepository->resolveFromStorage($callerType);
-            if ($resolvedEntityType === null) {
-                return ParametersAcceptorSelector::selectFromArgs(
-                    $scope,
-                    $methodCall->getArgs(),
-                    $methodReflection->getVariants()
-                )->getReturnType();
+        // A union of storages, such as getStorage($cond ? 'node' : 'user'),
+        // resolves each member on its own so no branch is dropped.
+        if ($callerType instanceof UnionType) {
+            $types = [];
+            foreach ($callerType->getTypes() as $storageType) {
+                $types[] = $this->resolveForStorage($methodReflection, $storageType, $declaredReturnType);
             }
-            $type = $resolvedEntityType->getClassType();
-        } else {
-            $type = $this->entityDataRepository->get($callerType->getEntityTypeId())->getClassType();
+            return TypeCombinator::union(...$types);
         }
 
-        if ($type === null) {
-            return ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $methodCall->getArgs(),
-                $methodReflection->getVariants()
-            )->getReturnType();
+        return $this->resolveForStorage($methodReflection, $callerType, $declaredReturnType);
+    }
+
+    private function resolveForStorage(MethodReflection $methodReflection, Type $storageType, Type $declaredReturnType): Type
+    {
+        if ($storageType instanceof EntityStorageType) {
+            $type = $this->entityDataRepository->get($storageType->getEntityTypeId())->getClassType();
+        } else {
+            $type = $this->entityDataRepository->resolveFromStorage($storageType)?->getClassType();
         }
-        if (in_array($methodReflection->getName(), ['load', 'loadUnchanged'], true)) {
+        if ($type === null) {
+            return $declaredReturnType;
+        }
+
+        $methodName = $methodReflection->getName();
+        if (in_array($methodName, ['load', 'loadUnchanged'], true)) {
             return TypeCombinator::addNull($type);
         }
 
-        if (in_array($methodReflection->getName(), ['loadMultiple', 'loadByProperties'], true)) {
-            if ((new ObjectType(ConfigEntityStorageInterface::class))->isSuperTypeOf($callerType)->yes()) {
+        if (in_array($methodName, ['loadMultiple', 'loadByProperties'], true)) {
+            if ((new ObjectType(ConfigEntityStorageInterface::class))->isSuperTypeOf($storageType)->yes()) {
                 return new ArrayType(new StringType(), $type);
             }
 
             return new ArrayType(new IntegerType(), $type);
         }
 
-        if ($methodReflection->getName() === 'create') {
+        if ($methodName === 'create') {
             return $type;
         }
 
-        return ParametersAcceptorSelector::selectFromArgs(
-            $scope,
-            $methodCall->getArgs(),
-            $methodReflection->getVariants()
-        )->getReturnType();
+        return $declaredReturnType;
     }
 }

--- a/src/Type/EntityStorage/EntityStorageType.php
+++ b/src/Type/EntityStorage/EntityStorageType.php
@@ -5,29 +5,65 @@ declare(strict_types=1);
 namespace mglaman\PHPStanDrupal\Type\EntityStorage;
 
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\IsSuperTypeOfResult;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
 
 class EntityStorageType extends ObjectType
 {
-    /**
-     * @var string
-     */
-    private $entityTypeId;
 
     public function __construct(
-        string $entityTypeId,
+        private readonly string $entityTypeId,
         string $className,
         ?Type $subtractedType = null,
         ?ClassReflection $classReflection = null
     ) {
         parent::__construct($className, $subtractedType, $classReflection);
-
-        $this->entityTypeId = $entityTypeId;
     }
 
     public function getEntityTypeId(): string
     {
         return $this->entityTypeId;
+    }
+
+    /**
+     * Storages for different entity types are distinct even when they share a
+     * class. Without this, a union such as NodeStorage|SqlContentEntityStorage
+     * collapses to the base class and the node branch is lost.
+     */
+    public function isSuperTypeOf(Type $type): IsSuperTypeOfResult
+    {
+        if ($type instanceof self && $type->entityTypeId !== $this->entityTypeId) {
+            return IsSuperTypeOfResult::createNo();
+        }
+
+        return parent::isSuperTypeOf($type);
+    }
+
+    public function equals(Type $type): bool
+    {
+        if ($type instanceof self && $type->entityTypeId !== $this->entityTypeId) {
+            return false;
+        }
+
+        return parent::equals($type);
+    }
+
+    /**
+     * PHPStan keys several caches by the cache-level description, so two
+     * storages sharing a class need distinct descriptions there. User-facing
+     * descriptions are unchanged.
+     */
+    public function describe(VerbosityLevel $level): string
+    {
+        $description = parent::describe($level);
+        // The level factories return singletons, and the level comparison
+        // methods are outside the PHPStan API promise.
+        if ($level === VerbosityLevel::cache()) {
+            return $description . '#' . $this->entityTypeId;
+        }
+
+        return $description;
     }
 }

--- a/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
@@ -4,11 +4,9 @@ namespace mglaman\PHPStanDrupal\Type;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
-use mglaman\PHPStanDrupal\Type\EntityStorage\EntityStorageType;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
-use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -51,25 +49,15 @@ class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMe
             return null;
         }
 
-        $returnType = null;
         $types = [];
         foreach ($constantStrings as $constantString) {
-            $entityTypeId = $constantString->getValue();
-            $storageType = $this->entityDataRepository->get($entityTypeId)->getStorageType();
-            if ($storageType !== null) {
-                $types[] = $storageType;
-                continue;
+            $storageType = $this->entityDataRepository->get($constantString->getValue())->getStorageType();
+            if ($storageType === null) {
+                // An unknown entity type ID. Once one member is unknown the
+                // whole call can only be trusted to the declared return type.
+                return null;
             }
-
-            $returnType ??= ParametersAcceptorSelector::selectFromArgs(
-                $scope,
-                $args,
-                $methodReflection->getVariants()
-            )->getReturnType();
-            $classNames = $returnType->getObjectClassNames();
-            $types[] = count($classNames) === 1
-                ? new EntityStorageType($entityTypeId, $classNames[0])
-                : $returnType;
+            $types[] = $storageType;
         }
         return TypeCombinator::union(...$types);
     }

--- a/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
+++ b/src/Type/EntityTypeManagerGetStorageDynamicReturnTypeExtension.php
@@ -5,13 +5,14 @@ namespace mglaman\PHPStanDrupal\Type;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use mglaman\PHPStanDrupal\Drupal\EntityDataRepository;
 use mglaman\PHPStanDrupal\Type\EntityStorage\EntityStorageType;
-use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use function count;
 
 class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -35,49 +36,41 @@ class EntityTypeManagerGetStorageDynamicReturnTypeExtension implements DynamicMe
         MethodReflection $methodReflection,
         MethodCall $methodCall,
         Scope $scope
-    ): Type {
-        $returnType = ParametersAcceptorSelector::selectFromArgs(
-            $scope,
-            $methodCall->getArgs(),
-            $methodReflection->getVariants()
-        )->getReturnType();
+    ): ?Type {
         if ($methodCall->isFirstClassCallable()) {
-            return $returnType;
+            return null;
         }
         $args = $methodCall->getArgs();
         if (count($args) === 0) {
-            // Calling getStorage() without arguments is invalid, but PHPStan
-            // reports that itself; do not crash the analysis.
-            return $returnType;
+            return null;
         }
 
-        $arg1 = $args[0]->value;
-
-        // @todo handle where the first param is EntityTypeInterface::id()
-        if ($arg1 instanceof MethodCall) {
-            // There may not be much that can be done, since it's a generic EntityTypeInterface.
-            return $returnType;
-        }
-        // @todo handle concat ie: entity_{$display_context}_display for entity_form_display or entity_view_display
-        if ($arg1 instanceof Concat) {
-            return $returnType;
+        $constantStrings = $scope->getType($args[0]->value)->getConstantStrings();
+        if ($constantStrings === []) {
+            // A dynamic entity type ID; fall back to the declared return type.
+            return null;
         }
 
-        $type = $scope->getType($arg1);
-        if (count($type->getConstantStrings()) === 0) {
-            return $returnType;
-        }
+        $returnType = null;
+        $types = [];
+        foreach ($constantStrings as $constantString) {
+            $entityTypeId = $constantString->getValue();
+            $storageType = $this->entityDataRepository->get($entityTypeId)->getStorageType();
+            if ($storageType !== null) {
+                $types[] = $storageType;
+                continue;
+            }
 
-        $entityTypeId = $type->getConstantStrings()[0]->getValue();
-        $storageType = $this->entityDataRepository->get($entityTypeId)->getStorageType();
-        if ($storageType !== null) {
-            return $storageType;
+            $returnType ??= ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $args,
+                $methodReflection->getVariants()
+            )->getReturnType();
+            $classNames = $returnType->getObjectClassNames();
+            $types[] = count($classNames) === 1
+                ? new EntityStorageType($entityTypeId, $classNames[0])
+                : $returnType;
         }
-
-        $classNames = $returnType->getObjectClassNames();
-        if (count($classNames) === 1) {
-            return new EntityStorageType($entityTypeId, $classNames[0]);
-        }
-        return $returnType;
+        return TypeCombinator::union(...$types);
     }
 }

--- a/tests/src/Type/data/entity-type-manager.php
+++ b/tests/src/Type/data/entity-type-manager.php
@@ -31,3 +31,35 @@ $dynamicEntityTypeId = (string) rand(0, 1);
 assertType('Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage($dynamicEntityTypeId));
 $displayContext = $dynamicEntityTypeId;
 assertType('Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage('entity_' . $displayContext . '_display'));
+
+// Chained calls resolve every member of the union, in either operand order.
+$nodeOrUser = $etm->getStorage(rand(0, 1) === 1 ? 'node' : 'user');
+assertType('Drupal\node\Entity\Node|Drupal\user\Entity\User|null', $nodeOrUser->load(1));
+assertType('array<int, Drupal\node\Entity\Node|Drupal\user\Entity\User>', $nodeOrUser->loadMultiple());
+assertType('Drupal\node\Entity\Node|Drupal\user\Entity\User', $nodeOrUser->create([]));
+$userOrNode = $etm->getStorage(rand(0, 1) === 1 ? 'user' : 'node');
+assertType('Drupal\node\Entity\Node|Drupal\user\Entity\User|null', $userOrNode->load(1));
+
+// Storages sharing a class stay distinct instead of collapsing to the base class.
+$nodeOrDefault = $etm->getStorage(rand(0, 1) === 1 ? 'node' : 'content_entity_using_default_storage');
+assertType('Drupal\Core\Entity\Sql\SqlContentEntityStorage|Drupal\node\NodeStorage', $nodeOrDefault);
+assertType('Drupal\node\Entity\Node|Drupal\phpstan_fixtures\Entity\ContentEntityUsingDefaultStorage|null', $nodeOrDefault->load(1));
+// PHPStan numbers members whose names collide; they are different storages.
+$blockOrDefault = $etm->getStorage(rand(0, 1) === 1 ? 'block' : 'config_entity_using_default_storage');
+assertType('Drupal\Core\Config\Entity\ConfigEntityStorage#1|Drupal\Core\Config\Entity\ConfigEntityStorage#2', $blockOrDefault);
+assertType('array<string, Drupal\block\Entity\Block|Drupal\phpstan_fixtures\Entity\ConfigEntityUsingDefaultStorage>', $blockOrDefault->loadMultiple());
+
+// A content and a config storage keep their own key types.
+$nodeOrBlock = $etm->getStorage(rand(0, 1) === 1 ? 'node' : 'block');
+assertType('array<int|string, Drupal\block\Entity\Block|Drupal\node\Entity\Node>', $nodeOrBlock->loadMultiple());
+
+// A known and an unknown entity type ID fall back to the declared return type.
+assertType('Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage(rand(0, 1) === 1 ? 'node' : 'not_an_entity_type'));
+
+// Narrowing a union member still works with the entity-type-aware comparison.
+if ($nodeOrUser instanceof \Drupal\node\NodeStorage) {
+    assertType('Drupal\node\NodeStorage', $nodeOrUser);
+    assertType('Drupal\node\Entity\Node|null', $nodeOrUser->load(1));
+} else {
+    assertType('Drupal\user\UserStorage', $nodeOrUser);
+}

--- a/tests/src/Type/data/entity-type-manager.php
+++ b/tests/src/Type/data/entity-type-manager.php
@@ -17,3 +17,17 @@ assertType('Drupal\Core\Config\Entity\ConfigEntityStorage', $etm->getStorage('co
 assertType('Drupal\phpstan_fixtures\CustomConfigEntityStorage', $etm->getStorage('config_entity_using_custom_storage'));
 const ENTITY_TYPE_ID_NODE = 'node';
 assertType('Drupal\node\NodeStorage', $etm->getStorage(ENTITY_TYPE_ID_NODE));
+
+// A first-class callable must not crash the analysis.
+assertType('Closure(string): Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage(...));
+
+// A union of constant strings resolves each storage, not just the first.
+$unionEntityTypeId = rand(0, 1) === 1 ? 'node' : 'user';
+assertType('Drupal\node\NodeStorage|Drupal\user\UserStorage', $etm->getStorage($unionEntityTypeId));
+assertType('Drupal\Core\Config\Entity\ConfigEntityStorage|Drupal\node\NodeStorage', $etm->getStorage(rand(0, 1) === 1 ? 'node' : 'block'));
+
+// A dynamic entity type ID falls back to the declared return type.
+$dynamicEntityTypeId = (string) rand(0, 1);
+assertType('Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage($dynamicEntityTypeId));
+$displayContext = $dynamicEntityTypeId;
+assertType('Drupal\Core\Entity\EntityStorageInterface', $etm->getStorage('entity_' . $displayContext . '_display'));


### PR DESCRIPTION
Split out of #1027. Type inference improvement, no configuration change.

## What changed

`getStorage()` now resolves **every** constant string in its argument, so `getStorage($cond ? 'node' : 'user')` infers `NodeStorage|UserStorage` instead of silently using the first string. Chained calls on that union return every branch: `->load(1)` is `Node|User|null`, `->loadMultiple()` is `array<int, Node|User>`, and `->create([])` is `Node|User`. Narrowing with `instanceof` on a member still works.

Three pieces make the union sound:

- **`EntityStorageType` compares by entity type ID.** `isSuperTypeOf()`, `equals()`, and the cache-level description treat two storages with different entity type IDs as distinct even when they share a class. Without this, `NodeStorage|SqlContentEntityStorage` collapsed to the base class and the node branch was lost. User-facing descriptions are unchanged.
- **`EntityStorageDynamicReturnTypeExtension` resolves each union member on its own** instead of asking `resolveFromStorage()` for the first registered match.
- **An unknown entity type ID falls back to the declared return type.** `getStorage($cond ? 'node' : 'not_an_entity_type')` is `EntityStorageInterface`. Before, an unknown ID produced an interface type tagged with the ID, which served no consumer.

The `Concat`/`MethodCall` AST sniffing is gone; `Scope::getType()` already folds constant expressions. The extension declares `?Type` and returns `null` to fall back, and no longer computes the declared return type eagerly on every call.

## Known display quirk

Two config entity types that both use `ConfigEntityStorage` describe as `ConfigEntityStorage#1|ConfigEntityStorage#2`. The `#N` suffix is PHPStan's own rendering for union members whose names collide. They are different storages, and the chained result (`Block|ConfigEntityUsingDefaultStorage`) reads normally.

## Testing

Fixture cases cover: the union on `getStorage()` itself, chained `load()`, `loadMultiple()`, and `create()` in both operand orders, two content storages sharing `SqlContentEntityStorage`, two config storages sharing `ConfigEntityStorage`, a content and config storage together (`array<int|string, Block|Node>`), a known plus unknown ID, a fully dynamic ID, a first-class callable, and `instanceof` narrowing. Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
