### PR TITLE
Remove dead code left over from the legacy audit

### DIFF
--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -150,7 +150,7 @@ class DrupalAutoloader
             $module_dir = $this->drupalRoot . '/' . $extension->getPath();
             // Add .install
             if (file_exists($module_dir . '/' . $module_name . '.install')) {
-                $ignored_install_files = ['entity_test', 'entity_test_update', 'update_test_schema'];
+                $ignored_install_files = ['entity_test', 'update_test_schema'];
                 if (!in_array($module_name, $ignored_install_files, true)) {
                     $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.install');
                 }

--- a/src/Drupal/ExtensionDiscovery.php
+++ b/src/Drupal/ExtensionDiscovery.php
@@ -409,13 +409,6 @@ class ExtensionDiscovery
                 continue;
             }
 
-            // This test module has a function declaration that conflicts with another module. Explicitly skip it.
-            // @see https://www.drupal.org/project/drupal/issues/3020142
-            // @todo remove when Drupal core fixed.
-            if ($fileinfo->getBasename('.info.yml') === 'no_transitions_css') {
-                continue;
-            }
-
             // Determine extension type from info file.
             $type = false;
             $file = $fileinfo->openFile('r');

--- a/src/Rules/Classes/PluginManagerInspectionRule.php
+++ b/src/Rules/Classes/PluginManagerInspectionRule.php
@@ -8,10 +8,8 @@ use PhpParser\Node;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use function sprintf;
 use function str_contains;
 use function strtolower;
 
@@ -58,7 +56,7 @@ final class PluginManagerInspectionRule implements Rule
 
         $errors = [];
         if ($this->isYamlDiscovery($originalNode)) {
-            $errors = $this->inspectYamlPluginManager($classReflection, $constructorMethodNode);
+            $errors = $this->inspectYamlPluginManager($constructorMethodNode);
         } else {
             // @todo inspect annotated plugin managers.
         }
@@ -108,38 +106,23 @@ final class PluginManagerInspectionRule implements Rule
     /**
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */
-    private function inspectYamlPluginManager(ClassReflection $classReflection, Node\Stmt\ClassMethod $constructorMethodNode): array
+    private function inspectYamlPluginManager(Node\Stmt\ClassMethod $constructorMethodNode): array
     {
         $errors = [];
-
-        $fqn = $classReflection->getName();
-        if (!$classReflection->hasConstructor()) {
-            return $errors;
-        }
-        $constructor = $classReflection->getConstructor();
-
-        if ($constructor->getDeclaringClass()->getName() !== $fqn) {
-            $errors[] = RuleErrorBuilder::message(
-                sprintf('%s must override __construct if using YAML plugins.', $fqn)
-            )
-                ->identifier('pluginManagerInspection.constructorOverrideMissing')
-                ->build();
-        } else {
-            foreach ($constructorMethodNode->stmts ?? [] as $constructorStmt) {
-                if ($constructorStmt instanceof Node\Stmt\Expression) {
-                    $constructorStmt = $constructorStmt->expr;
-                }
-                if ($constructorStmt instanceof Node\Expr\StaticCall
-                    && $constructorStmt->class instanceof Node\Name
-                    && ((string)$constructorStmt->class === 'parent')
-                    && $constructorStmt->name instanceof Node\Identifier
-                    && $constructorStmt->name->name === '__construct') {
-                    $errors[] = RuleErrorBuilder::message(
-                        'YAML plugin managers should not invoke its parent constructor.'
-                    )
-                        ->identifier('pluginManagerInspection.yamlPluginManagersInvokesParentConstructor')
-                        ->build();
-                }
+        foreach ($constructorMethodNode->stmts ?? [] as $constructorStmt) {
+            if ($constructorStmt instanceof Node\Stmt\Expression) {
+                $constructorStmt = $constructorStmt->expr;
+            }
+            if ($constructorStmt instanceof Node\Expr\StaticCall
+                && $constructorStmt->class instanceof Node\Name
+                && ((string)$constructorStmt->class === 'parent')
+                && $constructorStmt->name instanceof Node\Identifier
+                && $constructorStmt->name->name === '__construct') {
+                $errors[] = RuleErrorBuilder::message(
+                    'YAML plugin managers should not invoke its parent constructor.'
+                )
+                    ->identifier('pluginManagerInspection.yamlPluginManagersInvokesParentConstructor')
+                    ->build();
             }
         }
         return $errors;


### PR DESCRIPTION
Closes #1050. Dead code only, no behavior change and no release-note entry.

## What changed

- **`PluginManagerInspectionRule`**: the "`%s must override __construct if using YAML plugins.`" branch is gone, along with its `pluginManagerInspection.constructorOverrideMissing` identifier. Since #1027 the rule returns early unless the class declares its own constructor, and a class that declares its own constructor is always the declaring class, so the branch could not fire. The YAML inspection now takes only the constructor node it reads.
- **`DrupalAutoloader`**: `entity_test_update` is dropped from the ignored install files. The module has no `.install` file on 10.4.x, 11.3.x, or 11.4.x.
- **`ExtensionDiscovery`**: the `no_transitions_css` skip is gone. The module no longer exists anywhere in core on 10.4.x or later.

Checked each module against the drupal/core tree on GitHub for every supported branch before removing.

## Testing

Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
