### PR TITLE
Give interface-typed entities magic field properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,10 @@ parameters:
             stubFiles: true
 ```
 
-Both options are enabled by default.
+All options are enabled by default.
+
+> [!NOTE]
+> Content entities are registered as PHPStan universal object crates, because `ContentEntityBase::__get()` accepts any property name. With `entityFieldsViaMagicReflection` disabled, a field access such as `$node->field_foo` is typed `mixed` instead of being reported as an undefined property.
 
 #### Class resolver return types
 

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,9 @@
 parameters:
+	# Content entities accept any property name through ContentEntityBase::__get(),
+	# and PHPStan only consults property reflection extensions for an interface
+	# when it is listed here. Covers every interface extending ContentEntityInterface.
+	universalObjectCratesClasses:
+		- Drupal\Core\Entity\ContentEntityInterface
 	bootstrapFiles:
 		- drupal-autoloader.php
 	excludePaths:

--- a/src/Reflection/EntityFieldReflection.php
+++ b/src/Reflection/EntityFieldReflection.php
@@ -8,7 +8,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertyReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
@@ -24,8 +23,7 @@ class EntityFieldReflection implements PropertyReflection
 
     public function __construct(
         private readonly ClassReflection $declaringClass,
-        private readonly string $propertyName,
-        private readonly ReflectionProvider $reflectionProvider
+        private readonly string $propertyName
     ) {
     }
 
@@ -52,18 +50,12 @@ class EntityFieldReflection implements PropertyReflection
 
     private function isContentEntityType(): bool
     {
-        if (!$this->reflectionProvider->hasClass(ContentEntityInterface::class)) {
-            return false;
-        }
-        return $this->declaringClass->isSubclassOfClass($this->reflectionProvider->getClass(ContentEntityInterface::class));
+        return $this->declaringClass->is(ContentEntityInterface::class);
     }
 
     private function isConfigEntityType(): bool
     {
-        if (!$this->reflectionProvider->hasClass(ConfigEntityInterface::class)) {
-            return false;
-        }
-        return $this->declaringClass->isSubclassOfClass($this->reflectionProvider->getClass(ConfigEntityInterface::class));
+        return $this->declaringClass->is(ConfigEntityInterface::class);
     }
 
     public function getWritableType(): Type

--- a/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
+++ b/src/Reflection/EntityFieldsViaMagicReflectionExtension.php
@@ -2,11 +2,12 @@
 
 namespace mglaman\PHPStanDrupal\Reflection;
 
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\PropertiesClassReflectionExtension;
 use PHPStan\Reflection\PropertyReflection;
-use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\ShouldNotHappenException;
 use function array_key_exists;
 
@@ -19,11 +20,6 @@ use function array_key_exists;
  */
 class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflectionExtension
 {
-
-    public function __construct(
-        private readonly ReflectionProvider $reflectionProvider
-    ) {
-    }
 
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
@@ -45,7 +41,7 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
         // We need to find a way to parse the entity annotation so that at the minimum the `entity_keys` are
         // supported. The real fix is Drupal developers _really_ need to start writing @property definitions in the
         // class doc if they don't get `get` methods.
-        if ($classReflection->implementsInterface('Drupal\Core\Entity\ContentEntityInterface')) {
+        if ($classReflection->is(ContentEntityInterface::class)) {
             // @todo revisit if it's a good idea to be true.
             // Content entities have magical __get... so it is kind of true.
             return true;
@@ -59,8 +55,8 @@ class EntityFieldsViaMagicReflectionExtension implements PropertiesClassReflecti
 
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
-        if ($classReflection->implementsInterface('Drupal\Core\Entity\EntityInterface')) {
-            return new EntityFieldReflection($classReflection, $propertyName, $this->reflectionProvider);
+        if ($classReflection->is(EntityInterface::class)) {
+            return new EntityFieldReflection($classReflection, $propertyName);
         }
         if ($classReflection->is(FieldItemListInterface::class)) {
             return new FieldItemListPropertyReflection($classReflection, $propertyName);

--- a/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
+++ b/tests/src/Reflection/EntityFieldsViaMagicReflectionExtensionTest.php
@@ -3,6 +3,7 @@
 namespace mglaman\PHPStanDrupal\Tests\Reflection;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\module_installer_config_test\Entity\TestConfigType;
@@ -28,7 +29,7 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->extension = new EntityFieldsViaMagicReflectionExtension(self::createReflectionProvider());
+        $this->extension = new EntityFieldsViaMagicReflectionExtension();
     }
 
     /**
@@ -53,6 +54,18 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
         yield 'config entity not supported' => [
             // @phpstan-ignore class.notFound
             TestConfigType::class,
+            'foobar',
+            false
+        ];
+        // A value typed as the interface itself, such as a
+        // ContentEntityInterface parameter, must behave like a concrete entity.
+        yield 'content entity interface supported' => [
+            ContentEntityInterface::class,
+            'foobar',
+            true
+        ];
+        yield 'entity interface not supported' => [
+            EntityInterface::class,
             'foobar',
             false
         ];
@@ -119,6 +132,15 @@ final class EntityFieldsViaMagicReflectionExtensionTest extends PHPStanTestCase 
         $readableType = $originalPropertyReflection->getReadableType();
         self::assertInstanceOf(ObjectType::class, $readableType);
         self::assertEquals(ContentEntityInterface::class, $readableType->getClassName());
+    }
+
+    public function testGetPropertyContentEntityInterface(): void
+    {
+        $classReflection = $this->createReflectionProvider()->getClass(ContentEntityInterface::class);
+        $propertyReflection = $this->extension->getProperty($classReflection, 'field_myfield');
+        $readableType = $propertyReflection->getReadableType();
+        self::assertInstanceOf(ObjectType::class, $readableType);
+        self::assertEquals(FieldItemListInterface::class, $readableType->getClassName());
     }
 
     public function testGetPropertyFieldItemList(): void

--- a/tests/src/Type/data/entity-properties.php
+++ b/tests/src/Type/data/entity-properties.php
@@ -34,3 +34,18 @@ assertType('mixed', $fieldItemList->uri);
 /** @var EntityReferenceFieldItemList $refList */
 assertType('int|string|null', $refList->target_id);
 assertType('Drupal\Core\Entity\EntityInterface|null', $refList->entity);
+
+// A value typed as the interface itself gets the same magic field access as
+// a concrete entity class.
+function contentEntityInterfaceField(\Drupal\Core\Entity\ContentEntityInterface $entity): void
+{
+    assertType('Drupal\Core\Field\FieldItemListInterface', $entity->field_myfield);
+    assertType('Drupal\Core\Entity\ContentEntityInterface', $entity->original);
+}
+
+// Interfaces extending ContentEntityInterface keep their own @property tags
+// and still get magic field access.
+function nodeInterfaceField(\Drupal\node\NodeInterface $node): void
+{
+    assertType('Drupal\Core\Field\FieldItemListInterface', $node->field_myfield);
+}


### PR DESCRIPTION
Closes #1048. First slice of #929, scoped to `ContentEntityInterface`. Type inference fix.

## What changed

A parameter typed `ContentEntityInterface`, `NodeInterface`, or any other interface extending `ContentEntityInterface` now gets the same magic field properties as a concrete entity class. Before, `$entity->field_foo` on such a value was reported as an undefined property while the same access on a `Node` worked.

Two layers needed fixing:

- **The extension's checks were false for the interface itself.** `EntityFieldsViaMagicReflectionExtension` used `implementsInterface()` and `EntityFieldReflection` used `isSubclassOfClass()`. Both are false when the reflected class is the interface. Both now use `is()`, the same change #1027 made for `FieldItemListInterface`.
- **PHPStan never asked the extension about interfaces.** PHPStan only consults property reflection extensions for a class that allows dynamic properties, which means a `__get()` declaration, an `#[AllowDynamicProperties]` attribute, a `@phpstan-require-extends` tag, or membership in `universalObjectCratesClasses`. Entity interfaces have none of these. `extension.neon` now lists `Drupal\Core\Entity\ContentEntityInterface` as a universal object crate, which matches every interface extending it. That is an honest description: `ContentEntityBase::__get()` accepts any property name.

`EntityFieldReflection` no longer needs a `ReflectionProvider`, so the extension's constructor no longer takes one.

## Why not `@phpstan-require-extends`

A stub with `@phpstan-require-extends ContentEntityBase` opens the gate for `ContentEntityInterface` only. For `NodeInterface`, PHPStan then resolves properties through the required class before consulting the interface's own `@property` tags, and `$node->book` lost its `BookData` type. The crate list opens the gate for the interface hierarchy itself, so the annotations extension runs first and `@property` tags keep winning.

## Side effects worth knowing

- **`@property` tags on entity interfaces now resolve.** `NodeInterface::$book` and a project's own `@property string $custom` on an interface extending `ContentEntityInterface` were undefined-property errors before. This is a strict improvement.
- **With `entityFieldsViaMagicReflection: false`, entity field access is `mixed` instead of an undefined-property error.** The crate registration is what opens the gate, and the crate extension is the fallback when ours is off. The README note under "Disabling extensions" documents this.

## Testing

Unit cases for `hasProperty()` on `ContentEntityInterface` (true) and `EntityInterface` (false), and `getProperty()` on `ContentEntityInterface`. Fixture cases for `field_myfield` and `original` on a `ContentEntityInterface` parameter and `field_myfield` on a `NodeInterface` parameter. The existing `book-module` fixture guards the `@property` precedence. Full suite, self-analysis, and phpcs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

